### PR TITLE
fix: enforce a canonical ownership guard on sql/ migration scripts

### DIFF
--- a/packages/db-postgres/sql/0001_upgrade-2.7.0-to-3.0.sql
+++ b/packages/db-postgres/sql/0001_upgrade-2.7.0-to-3.0.sql
@@ -130,6 +130,43 @@ CREATE VIEW "public"."byline_current_published_documents" AS (
   where "rn" = 1
 );
 
+-- ---------------------------------------------------------------------------
+-- byline:ownership-guard
+--
+-- If this script was run by a superuser (e.g. `postgres`) rather than the
+-- application's DB role, any object it created is owned by that superuser and
+-- the app role gets "permission denied". Reassign every table and sequence in
+-- `public` not already owned by the database owner — the app role, per
+-- CREATE DATABASE ... WITH OWNER <app_role> — back to it. Indexes inherit
+-- table ownership, so they follow automatically. No-op when the app role ran
+-- the script (current_user = db owner) or nothing is mis-owned.
+--
+-- Keep this block identical across every sql/ migration: the ownership-guard
+-- contract test asserts its presence in any script that creates a table. See
+-- src/database/ownership-guard.test.node.ts.
+-- ---------------------------------------------------------------------------
+DO $$
+DECLARE
+  db_owner text := (
+    SELECT pg_get_userbyid(datdba) FROM pg_database WHERE datname = current_database()
+  );
+  obj record;
+BEGIN
+  IF current_user = db_owner THEN
+    RETURN;
+  END IF;
+  FOR obj IN
+    SELECT c.relname
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relkind IN ('r', 'p', 'S')
+      AND c.relowner <> (SELECT oid FROM pg_roles WHERE rolname = db_owner)
+  LOOP
+    EXECUTE format('ALTER TABLE public.%I OWNER TO %I', obj.relname, db_owner);
+  END LOOP;
+END $$;
+
 COMMIT;
 
 -- =============================================================================

--- a/packages/db-postgres/sql/0003_add-audit-log.sql
+++ b/packages/db-postgres/sql/0003_add-audit-log.sql
@@ -59,19 +59,40 @@ CREATE INDEX IF NOT EXISTS "idx_audit_log_action"
   ON "byline_audit_log" USING btree ("action", "id");
 
 -- ---------------------------------------------------------------------------
--- Ownership guard. If this script is run as a superuser (e.g. `postgres`), the
--- new table would be owned by that superuser and the application's DB role would
--- get "permission denied". Reassign it to the database owner — which is the app
--- role (CREATE DATABASE ... WITH OWNER <app_role>) — so the table is accessible
--- regardless of who runs the script. Indexes inherit table ownership, so they
--- follow automatically. No-op when the table is already correctly owned.
+-- byline:ownership-guard
+--
+-- If this script was run by a superuser (e.g. `postgres`) rather than the
+-- application's DB role, any object it created is owned by that superuser and
+-- the app role gets "permission denied". Reassign every table and sequence in
+-- `public` not already owned by the database owner — the app role, per
+-- CREATE DATABASE ... WITH OWNER <app_role> — back to it. Indexes inherit
+-- table ownership, so they follow automatically. No-op when the app role ran
+-- the script (current_user = db owner) or nothing is mis-owned.
+--
+-- Keep this block identical across every sql/ migration: the ownership-guard
+-- contract test asserts its presence in any script that creates a table. See
+-- src/database/ownership-guard.test.node.ts.
 -- ---------------------------------------------------------------------------
 DO $$
-BEGIN
-  EXECUTE format(
-    'ALTER TABLE "byline_audit_log" OWNER TO %I',
-    (SELECT pg_get_userbyid(datdba) FROM pg_database WHERE datname = current_database())
+DECLARE
+  db_owner text := (
+    SELECT pg_get_userbyid(datdba) FROM pg_database WHERE datname = current_database()
   );
+  obj record;
+BEGIN
+  IF current_user = db_owner THEN
+    RETURN;
+  END IF;
+  FOR obj IN
+    SELECT c.relname
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relkind IN ('r', 'p', 'S')
+      AND c.relowner <> (SELECT oid FROM pg_roles WHERE rolname = db_owner)
+  LOOP
+    EXECUTE format('ALTER TABLE public.%I OWNER TO %I', obj.relname, db_owner);
+  END LOOP;
 END $$;
 
 COMMIT;

--- a/packages/db-postgres/sql/0004_document_relationships.sql
+++ b/packages/db-postgres/sql/0004_document_relationships.sql
@@ -77,24 +77,40 @@ BEGIN
 END $$;
 
 -- ---------------------------------------------------------------------------
--- Ownership guard. If this script is run as a superuser (e.g. `postgres`), the
--- recreated table would be owned by that superuser and the application's DB role
--- would get "permission denied". Reassign it to the database owner — which is
--- the app role (CREATE DATABASE ... WITH OWNER <app_role>) — so the table is
--- accessible regardless of who runs the script. Indexes inherit table ownership.
--- No-op when already correctly owned.
+-- byline:ownership-guard
+--
+-- If this script was run by a superuser (e.g. `postgres`) rather than the
+-- application's DB role, any object it created is owned by that superuser and
+-- the app role gets "permission denied". Reassign every table and sequence in
+-- `public` not already owned by the database owner — the app role, per
+-- CREATE DATABASE ... WITH OWNER <app_role> — back to it. Indexes inherit
+-- table ownership, so they follow automatically. No-op when the app role ran
+-- the script (current_user = db owner) or nothing is mis-owned.
+--
+-- Keep this block identical across every sql/ migration: the ownership-guard
+-- contract test asserts its presence in any script that creates a table. See
+-- src/database/ownership-guard.test.node.ts.
 -- ---------------------------------------------------------------------------
 DO $$
+DECLARE
+  db_owner text := (
+    SELECT pg_get_userbyid(datdba) FROM pg_database WHERE datname = current_database()
+  );
+  obj record;
 BEGIN
-  IF EXISTS (
-    SELECT 1 FROM information_schema.tables
-    WHERE table_name = 'byline_document_relationships'
-  ) THEN
-    EXECUTE format(
-      'ALTER TABLE "byline_document_relationships" OWNER TO %I',
-      (SELECT pg_get_userbyid(datdba) FROM pg_database WHERE datname = current_database())
-    );
+  IF current_user = db_owner THEN
+    RETURN;
   END IF;
+  FOR obj IN
+    SELECT c.relname
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relkind IN ('r', 'p', 'S')
+      AND c.relowner <> (SELECT oid FROM pg_roles WHERE rolname = db_owner)
+  LOOP
+    EXECUTE format('ALTER TABLE public.%I OWNER TO %I', obj.relname, db_owner);
+  END LOOP;
 END $$;
 
 COMMIT;

--- a/packages/db-postgres/sql/0005_add-admin-user-preferences.sql
+++ b/packages/db-postgres/sql/0005_add-admin-user-preferences.sql
@@ -44,24 +44,40 @@ BEGIN
 END $$;
 
 -- ---------------------------------------------------------------------------
--- Ownership guard. If this script is run as a superuser (e.g. `postgres`), the
--- created table would be owned by that superuser and the application's DB role
--- would get "permission denied". Reassign it to the database owner — which is
--- the app role (CREATE DATABASE ... WITH OWNER <app_role>) — so the table is
--- accessible regardless of who runs the script. No-op when already correctly
--- owned.
+-- byline:ownership-guard
+--
+-- If this script was run by a superuser (e.g. `postgres`) rather than the
+-- application's DB role, any object it created is owned by that superuser and
+-- the app role gets "permission denied". Reassign every table and sequence in
+-- `public` not already owned by the database owner — the app role, per
+-- CREATE DATABASE ... WITH OWNER <app_role> — back to it. Indexes inherit
+-- table ownership, so they follow automatically. No-op when the app role ran
+-- the script (current_user = db owner) or nothing is mis-owned.
+--
+-- Keep this block identical across every sql/ migration: the ownership-guard
+-- contract test asserts its presence in any script that creates a table. See
+-- src/database/ownership-guard.test.node.ts.
 -- ---------------------------------------------------------------------------
 DO $$
+DECLARE
+  db_owner text := (
+    SELECT pg_get_userbyid(datdba) FROM pg_database WHERE datname = current_database()
+  );
+  obj record;
 BEGIN
-  IF EXISTS (
-    SELECT 1 FROM information_schema.tables
-    WHERE table_name = 'byline_admin_user_preferences'
-  ) THEN
-    EXECUTE format(
-      'ALTER TABLE "byline_admin_user_preferences" OWNER TO %I',
-      (SELECT pg_get_userbyid(datdba) FROM pg_database WHERE datname = current_database())
-    );
+  IF current_user = db_owner THEN
+    RETURN;
   END IF;
+  FOR obj IN
+    SELECT c.relname
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relkind IN ('r', 'p', 'S')
+      AND c.relowner <> (SELECT oid FROM pg_roles WHERE rolname = db_owner)
+  LOOP
+    EXECUTE format('ALTER TABLE public.%I OWNER TO %I', obj.relname, db_owner);
+  END LOOP;
 END $$;
 
 COMMIT;

--- a/packages/db-postgres/sql/README.md
+++ b/packages/db-postgres/sql/README.md
@@ -1,0 +1,66 @@
+# Hand-written upgrade scripts (`sql/`)
+
+These numbered `.sql` scripts are the **Drizzle-independent** upgrade path for
+existing production databases — the ones that do not run `drizzle:migrate`
+(after a release squash the Drizzle journal no longer matches a deployed DB).
+Each is idempotent, wrapped in a single transaction, and applied by hand:
+
+```sh
+psql "$DATABASE_URL" -f packages/db-postgres/sql/0005_add-admin-user-preferences.sql
+```
+
+The Drizzle stream (`src/database/migrations/`, run via `drizzle:migrate`) and
+`@byline/search-postgres` (`migrate(pool)`) both connect over a pool as the
+application's DB role, so their objects are owned correctly by construction.
+The rules below apply only to this hand-written stream.
+
+## Ownership guard
+
+Prefer running these scripts **as the application's DB role**. When they are run
+as a superuser (e.g. `postgres`) instead, any table they create is owned by that
+superuser and the running server — which connects as the app role — hits
+`permission denied`.
+
+Every script that creates a table must therefore end, immediately before
+`COMMIT`, with the canonical ownership guard. It reassigns every table and
+sequence in `public` not already owned by the database owner (the app role, per
+`CREATE DATABASE ... WITH OWNER <app_role>`) back to it, and no-ops when the app
+role ran the script or nothing is mis-owned:
+
+```sql
+-- ---------------------------------------------------------------------------
+-- byline:ownership-guard
+-- ... (see any existing 000N script for the full comment)
+-- ---------------------------------------------------------------------------
+DO $$
+DECLARE
+  db_owner text := (
+    SELECT pg_get_userbyid(datdba) FROM pg_database WHERE datname = current_database()
+  );
+  obj record;
+BEGIN
+  IF current_user = db_owner THEN
+    RETURN;
+  END IF;
+  FOR obj IN
+    SELECT c.relname
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relkind IN ('r', 'p', 'S')
+      AND c.relowner <> (SELECT oid FROM pg_roles WHERE rolname = db_owner)
+  LOOP
+    EXECUTE format('ALTER TABLE public.%I OWNER TO %I', obj.relname, db_owner);
+  END LOOP;
+END $$;
+```
+
+Keep the block **identical** across scripts — it names no table, so there is
+nothing to customise. Because it converges *all* mis-owned public objects to the
+database owner, it is safe to copy verbatim regardless of what the script
+creates, and re-running it is always a no-op once ownership is correct.
+
+This is enforced: `src/database/ownership-guard.test.node.ts` fails CI if any
+script containing `CREATE TABLE` is missing the `-- byline:ownership-guard`
+marker or the reassignment statement. Constraint-only scripts (no `CREATE
+TABLE`) do not need the guard.

--- a/packages/db-postgres/src/database/ownership-guard.test.node.ts
+++ b/packages/db-postgres/src/database/ownership-guard.test.node.ts
@@ -1,0 +1,65 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+/**
+ * Contract test for the hand-written `sql/` upgrade scripts.
+ *
+ * Those scripts are the Drizzle-independent production upgrade path and are
+ * run by hand via `psql -f` — possibly as a superuser. A table created by a
+ * superuser is owned by that superuser, and the application's DB role then
+ * gets "permission denied". Every script that creates a table must therefore
+ * end with the ownership guard that reassigns objects back to the database
+ * owner (the app role). The guard already drifted once — 0005 shipped without
+ * it — so this test makes the requirement structural instead of a convention
+ * someone has to remember. See sql/README.md.
+ *
+ * The Drizzle stream (`drizzle:migrate`) and `@byline/search-postgres` run
+ * over a connection pool as the app role, so their objects are owned correctly
+ * by construction — this guard is a `sql/`-only concern.
+ */
+
+import { readdirSync, readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+const SQL_DIR = join(dirname(fileURLToPath(import.meta.url)), '..', '..', 'sql')
+const OWNERSHIP_GUARD_MARKER = '-- byline:ownership-guard'
+const REASSIGN_STATEMENT = 'ALTER TABLE public.%I OWNER TO %I'
+
+function sqlFiles(): string[] {
+  return readdirSync(SQL_DIR)
+    .filter((name) => name.endsWith('.sql'))
+    .sort()
+}
+
+describe('sql/ migration ownership guard', () => {
+  const files = sqlFiles()
+
+  it('finds the hand-written migration scripts (fails loudly if the dir moves)', () => {
+    expect(files.length).toBeGreaterThan(0)
+  })
+
+  for (const file of files) {
+    const body = readFileSync(join(SQL_DIR, file), 'utf8')
+    // Only scripts that create a table can leave a mis-owned object behind.
+    if (!/create\s+table/i.test(body)) continue
+
+    describe(file, () => {
+      it('carries the ownership-guard marker', () => {
+        expect(body).toContain(OWNERSHIP_GUARD_MARKER)
+      })
+
+      it('reassigns object ownership to the database owner', () => {
+        // Guards against a marker comment with no actual reassignment block.
+        expect(body).toContain(REASSIGN_STATEMENT)
+      })
+    })
+  }
+})


### PR DESCRIPTION
Closes #38.

## Problem

The hand-written `packages/db-postgres/sql/*.sql` upgrade scripts run by hand via `psql -f`, sometimes as a **superuser** (e.g. `postgres`). A table created that way is owned by the superuser, and the running server — connecting as the app role — hits `permission denied`. The guard existed in `0003` but drifted: `0005` shipped without it (patched in 4.6.1/4.6.2), `0003`/`0004`/`0005` each carried their own table-name-hardcoded copy, and `0001` had none.

`sql/`-only concern: the Drizzle stream and `@byline/search-postgres` run over a pool as the app role, so their objects are owned correctly by construction.

## Fix

- **One canonical, table-agnostic guard block** ends every table-creating script (before `COMMIT`). It reassigns every table and sequence in `public` not already owned by the database owner (the app role) back to it, and no-ops when the app role ran the script (`current_user = db_owner`) or nothing is mis-owned. Names no table → byte-identical everywhere → nothing to get wrong. Stays in-file so it can't be bypassed by how the script is invoked. Marked `-- byline:ownership-guard`.
- **Contract test** `ownership-guard.test.node.ts` fails CI if any `sql/` script containing `CREATE TABLE` is missing the marker or the reassignment statement (mirrors `field-store-map` / `path-dialects`). Constraint-only scripts (e.g. `0002`) are exempt.
- **`sql/README.md`** documents "prefer running as the app role" and the canonical block.
- Backfilled `0001`; normalised `0003`/`0004`/`0005` onto the canonical block.

## Changes

- `sql/0001,0003,0004,0005.sql` — canonical guard (backfill + normalise).
- `sql/README.md` (new).
- `src/database/ownership-guard.test.node.ts` (new).

## Testing

- `pnpm --filter @byline/db-postgres test` — 18 node-mode tests pass (9 new ownership-guard checks; `0002` correctly skipped).
- `pnpm --filter @byline/db-postgres typecheck` / `lint` — clean.
- **Executed the guard SQL against a live `byline_dev`** in rolled-back transactions: the canonical block parses and runs (no-op RETURN path), and a loop-forcing variant exercised the `FOR`/`format`/`EXECUTE` path across 26 real `public` objects (tables + sequences) with no error.
