### PR TITLE
fix: preserve editor list-return state across the preview round-trip

### DIFF
--- a/packages/host-tanstack-start/src/admin-shell/collections/edit.tsx
+++ b/packages/host-tanstack-start/src/admin-shell/collections/edit.tsx
@@ -16,6 +16,7 @@ import { useTranslation } from '@byline/i18n/react'
 import { Container, Section, useToastManager } from '@byline/ui/react'
 
 import { getAdminRoutePath } from '../../routes/admin-path.js'
+import { clearListReturnState } from '../../routes/list-return-storage.js'
 import {
   copyDocumentToLocale,
   deleteDocument,
@@ -373,7 +374,10 @@ export const EditView = ({
         },
       })
       setEditState({ status: 'success', message: description })
-      // Navigate back to the collection list after deletion.
+      // Navigate back to the collection list after deletion. The return
+      // target has now been consumed — clear the stored fallback so a later
+      // visit doesn't resurrect a stale list position.
+      clearListReturnState(path, String(initialData.id))
       navigate({
         to: getAdminRoutePath('collections', '$collection'),
         params: { collection: path },
@@ -536,13 +540,17 @@ export const EditView = ({
           restoreWarnings={restoreWarnings}
           nextStatus={nextStatus}
           workflowStatuses={workflowStatuses}
-          onCancel={() =>
+          onCancel={() => {
+            // Close consumes the return target — clear the stored fallback so
+            // re-opening this document later degrades to the bare list unless
+            // a fresh `from` is supplied.
+            clearListReturnState(path, String(initialData.id))
             navigate({
               to: getAdminRoutePath('collections', '$collection'),
               params: { collection: path },
               search: returnSearch,
             })
-          }
+          }}
           collectionPath={path}
         />
       </Container>

--- a/packages/host-tanstack-start/src/routes/create-collection-edit-route.tsx
+++ b/packages/host-tanstack-start/src/routes/create-collection-edit-route.tsx
@@ -6,7 +6,7 @@
  * Copyright (c) Infonomic Company Limited
  */
 
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { createFileRoute, notFound } from '@tanstack/react-router'
 
 import type { CollectionDefinition } from '@byline/core'
@@ -22,6 +22,7 @@ import { getCollectionDocument } from '../server-fns/collections/index.js'
 import { getAdminRoutePath } from './admin-path.js'
 import { getContentLocaleRouteConfig } from './get-content-locale-route-config.js'
 import { decodeListReturnState } from './list-return-state.js'
+import { persistListReturnState, readListReturnState } from './list-return-storage.js'
 
 const searchSchema = z.object({
   locale: z.string().optional(),
@@ -83,6 +84,24 @@ export function createCollectionEditRoute(path: string) {
       const navigate = useNavigate()
       const { contentLocales, defaultContentLocale } = getContentLocaleRouteConfig()
 
+      // Return-to-list state. The URL `from` param is the primary carrier;
+      // when present we also mirror it into tab-scoped sessionStorage so the
+      // full-page preview round-trip (which discards the admin URL) can
+      // recover it. When the URL has no `from` — e.g. the editor was
+      // re-opened from the public preview bar's Edit link — we fall back to
+      // the stored value. See list-return-storage.ts.
+      const [returnSearch, setReturnSearch] = useState<Record<string, unknown> | undefined>(() =>
+        decodeListReturnState(search.from)
+      )
+      useEffect(() => {
+        if (search.from != null && search.from.length > 0) {
+          persistListReturnState(collection, id, search.from)
+          setReturnSearch(decodeListReturnState(search.from))
+        } else {
+          setReturnSearch(decodeListReturnState(readListReturnState(collection, id)))
+        }
+      }, [search.from, collection, id])
+
       // Post-create toast for the create → edit redirect (?action=created).
       // Ref-guarded for the same reason as the list route's created toast:
       // `toastManager` changes identity on every add, so the effect depends
@@ -138,7 +157,7 @@ export function createCollectionEditRoute(path: string) {
             locale={locale}
             contentLocales={contentLocales}
             defaultContentLocale={defaultContentLocale}
-            returnSearch={decodeListReturnState(search.from)}
+            returnSearch={returnSearch}
           />
         </>
       )

--- a/packages/host-tanstack-start/src/routes/list-return-storage.test.node.ts
+++ b/packages/host-tanstack-start/src/routes/list-return-storage.test.node.ts
@@ -1,0 +1,77 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  clearListReturnState,
+  persistListReturnState,
+  readListReturnState,
+} from './list-return-storage.js'
+
+/** Minimal Map-backed `Storage` stand-in — node mode has no sessionStorage. */
+function mockSessionStorage(): Storage {
+  const map = new Map<string, string>()
+  return {
+    get length() {
+      return map.size
+    },
+    clear: () => map.clear(),
+    getItem: (k: string) => (map.has(k) ? (map.get(k) as string) : null),
+    key: (i: number) => Array.from(map.keys())[i] ?? null,
+    removeItem: (k: string) => {
+      map.delete(k)
+    },
+    setItem: (k: string, v: string) => {
+      map.set(k, v)
+    },
+  }
+}
+
+function stub(): void {
+  ;(globalThis as { sessionStorage?: Storage }).sessionStorage = mockSessionStorage()
+}
+
+describe('list-return-storage', () => {
+  afterEach(() => {
+    delete (globalThis as { sessionStorage?: Storage }).sessionStorage
+  })
+
+  it('persists and reads a value keyed by collection + id', () => {
+    stub()
+    persistListReturnState('news', '42', 'page=6&order=title')
+    expect(readListReturnState('news', '42')).toBe('page=6&order=title')
+  })
+
+  it('scopes stored state by collection + id', () => {
+    stub()
+    persistListReturnState('news', '42', 'page=6')
+    expect(readListReturnState('news', '99')).toBeUndefined()
+    expect(readListReturnState('pages', '42')).toBeUndefined()
+  })
+
+  it('clears a stored value on consume', () => {
+    stub()
+    persistListReturnState('news', '42', 'page=6')
+    clearListReturnState('news', '42')
+    expect(readListReturnState('news', '42')).toBeUndefined()
+  })
+
+  it('ignores an empty from value (nothing worth carrying)', () => {
+    stub()
+    persistListReturnState('news', '42', '')
+    expect(readListReturnState('news', '42')).toBeUndefined()
+  })
+
+  it('degrades silently when sessionStorage is unavailable', () => {
+    // No stub installed — mirrors SSR / privacy-mode contexts.
+    expect(() => persistListReturnState('news', '42', 'page=6')).not.toThrow()
+    expect(readListReturnState('news', '42')).toBeUndefined()
+    expect(() => clearListReturnState('news', '42')).not.toThrow()
+  })
+})

--- a/packages/host-tanstack-start/src/routes/list-return-storage.ts
+++ b/packages/host-tanstack-start/src/routes/list-return-storage.ts
@@ -1,0 +1,80 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+/**
+ * Tab-scoped fallback for the collection editor's return-to-list state.
+ *
+ * The primary carrier is the `from` URL param (see list-return-state.ts) —
+ * pure, shareable, and enough for every in-app navigation. But the preview
+ * affordance does a full-page `window.location.assign()` to the public site,
+ * which discards the admin URL (and its `from`). When the editor is re-opened
+ * from the public preview bar's "Edit" link, that link carries only the
+ * collection and document id — no `from` — so the URL alone can no longer say
+ * which list page / filter to return to on close.
+ *
+ * sessionStorage bridges that gap: it survives a full-page navigation within
+ * the same tab, is scoped to the tab, and never leaks into shareable URLs. The
+ * editor persists `from` whenever it renders with one, keyed by collection +
+ * document id, and reads it back only when the URL carries no `from`. Closing
+ * or deleting the document consumes (clears) the entry, so a later visit to
+ * the same document with no context degrades to the bare list rather than a
+ * stale page.
+ *
+ * Every access is guarded: an absent `sessionStorage` (SSR, privacy modes,
+ * quota failures) degrades silently to "no stored state" — never an error.
+ */
+
+const KEY_PREFIX = 'byline:list-return:'
+
+/** Resolve `sessionStorage` defensively — absent under SSR, may throw in some
+ * sandboxed / privacy contexts. */
+function storage(): Storage | undefined {
+  try {
+    return globalThis.sessionStorage ?? undefined
+  } catch {
+    return undefined
+  }
+}
+
+function keyFor(collection: string, id: string): string {
+  return `${KEY_PREFIX}${collection}:${id}`
+}
+
+/** Persist the encoded `from` state for one document. No-op when unavailable. */
+export function persistListReturnState(collection: string, id: string, from: string): void {
+  if (from.length === 0) return
+  const store = storage()
+  if (store == null) return
+  try {
+    store.setItem(keyFor(collection, id), from)
+  } catch {
+    // Quota exceeded / storage disabled — persistence is best-effort only.
+  }
+}
+
+/** Read the stored `from` state for one document, or `undefined`. */
+export function readListReturnState(collection: string, id: string): string | undefined {
+  const store = storage()
+  if (store == null) return undefined
+  try {
+    return store.getItem(keyFor(collection, id)) ?? undefined
+  } catch {
+    return undefined
+  }
+}
+
+/** Clear the stored `from` state for one document (on close / delete). */
+export function clearListReturnState(collection: string, id: string): void {
+  const store = storage()
+  if (store == null) return
+  try {
+    store.removeItem(keyFor(collection, id))
+  } catch {
+    // Best-effort — nothing to recover if removal fails.
+  }
+}


### PR DESCRIPTION
Closes #36.

## Problem

The collection editor's "return to the list page you came from" (issue #17) is driven **solely** by the `from` URL param — no state or storage backing. Any navigation that discards the admin URL loses it, and Close/Delete then silently drop the user on the bare list (page 1, no filters).

Two paths trigger it:

1. **Preview round-trip (primary).** The preview link does a full-page `window.location.assign()` to the public site, discarding the admin URL. Returning via the public admin bar's **Edit** link (`<a href={admin/collections/{c}/{id}}>` — collection + id only, no `from`) lands the editor with no `from`. (Browser Back still works, since `assign()` keeps the prior URL in history.)
2. **ViewMenu Edit/History/API buttons** replace the whole search object (`search: locale ? { locale } : {}`), dropping `from` on in-editor hops.

## Fix (sessionStorage-only)

A tab-scoped `sessionStorage` fallback keyed by `collection:id`:

- Persist `from` whenever the editor renders with one.
- Fall back to the stored value when the URL carries no `from`.
- Clear the entry on close/delete so a later context-free visit degrades to the bare list rather than a stale page.

sessionStorage survives a full-page navigation within the same tab, is scoped to the tab, and never leaks into shareable URLs — so it repairs **both** round-trips with no change to the public `ContentAdminBar` or the history/api route schemas. Every access is guarded, so SSR / privacy modes degrade silently.

## Changes

- `routes/list-return-storage.ts` (new) — guarded `persist` / `read` / `clear` helpers.
- `routes/create-collection-edit-route.tsx` — `from` (URL) → sessionStorage fallback; persist when the URL carries `from`.
- `admin-shell/collections/edit.tsx` — clear the stored entry on close and delete.
- `routes/list-return-storage.test.node.ts` (new) — persist/read/scope/clear/empty/degradation.

## Testing

- `pnpm --filter @byline/host-tanstack-start test` — new + existing return-state suites pass (11 tests).
- `pnpm --filter @byline/host-tanstack-start typecheck` — clean.
- `pnpm --filter @byline/host-tanstack-start lint` — clean.

## Follow-up (not this PR)

Threading `from` through the ViewMenu buttons and the history/api route search schemas would keep in-editor navigation URL-clean rather than relying on the storage fallback for those hops. Optional now that the fallback covers correctness.
