### PR TITLE
feat(core): classifyError adapter seam for cross-dialect DB error classification

### DIFF
--- a/.changeset/db-error-classification-seam.md
+++ b/.changeset/db-error-classification-seam.md
@@ -1,0 +1,6 @@
+---
+"@byline/core": minor
+"@byline/db-postgres": patch
+---
+
+Added a code-based `classifyError` adapter seam (`IDbAdapter.classifyError`, `DbErrorCodes`, `DbErrorClassification`) so `@byline/core` maps database failures to domain errors without inspecting driver-specific error anatomy. `rethrowPathConflict` now delegates to it; `@byline/db-postgres` implements the classifier by moving its existing `23505` + cause-walk detection behind the seam (behaviour unchanged). This is the error-side analogue of the storage `normalizeRow` seam and unblocks a second database adapter.

--- a/packages/core/src/@types/db-types.ts
+++ b/packages/core/src/@types/db-types.ts
@@ -1,6 +1,7 @@
 import type { RequestContext } from '@byline/auth'
 import type { CollectionDefinition } from '@byline/core'
 
+import type { DbErrorClassification } from '../lib/errors.js'
 import type { QueryPredicate } from './query-predicate.js'
 
 /**
@@ -268,6 +269,16 @@ export interface IDbAdapter {
    * need not implement it. See docs/07-internationalization/index.md.
    */
   backfillSourceLocales?: () => Promise<{ rowsUpdated: number }>
+  /**
+   * Classify a raw driver error into an adapter-agnostic, code-based shape so
+   * core can map database failures to domain errors without knowing driver
+   * anatomy. The error-side analogue of the storage `normalizeRow` seam.
+   *
+   * Optional: when absent, core treats every error as `DB_UNKNOWN` and rethrows
+   * it unchanged — the current behaviour for adapters that do not implement it.
+   * Canonical adapters (db-postgres, db-mysql) implement it.
+   */
+  classifyError?(err: unknown): DbErrorClassification
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -53,6 +53,9 @@ export {
 } from './host/host-request-bridge.js'
 export {
   BylineError,
+  type DbErrorClassification,
+  type DbErrorCode,
+  DbErrorCodes,
   ERR_AUDIT_UNSUPPORTED,
   ERR_CONFLICT,
   ERR_DATABASE,

--- a/packages/core/src/lib/errors.ts
+++ b/packages/core/src/lib/errors.ts
@@ -210,3 +210,36 @@ export const ERR_AUDIT_UNSUPPORTED = createErrorType(ErrorCodes.AUDIT_UNSUPPORTE
  * reconcile, while transports can distinguish it from a rolled-back mutation.
  */
 export const ERR_TREE_HOOK_COMMITTED = createErrorType(ErrorCodes.TREE_HOOK_COMMITTED, 'warn')
+
+// ---------------------------------------------------------------------------
+// Database error classification (adapter seam)
+// ---------------------------------------------------------------------------
+
+/**
+ * Code-based classification of a raw database driver error, produced by
+ * `IDbAdapter.classifyError`. The error-side analogue of the storage
+ * `normalizeRow` seam: the adapter canonicalises driver anatomy into these
+ * codes so `@byline/core` can map DB failures to domain errors (e.g.
+ * `ERR_PATH_CONFLICT`) without knowing any driver's error shape.
+ *
+ * Distinct from `ErrorCodes` above: those are thrown `BylineError` codes;
+ * these are returned classification values. Extend with new codes (e.g. a
+ * future `STALE_RECORD` for optimistic-concurrency failures) as consumers
+ * need them.
+ */
+export const DbErrorCodes = {
+  UNIQUE_VIOLATION: 'DB_UNIQUE_VIOLATION',
+  UNKNOWN: 'DB_UNKNOWN',
+} as const
+
+export type DbErrorCode = (typeof DbErrorCodes)[keyof typeof DbErrorCodes]
+
+export interface DbErrorClassification {
+  code: DbErrorCode
+  /**
+   * For `DB_UNIQUE_VIOLATION`: the violated constraint / index name when the
+   * driver exposes it (Postgres carries it structurally; MySQL parses it from
+   * the error message). Absent when the driver surfaces no name.
+   */
+  constraint?: string
+}

--- a/packages/core/src/services/document-lifecycle.test.node.ts
+++ b/packages/core/src/services/document-lifecycle.test.node.ts
@@ -15,7 +15,7 @@ import {
 } from '@byline/auth'
 import { describe, expect, it, vi } from 'vitest'
 
-import { BylineError, ERR_PATH_CONFLICT, ErrorCodes } from '../lib/errors.js'
+import { BylineError, DbErrorCodes, ERR_PATH_CONFLICT, ErrorCodes } from '../lib/errors.js'
 import {
   changeDocumentStatus,
   copyToLocale,
@@ -77,7 +77,21 @@ function createMockDb() {
   const auditAppend = vi.fn().mockResolvedValue({ id: 'audit-1' })
   const withTransaction = vi.fn(async (fn: () => Promise<unknown>) => fn())
 
+  // Fake classifier mirroring db-postgres's real one closely enough for
+  // rethrowPathConflict's consumption of the seam: a pg-shaped 23505 with a
+  // constraint name classifies as a unique violation; anything else is
+  // unknown. Individual tests inject pg-shaped errors on `createDocumentVersion`
+  // (see `translates a Postgres unique-constraint violation...` below).
+  const classifyError = vi.fn((err: unknown) => {
+    const e = err as { code?: string; constraint?: string } | undefined
+    if (e?.code === '23505') {
+      return { code: DbErrorCodes.UNIQUE_VIOLATION, constraint: e.constraint }
+    }
+    return { code: DbErrorCodes.UNKNOWN }
+  })
+
   const db: IDbAdapter = {
+    classifyError,
     commands: {
       collections: {
         create: vi.fn(),

--- a/packages/core/src/services/document-lifecycle/create.ts
+++ b/packages/core/src/services/document-lifecycle/create.ts
@@ -134,7 +134,7 @@ export async function createDocument(
           orderKey,
           createdBy: actorId(ctx),
         })
-        .catch((err: unknown) => rethrowPathConflict(err, resolvedPath, defaultLocale))
+        .catch((err: unknown) => rethrowPathConflict(db, err, resolvedPath, defaultLocale))
 
       const documentId = extractDocumentId(result.document)
       const documentVersionId = extractVersionId(result.document)

--- a/packages/core/src/services/document-lifecycle/duplicate.ts
+++ b/packages/core/src/services/document-lifecycle/duplicate.ts
@@ -238,7 +238,7 @@ export async function duplicateDocument(
             orderKey,
             createdBy: actorId(ctx),
           })
-          .catch((err: unknown) => rethrowPathConflict(err, finalPath, defaultLocale))
+          .catch((err: unknown) => rethrowPathConflict(db, err, finalPath, defaultLocale))
       } catch (err: unknown) {
         if (!isPathConflictError(err)) {
           throw err
@@ -265,7 +265,7 @@ export async function duplicateDocument(
             orderKey,
             createdBy: actorId(ctx),
           })
-          .catch((retryErr: unknown) => rethrowPathConflict(retryErr, finalPath, defaultLocale))
+          .catch((retryErr: unknown) => rethrowPathConflict(db, retryErr, finalPath, defaultLocale))
       }
 
       const newDocumentId = extractDocumentId(result.document)

--- a/packages/core/src/services/document-lifecycle/internals.ts
+++ b/packages/core/src/services/document-lifecycle/internals.ts
@@ -16,12 +16,13 @@
 import {
   type CollectionDefinition,
   type CollectionHookSlot,
+  type IDbAdapter,
   normalizeCollectionHook,
   type RichTextEmbedFn,
   type RichTextPopulateFn,
 } from '../../@types/index.js'
 import { getCollectionDefinition, getServerConfig } from '../../config/config.js'
-import { ERR_PATH_CONFLICT, ErrorCodes } from '../../lib/errors.js'
+import { DbErrorCodes, ERR_PATH_CONFLICT, ErrorCodes } from '../../lib/errors.js'
 import { generateKeyBetween } from '../../lib/fractional-index.js'
 import { createReadContext } from '../populate.js'
 import { embedRichTextFields } from '../richtext-embed.js'
@@ -156,35 +157,32 @@ export function extractDocumentId(document: any): string {
 }
 
 /**
- * Detect a Postgres unique-constraint violation on
+ * Detect a unique-constraint violation on
  * `byline_document_paths(collection_id, locale, path)` and translate it
  * to `ERR_PATH_CONFLICT`. Any other error is rethrown unchanged.
  *
- * The Postgres SQLSTATE for unique violations is `23505`. Drivers carry
- * the constraint name on the error object (`constraint`); matching by
- * name keeps this targeted to the path constraint and avoids spuriously
- * rebranding unrelated unique violations as path conflicts.
- *
- * Drizzle wraps the underlying pg error in `DrizzleQueryError` with the
- * original attached as `cause`, so we walk a short cause chain to find
- * the carried `code` / `constraint`.
+ * Driver anatomy (SQLSTATE codes, `cause`-chain walking, constraint-name
+ * carriage) is delegated to `db.classifyError` — the adapter seam that
+ * canonicalises a raw driver error into a `DbErrorClassification`. This
+ * function only knows the classification codes and the path constraint's
+ * name substring; it stays targeted to the path constraint so unrelated
+ * unique violations aren't spuriously rebranded as path conflicts.
  */
-export function rethrowPathConflict(err: unknown, path: string, locale: string): never {
-  type PgLikeError = { code?: string; constraint?: string; cause?: unknown }
-  let e: PgLikeError | undefined = err as PgLikeError | undefined
-  // Walk at most a few `cause` hops — DrizzleQueryError → underlying pg error.
-  for (let i = 0; i < 3 && e; i++) {
-    if (
-      e.code === '23505' &&
-      typeof e.constraint === 'string' &&
-      e.constraint.includes('document_paths_collection_locale_path')
-    ) {
-      throw ERR_PATH_CONFLICT({
-        message: `path "${path}" is already in use in this collection (locale: ${locale})`,
-        details: { path, locale, constraint: e.constraint },
-      })
-    }
-    e = e.cause as PgLikeError | undefined
+export function rethrowPathConflict(
+  db: IDbAdapter,
+  err: unknown,
+  path: string,
+  locale: string
+): never {
+  const classification = db.classifyError?.(err)
+  if (
+    classification?.code === DbErrorCodes.UNIQUE_VIOLATION &&
+    classification.constraint?.includes('document_paths_collection_locale_path')
+  ) {
+    throw ERR_PATH_CONFLICT({
+      message: `path "${path}" is already in use in this collection (locale: ${locale})`,
+      details: { path, locale, constraint: classification.constraint },
+    })
   }
   throw err as Error
 }

--- a/packages/core/src/services/document-lifecycle/rethrow-path-conflict.test.node.ts
+++ b/packages/core/src/services/document-lifecycle/rethrow-path-conflict.test.node.ts
@@ -1,0 +1,49 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import { type DbErrorClassification, ErrorCodes } from '../../lib/errors.js'
+import { rethrowPathConflict } from './internals.js'
+import type { IDbAdapter } from '../../@types/index.js'
+
+const adapterWith = (c: DbErrorClassification | undefined): IDbAdapter =>
+  ({ classifyError: c === undefined ? undefined : () => c }) as unknown as IDbAdapter
+
+describe('rethrowPathConflict', () => {
+  it('maps a unique violation on the path constraint to ERR_PATH_CONFLICT', () => {
+    const db = adapterWith({
+      code: 'DB_UNIQUE_VIOLATION',
+      constraint: 'byline_document_paths_document_paths_collection_locale_path',
+    })
+    try {
+      rethrowPathConflict(db, new Error('raw'), 'news/hello', 'en')
+      throw new Error('should have thrown')
+    } catch (e) {
+      expect((e as { code?: string }).code).toBe(ErrorCodes.PATH_CONFLICT)
+    }
+  })
+
+  it('rethrows raw when the unique violation is on a different constraint', () => {
+    const raw = new Error('raw')
+    const db = adapterWith({ code: 'DB_UNIQUE_VIOLATION', constraint: 'some_other_unique' })
+    expect(() => rethrowPathConflict(db, raw, 'p', 'en')).toThrow(raw)
+  })
+
+  it('rethrows raw for DB_UNKNOWN', () => {
+    const raw = new Error('raw')
+    const db = adapterWith({ code: 'DB_UNKNOWN' })
+    expect(() => rethrowPathConflict(db, raw, 'p', 'en')).toThrow(raw)
+  })
+
+  it('rethrows raw when the adapter has no classifyError', () => {
+    const raw = new Error('raw')
+    const db = adapterWith(undefined)
+    expect(() => rethrowPathConflict(db, raw, 'p', 'en')).toThrow(raw)
+  })
+})

--- a/packages/core/src/services/document-lifecycle/system-fields.ts
+++ b/packages/core/src/services/document-lifecycle/system-fields.ts
@@ -151,7 +151,7 @@ export async function updateDocumentSystemFields(
               locale: sourceLocale,
               path: pathForCommand,
             })
-            .catch((err: unknown) => rethrowPathConflict(err, pathForCommand, sourceLocale))
+            .catch((err: unknown) => rethrowPathConflict(db, err, pathForCommand, sourceLocale))
           await audit.append({
             documentId: params.documentId,
             collectionId,

--- a/packages/core/src/services/document-lifecycle/update.ts
+++ b/packages/core/src/services/document-lifecycle/update.ts
@@ -146,7 +146,7 @@ export async function updateDocument(
           previousVersionId: originalData.document_version_id as string | undefined,
           createdBy: actorId(ctx),
         })
-        .catch((err: unknown) => rethrowPathConflict(err, pathForCommand ?? '', defaultLocale))
+        .catch((err: unknown) => rethrowPathConflict(db, err, pathForCommand ?? '', defaultLocale))
 
       const documentId = extractDocumentId(result.document) || params.documentId
       const documentVersionId = extractVersionId(result.document)
@@ -316,7 +316,7 @@ export async function updateDocumentWithPatches(
           previousVersionId: originalData.document_version_id as string | undefined,
           createdBy: actorId(ctx),
         })
-        .catch((err: unknown) => rethrowPathConflict(err, pathForCommand ?? '', defaultLocale))
+        .catch((err: unknown) => rethrowPathConflict(db, err, pathForCommand ?? '', defaultLocale))
 
       const documentId = extractDocumentId(result.document) || params.documentId
       const documentVersionId = extractVersionId(result.document)

--- a/packages/core/src/storage/store-manifest.ts
+++ b/packages/core/src/storage/store-manifest.ts
@@ -218,6 +218,10 @@ export const storeColumnManifest: ColumnDef[] = [
     nullCast: 'varchar',
     sources: { json: 'json_schema' },
   },
+  // nullCast 'text[]' is the one abstract null-cast type with no MySQL array
+  // equivalent; the MySQL adapter maps it to CAST(NULL AS JSON) in its UNION
+  // null casts (Postgres uses NULL::text[]). See
+  // specs/2026-07-24-db-error-classification-seam-design.md §6.
   {
     name: 'object_keys',
     nullCast: 'text[]',

--- a/packages/db-conformance/src/index.ts
+++ b/packages/db-conformance/src/index.ts
@@ -33,11 +33,18 @@ import { versioningSuite } from './suites/versioning.js'
  * its own hooks.
  */
 export interface ConformanceHooks {
-  /** Construct the adapter under test against the test database. */
+  /**
+   * Construct the adapter under test against the test database. Called once
+   * per suite (~14× per run — see `runAdapterConformanceSuite` below), all of
+   * which share the single `teardown()` call at the end of the run.
+   * Implementations should memoise their connection pool across calls (open
+   * it once, reuse it) rather than opening a fresh pool per call, to avoid
+   * leaking pools until teardown.
+   */
   createAdapter(collections: readonly CollectionDefinition[]): Promise<IDbAdapter>
   /** Bring the test DB to current schema (idempotent). Called once per run. */
   migrate(): Promise<void>
-  /** Truncate all Byline tables. Called between test files. */
+  /** Truncate all Byline tables. Called once per suite, from each suite's `beforeAll`. */
   truncate(): Promise<void>
   /** Close pools/connections. */
   teardown(): Promise<void>

--- a/packages/db-conformance/src/index.ts
+++ b/packages/db-conformance/src/index.ts
@@ -40,6 +40,10 @@ export interface ConformanceHooks {
    * Implementations should memoise their connection pool across calls (open
    * it once, reuse it) rather than opening a fresh pool per call, to avoid
    * leaking pools until teardown.
+   *
+   * The adapter returned here must implement `classifyError` (optional on
+   * `IDbAdapter`, but required to run this suite) — the `document-paths`
+   * suite asserts it directly.
    */
   createAdapter(collections: readonly CollectionDefinition[]): Promise<IDbAdapter>
   /** Bring the test DB to current schema (idempotent). Called once per run. */

--- a/packages/db-conformance/src/suites/document-paths.ts
+++ b/packages/db-conformance/src/suites/document-paths.ts
@@ -103,16 +103,15 @@ export function documentPathsSuite(hooks: ConformanceHooks): void {
       }
 
       expect(caught, 'expected unique-constraint violation on duplicate path').toBeTruthy()
-      // Drizzle wraps pg errors in DrizzleQueryError with the original error
-      // attached as `cause`. The lifecycle layer's rethrowPathConflict reads
-      // both the wrapper and the cause to detect 23505 + the path constraint
-      // name; mirror that here.
-      const original = caught.cause ?? caught
-      expect(original.code, `expected SQLSTATE 23505, got ${original?.code}`).toBe('23505')
-      expect(
-        String(original.constraint ?? ''),
-        `constraint name should reference the path index, got ${original?.constraint}`
-      ).toMatch(/document_paths_collection_locale_path/)
+      // Adapter-agnostic: the adapter classifies its own driver error; core maps
+      // this classification to ERR_PATH_CONFLICT. (The raw Postgres 23505/anatomy
+      // is pinned in db-postgres's own classify-error unit test.)
+      if (adapter.classifyError == null) {
+        throw new Error('expected adapter to implement classifyError for this suite')
+      }
+      const classification = adapter.classifyError(caught)
+      expect(classification.code).toBe('DB_UNIQUE_VIOLATION')
+      expect(classification.constraint ?? '').toContain('document_paths_collection_locale_path')
     })
 
     it('upserts in place when the same document re-saves the same path', async () => {

--- a/packages/db-postgres/src/index.ts
+++ b/packages/db-postgres/src/index.ts
@@ -15,6 +15,7 @@ import { DBManagerImpl, TXManagerImpl } from './lib/db-manager.js'
 import { createAuditCommands } from './modules/audit/audit-commands.js'
 import { createAuditQueries } from './modules/audit/audit-queries.js'
 import { createCounterCommands } from './modules/counters/counters-commands.js'
+import { classifyError } from './modules/storage/classify-error.js'
 import {
   createCommandBuilders,
   type ReAnchorReport,
@@ -167,5 +168,6 @@ export const pgAdapter = ({
     backfillSourceLocales: () => commandBuilders.documents.backfillSourceLocales(),
     reAnchorDocument: (params) => commandBuilders.documents.reAnchorDocument(params),
     reAnchorDocuments: (params) => commandBuilders.documents.reAnchorDocuments(params),
+    classifyError,
   }
 }

--- a/packages/db-postgres/src/modules/storage/classify-error.test.node.ts
+++ b/packages/db-postgres/src/modules/storage/classify-error.test.node.ts
@@ -1,0 +1,41 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import { classifyError } from './classify-error.js'
+
+describe('classifyError (postgres)', () => {
+  it('classifies a raw 23505 as DB_UNIQUE_VIOLATION with the constraint', () => {
+    const err = { code: '23505', constraint: 'document_paths_collection_locale_path' }
+    expect(classifyError(err)).toEqual({
+      code: 'DB_UNIQUE_VIOLATION',
+      constraint: 'document_paths_collection_locale_path',
+    })
+  })
+
+  it('walks a Drizzle-style cause chain to the underlying pg error', () => {
+    const err = {
+      name: 'DrizzleQueryError',
+      cause: { code: '23505', constraint: 'some_other_unique' },
+    }
+    expect(classifyError(err)).toEqual({
+      code: 'DB_UNIQUE_VIOLATION',
+      constraint: 'some_other_unique',
+    })
+  })
+
+  it('returns DB_UNKNOWN for a non-unique error', () => {
+    expect(classifyError({ code: '23503' })).toEqual({ code: 'DB_UNKNOWN' })
+  })
+
+  it('returns DB_UNKNOWN for a non-error value', () => {
+    expect(classifyError(undefined)).toEqual({ code: 'DB_UNKNOWN' })
+    expect(classifyError('boom')).toEqual({ code: 'DB_UNKNOWN' })
+  })
+})

--- a/packages/db-postgres/src/modules/storage/classify-error.ts
+++ b/packages/db-postgres/src/modules/storage/classify-error.ts
@@ -1,0 +1,28 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import { type DbErrorClassification, DbErrorCodes } from '@byline/core'
+
+/**
+ * Classify a Postgres driver error. Walks a short `cause` chain
+ * (DrizzleQueryError → underlying pg error) looking for SQLSTATE `23505`
+ * (unique violation) and returns the carried constraint name. This is the
+ * driver-anatomy logic formerly inlined in core's `rethrowPathConflict`;
+ * core now maps the returned classification to `ERR_PATH_CONFLICT`.
+ */
+export function classifyError(err: unknown): DbErrorClassification {
+  type PgLikeError = { code?: string; constraint?: string; cause?: unknown }
+  let e = err as PgLikeError | undefined
+  for (let i = 0; i < 3 && e != null && typeof e === 'object'; i++) {
+    if (e.code === '23505') {
+      return { code: DbErrorCodes.UNIQUE_VIOLATION, constraint: e.constraint }
+    }
+    e = e.cause as PgLikeError | undefined
+  }
+  return { code: DbErrorCodes.UNKNOWN }
+}

--- a/packages/db-postgres/tests/conformance.integration.test.ts
+++ b/packages/db-postgres/tests/conformance.integration.test.ts
@@ -30,6 +30,7 @@ import { createAdminStore as createPgAdminStore } from '../src/modules/admin/adm
 import { createAuditCommands } from '../src/modules/audit/audit-commands.js'
 import { createAuditQueries } from '../src/modules/audit/audit-queries.js'
 import { createCounterCommands } from '../src/modules/counters/counters-commands.js'
+import { classifyError } from '../src/modules/storage/classify-error.js'
 
 function getConnectionString(): string {
   const connectionString = process.env.BYLINE_DB_POSTGRES_CONNECTION_STRING
@@ -45,6 +46,7 @@ runAdapterConformanceSuite({
     const auditQueries = createAuditQueries(testDb.db)
 
     return {
+      classifyError,
       commands: {
         ...testDb.commandBuilders,
         counters: counterCommands,


### PR DESCRIPTION
Adds a code-based `classifyError` adapter seam so `@byline/core` maps database failures to domain errors without inspecting driver-specific error anatomy — the error-side analogue of the storage `normalizeRow` seam. This is the last piece of Postgres-specific error handling in shared code, and removing it unblocks the MySQL adapter's write path.

Design: [`specs/2026-07-24-db-error-classification-seam-design.md`](https://github.com/Byline-CMS/bylinecms.dev/blob/develop/specs/2026-07-24-db-error-classification-seam-design.md)

## What changed

- **`@byline/core`** — new `DbErrorCodes` / `DbErrorClassification` (code-based, distinct from the thrown-`BylineError` `ErrorCodes` family) and an optional `IDbAdapter.classifyError(err): DbErrorClassification`. `rethrowPathConflict` now delegates driver anatomy to `db.classifyError` and keeps the path-specific decision in core (maps to `ERR_PATH_CONFLICT` only when the classification is `DB_UNIQUE_VIOLATION` **and** the constraint is `document_paths_collection_locale_path`).
- **`@byline/db-postgres`** — implements `classifyError` by lifting the exact `23505` + Drizzle cause-walk detection out of core. Behaviour is unchanged: the same `ERR_PATH_CONFLICT` surfaces from the same driver errors.
- **`@byline/db-conformance`** — the `document-paths` suite now asserts the adapter-agnostic seam instead of the raw Postgres `23505`/constraint shape. The raw-shape anatomy is pinned in db-postgres's own `classify-error` unit test.
- **Docs (#46)** — corrected the `ConformanceHooks` call-contract docs (per-suite `truncate`/`createAdapter`, single `teardown`, memoise-your-pool) and noted the MySQL `text[]` → `CAST(NULL AS JSON)` nullCast mapping for the future adapter.

## Correctness

The classifier reports `DB_UNIQUE_VIOLATION` for *any* unique violation; the path-specific mapping stays in core's `rethrowPathConflict`, so a non-path unique violation still rethrows raw (never a false `ERR_PATH_CONFLICT`). This is pinned in a new DB-free core unit test (all four outcomes) and in db-postgres's classifier unit test, and the failure direction is safe by construction.

## Verification

- db-postgres integration: **173 passed / 0 skipped** — unchanged from the pre-branch baseline (behaviour-preserving).
- Workspace unit tests green (core gains 4 `rethrow-path-conflict` tests + 4 `classify-error` tests); `pnpm typecheck` and `pnpm lint` clean.

The db-mysql `classifyError` is specified in the design but implemented in Phase 2 (the package does not exist yet). No release is required before Phase 2 — db-mysql consumes `@byline/core` in-workspace.

Closes #45
Closes #46