### PR TITLE
feat(db-mysql): adapter foundation — provisioning, package skeleton and schema

### DIFF
--- a/.changeset/db-init-percent-decoding.md
+++ b/.changeset/db-init-percent-decoding.md
@@ -1,0 +1,9 @@
+---
+"@byline/db-postgres": patch
+---
+
+`db_init.sh` now percent-decodes the user and password in `BYLINE_DB_POSTGRES_CONNECTION_STRING`, matching what node-postgres itself does when it parses the same string. Previously the script's URL parser split the connection string without decoding, so a password written `pa%40ss` created the database role with the literal `pa%40ss` while the adapter connected as `pa@ss` — an access-denied failure with nothing pointing at the cause.
+
+The script now also rejects a malformed percent-escape (a `%` not followed by two hex digits) with a clear message rather than passing it through. This is stricter than before: a connection string whose password contains a raw, un-encoded `%` — which RFC 3986 requires be written `%25` — is refused by `db_init.sh` where it was previously accepted. Such a string was already failing on the adapter side, where node-postgres throws `URIError: URI malformed` on the same input.
+
+Connection strings containing no percent-encoding are unaffected.

--- a/mysql/README.md
+++ b/mysql/README.md
@@ -19,6 +19,17 @@ For initializing and seeding the database, generating/applying migrations, and
 the test database, see the root `CLAUDE.md` (Database section) and
 `docs/09-testing.md`.
 
+## Initializing the databases
+
+`packages/db-mysql/src/database/db_init.sh` (drop/recreate `byline_dev` from
+`packages/db-mysql/.env`) and `db_init_test.sh` (the same, against
+`byline_test` via `.env.test`) mirror the `packages/db-postgres` init scripts.
+From the repo root:
+
+```sh
+pnpm db:init:test:mysql
+```
+
 ## Adminer
 
 A web-based database UI is available under the `adminer` compose profile:

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "clean": "pnpm -r run clean && node scripts/clean node_modules .turbo",
     "db:init": "TURBO_UI=true turbo run db:init",
     "db:init:test": "cd packages/db-postgres/src/database && ./db_init_test.sh",
+    "db:init:test:mysql": "cd packages/db-mysql/src/database && ./db_init_test.sh",
     "byline:generate": "turbo run byline:generate",
     "byline:generate:check": "turbo run byline:generate:check",
     "docs:check": "pnpm --filter @byline/webapp docs:check",

--- a/packages/db-mysql/.env.example
+++ b/packages/db-mysql/.env.example
@@ -6,7 +6,15 @@
 # database, copy .env.test.example to .env.test instead and
 # run `pnpm db:init:test:mysql`.
 #
-# Single source of truth — common.sh parses this URL to derive
-# user / password / host / port / database. Must use the
-# mysql:// scheme.
+# Single source of truth. The primary consumer is `mysqlAdapter`
+# (packages/db-mysql/src/index.ts), which hands this string straight to
+# mysql2 — mysql2 parses URLs natively, including this one. `common.sh`
+# also parses it, but only because the `mysql` CLI takes discrete flags
+# rather than a URL; that parsing exists to serve the shell scripts, not
+# the other way round. Must use the mysql:// scheme. Special characters
+# in the user or password must be percent-encoded (`@` as `%40`, `#` as
+# `%23`, `/` as `%2F`, …) — mysql2 and common.sh's urldecode() both
+# percent-decode the userinfo the same way, so an unencoded reserved
+# character would parse differently (or fail to parse) on one side or
+# the other.
 BYLINE_DB_MYSQL_CONNECTION_STRING=mysql://byline:byline@127.0.0.1:3306/byline_dev

--- a/packages/db-mysql/.env.example
+++ b/packages/db-mysql/.env.example
@@ -1,0 +1,12 @@
+# Copy this file to .env and change the values accordingly,
+# including user and password.
+# The DB name MUST end in `_dev` (or `_test` for test envs) —
+# db_init.sh refuses to operate on anything else (see
+# check_db_suffix in common.sh). For the dedicated test
+# database, copy .env.test.example to .env.test instead and
+# run `pnpm db:init:test:mysql`.
+#
+# Single source of truth — common.sh parses this URL to derive
+# user / password / host / port / database. Must use the
+# mysql:// scheme.
+BYLINE_DB_MYSQL_CONNECTION_STRING=mysql://byline:byline@127.0.0.1:3306/byline_dev

--- a/packages/db-mysql/.env.test.example
+++ b/packages/db-mysql/.env.test.example
@@ -2,4 +2,7 @@
 # The DB name MUST end in `_test` — db_init.sh refuses to operate
 # on anything else (see check_db_suffix in common.sh) and the test
 # bootstrap calls assertTestDatabase() with the same guard.
+# Special characters in the user or password must be percent-encoded
+# (`@` as `%40`, `#` as `%23`, `/` as `%2F`, …) — see .env.example for
+# why (mysql2 and common.sh's urldecode() both decode the userinfo).
 BYLINE_DB_MYSQL_CONNECTION_STRING=mysql://byline:byline@127.0.0.1:3306/byline_test

--- a/packages/db-mysql/.env.test.example
+++ b/packages/db-mysql/.env.test.example
@@ -1,0 +1,5 @@
+# Copy this file to .env.test for the dedicated test database.
+# The DB name MUST end in `_test` — db_init.sh refuses to operate
+# on anything else (see check_db_suffix in common.sh) and the test
+# bootstrap calls assertTestDatabase() with the same guard.
+BYLINE_DB_MYSQL_CONNECTION_STRING=mysql://byline:byline@127.0.0.1:3306/byline_test

--- a/packages/db-mysql/LICENSE
+++ b/packages/db-mysql/LICENSE
@@ -1,0 +1,373 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/packages/db-mysql/biome.jsonc
+++ b/packages/db-mysql/biome.jsonc
@@ -1,0 +1,4 @@
+{
+  "root": false,
+  "extends": ["../../biome.jsonc"]
+}

--- a/packages/db-mysql/drizzle.config.ts
+++ b/packages/db-mysql/drizzle.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'drizzle-kit'
+
+export default defineConfig({
+  dialect: 'mysql',
+  schema: './src/database/schema/index.ts',
+  out: './src/database/migrations',
+  dbCredentials: {
+    // @ts-expect-error
+    url: process.env.BYLINE_DB_MYSQL_CONNECTION_STRING as string,
+  },
+  verbose: true,
+  strict: true,
+})

--- a/packages/db-mysql/package.json
+++ b/packages/db-mysql/package.json
@@ -1,0 +1,87 @@
+{
+  "name": "@byline/db-mysql",
+  "private": false,
+  "license": "MPL-2.0",
+  "version": "4.7.0",
+  "engines": {
+    "node": ">=20.9.0"
+  },
+  "description": "Byline CMS db mysql package",
+  "keywords": [
+    "cms",
+    "headless cms",
+    "content management"
+  ],
+  "homepage": "https://github.com/Byline-CMS/bylinecms.dev",
+  "bugs": {
+    "url": "https://github.com/Byline-CMS/bylinecms.dev/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Byline-CMS/bylinecms.dev.git",
+    "directory": "packages/db-mysql"
+  },
+  "type": "module",
+  "main": "dist/index.js",
+  "index": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "dev": "chokidar 'src/**/*' -c 'npm-run-all build'",
+    "build": "tsc -p tsconfig.json && tsc-alias",
+    "clean": "node scripts/clean.js node_modules dist build .turbo",
+    "lint": "biome check --write --unsafe --diagnostic-level=error",
+    "db:init": "cd src/database && ./db_init.sh",
+    "drizzle:generate": "tsc -p tsconfig.json && drizzle-kit generate --config=drizzle.config.ts",
+    "drizzle:migrate": "drizzle-kit migrate --config=drizzle.config.ts",
+    "drizzle:push": "tsc -p tsconfig.json && drizzle-kit push --config=drizzle.config.ts",
+    "drizzle:drop": "drizzle-kit drop --config=drizzle.config.ts",
+    "test": "vitest run --mode=node",
+    "test:integration": "LOG_LEVEL=off vitest run --mode=integration",
+    "test:watch": "LOG_LEVEL=off vitest --mode=integration",
+    "typecheck": "tsc --noEmit"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
+    },
+    "./admin": {
+      "types": "./dist/modules/admin/index.d.ts",
+      "import": "./dist/modules/admin/index.js",
+      "require": "./dist/modules/admin/index.js"
+    },
+    "./schema": {
+      "types": "./dist/database/schema/index.d.ts",
+      "import": "./dist/database/schema/index.js",
+      "require": "./dist/database/schema/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist"
+  ],
+  "dependencies": {
+    "@byline/core": "workspace:*",
+    "drizzle-orm": "^0.45.2",
+    "mysql2": "^3.23.1",
+    "npm-run-all": "^4.1.5"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "2.5.4",
+    "@byline/db-conformance": "workspace:*",
+    "@types/node": "^26.1.1",
+    "chokidar": "^5.0.0",
+    "chokidar-cli": "^3.0.0",
+    "dotenv": "^17.4.2",
+    "drizzle-kit": "^0.31.10",
+    "tsc-alias": "^1.9.1",
+    "tsx": "^4.23.1",
+    "typescript": "^7.0.2",
+    "vitest": "^4.1.10"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  }
+}

--- a/packages/db-mysql/scripts/clean.js
+++ b/packages/db-mysql/scripts/clean.js
@@ -1,0 +1,5 @@
+import { rmSync } from 'node:fs'
+
+for (const target of process.argv.slice(2)) {
+  rmSync(target, { recursive: true, force: true })
+}

--- a/packages/db-mysql/sql/README.md
+++ b/packages/db-mysql/sql/README.md
@@ -1,0 +1,60 @@
+# Hand-written upgrade scripts (`sql/`)
+
+This directory is the **Drizzle-independent** upgrade path for existing
+production databases — the ones that do not run `drizzle:migrate` (after a
+release squash the Drizzle journal no longer matches a deployed DB). It
+mirrors `packages/db-postgres/sql/README.md`'s role and conventions, with
+one deliberate difference: **this stream starts empty.** `@byline/db-mysql`
+has no released versions yet, so there is nothing to hand-patch forward
+from. The first script lands here the first time a post-release schema
+change needs an upgrade path that bypasses the Drizzle journal.
+
+When scripts do land, each should be numbered, idempotent, and applied by
+hand as the application's DB role:
+
+```sh
+mysql -u byline -p byline_dev < packages/db-mysql/sql/0001_example.sql
+```
+
+## Conventions
+
+- **Numbered.** Scripts apply in filename order (`0001_...`, `0002_...`),
+  same as the Postgres stream.
+- **Idempotent.** Each script should be safe to run more than once — guard
+  `CREATE TABLE` / `ALTER TABLE ... ADD COLUMN` with `IF NOT EXISTS` (or an
+  `information_schema` check for the ALTER forms MySQL's `IF NOT EXISTS`
+  doesn't cover) so a re-run after a partial failure doesn't error out on
+  work that already landed.
+- **Transactional, with a MySQL-specific caveat.** Wrap the
+  data-manipulation portions of a script in `START TRANSACTION` /
+  `COMMIT` the same way the Postgres scripts do. But unlike Postgres,
+  **MySQL DDL is not transactional** — every `CREATE TABLE`, `ALTER TABLE`,
+  `CREATE INDEX`, `CREATE VIEW`, etc. statement causes an implicit commit
+  and cannot be rolled back once it has run, regardless of any surrounding
+  `START TRANSACTION`. In practice this means: if a script mixes DDL and
+  DML, and a later statement fails, everything before the last DDL
+  statement has already landed permanently. "Transactional" here can only
+  promise atomicity for the DML portions; a failed script may leave partial
+  DDL applied and require manual inspection and cleanup before re-running.
+  Keep scripts small and single-purpose to minimize the blast radius of a
+  partial failure.
+
+## No ownership guard
+
+`packages/db-postgres/sql/README.md` documents a Postgres-specific
+"ownership guard" block: running a script as a superuser instead of the
+application's DB role leaves tables owned by that superuser, which the
+running server (connecting as the app role) then can't use —
+`permission denied`. **MySQL has no equivalent failure mode.** MySQL's
+privilege model is grant-based, not object-owner-based: a table created by
+any authenticated connection (root or otherwise) is usable by every role
+that has been `GRANT`ed the relevant privilege on the database (see
+`db-reset.sql.template`'s `GRANT ALL PRIVILEGES ON <db>.* TO '<app_user>'@'%'`).
+There is no per-object "owner" that can starve the app role of access the
+way Postgres's `OWNER` can, so scripts in this directory carry no
+ownership-guard block, and none should be added.
+
+The Drizzle stream (`src/database/migrations/`, run via `drizzle:migrate`)
+connects over the same pool as the application's DB role, so its objects
+are usable by construction. The rules above apply only to this
+hand-written stream.

--- a/packages/db-mysql/sql/README.md
+++ b/packages/db-mysql/sql/README.md
@@ -20,11 +20,15 @@ mysql -u byline -p byline_dev < packages/db-mysql/sql/0001_example.sql
 
 - **Numbered.** Scripts apply in filename order (`0001_...`, `0002_...`),
   same as the Postgres stream.
-- **Idempotent.** Each script should be safe to run more than once — guard
-  `CREATE TABLE` / `ALTER TABLE ... ADD COLUMN` with `IF NOT EXISTS` (or an
-  `information_schema` check for the ALTER forms MySQL's `IF NOT EXISTS`
-  doesn't cover) so a re-run after a partial failure doesn't error out on
-  work that already landed.
+- **Idempotent.** Each script should be safe to run more than once.
+  `CREATE TABLE` and `CREATE INDEX` take `IF NOT EXISTS`; `DROP TABLE` /
+  `DROP INDEX` take `IF EXISTS`. `ALTER TABLE` (adding a column, changing a
+  type, adding a constraint, …) takes neither — MySQL has no
+  `IF NOT EXISTS` form for any `ALTER TABLE` variant — so every `ALTER
+  TABLE` guard needs an explicit `information_schema` check (e.g. query
+  `information_schema.COLUMNS` for the column before adding it) so a
+  re-run after a partial failure doesn't error out on work that already
+  landed.
 - **Transactional, with a MySQL-specific caveat.** Wrap the
   data-manipulation portions of a script in `START TRANSACTION` /
   `COMMIT` the same way the Postgres scripts do. But unlike Postgres,

--- a/packages/db-mysql/src/database/common.sh
+++ b/packages/db-mysql/src/database/common.sh
@@ -213,16 +213,28 @@ MYSQL_PASSWORD_ESC=$(sed -e 's/\\/\\\\/g' -e "s/[']/\\\\&/g" <<< $MYSQL_PASSWORD
 # https://stackoverflow.com/questions/407523/escape-a-string-for-a-sed-replace-pattern/2705678#2705678
 MYSQL_PASSWORD_ESC=$(sed -e 's/[\/&]/\\&/g' <<< $MYSQL_PASSWORD_ESC)
 
-# Escape the username for the same sed substitution in db_init.sh. Before
-# `urldecode` (above) existed, a raw `/`, `&`, or `\` in the username was
-# structurally impossible — it would have broken URL parsing before
-# `parse_mysql_url` ever ran. Now a percent-encoded username (`%2F`,
-# `%26`, `%5C`) decodes into exactly those sed-special characters and
-# reaches db_init.sh's `s/${db_user}/.../ ` substitution unescaped,
-# corrupting the generated SQL (or, for `&`, silently substituting the
-# whole matched text instead of the literal username). Unlike the
-# password, the username never appears through this script as a SQL
-# string literal that also needs quote/backslash escaping — it only ever
-# reaches sed as a replacement value — so it gets this one escaping stage
-# and not the SQL-literal stage above.
-MYSQL_USER_ESC=$(sed -e 's/[\/&]/\\&/g' <<< $MYSQL_USER)
+# Escape the username for db_init.sh, which needs BOTH stages the
+# password gets above — not just the sed-replacement stage. Before
+# `urldecode` (above) existed, a raw `'`, `\`, `/`, or `&` in the username
+# was structurally impossible — it would have broken URL parsing before
+# `parse_mysql_url` ever ran. Now a percent-encoded username (`%27`,
+# `%5C`, `%2F`, `%26`) decodes into exactly those characters and reaches
+# db_init.sh unescaped.
+#
+# `db-reset.sql.template` renders the username as
+# `'${db_user}'@'%'` — inside single quotes, exactly like the password —
+# so it IS a MySQL SQL string literal here, not a bare identifier the way
+# Postgres's unquoted `CREATE ROLE ${db_user}` is. Skipping the SQL-literal
+# stage is exactly the failure this whole line of work exists to
+# eliminate: a `%5C` in the username decodes to a literal `\`, which
+# MySQL's string parser then treats as an escape-introducer and silently
+# swallows (`'byl\ine'` reads as `byline`) rather than raising a syntax
+# error — so `db_init.sh` would create the user under a different literal
+# name than mysql2 connects with, and the resulting "Access denied"
+# wouldn't point anywhere near the real cause. (`%27` — a literal `'` —
+# gives a loud syntax error instead of a silent mismatch, but still needs
+# escaping to not break the template.) Postgres's `common.sh` stays
+# single-stage: that dialect's template never quotes `${db_user}`, so a
+# username there is never a SQL string literal to begin with.
+MYSQL_USER_ESC=$(sed -e 's/\\/\\\\/g' -e "s/[']/\\\\&/g" <<< $MYSQL_USER)
+MYSQL_USER_ESC=$(sed -e 's/[\/&]/\\&/g' <<< $MYSQL_USER_ESC)

--- a/packages/db-mysql/src/database/common.sh
+++ b/packages/db-mysql/src/database/common.sh
@@ -43,6 +43,40 @@ check_conf_var() {
 
 ###~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~##
 #
+# FUNCTION: urldecode
+# Percent-decode a single URL component (RFC 3986 %XX escapes).
+#
+# `parse_mysql_url` below extracts the user/password substrings from the
+# connection string by plain string manipulation — it does not decode
+# percent-escapes. But `mysqlAdapter` hands the same connection string to
+# mysql2, which parses it as a real URL and DOES percent-decode the
+# userinfo (username/password) component. Left undecoded here, a password
+# containing a character that had to be percent-encoded in the URL (`@`,
+# `#`, `/`, `%`, `'`, a literal `\`, …) would make `db_init.sh` create the
+# MySQL user with the literal percent-escaped string as its password,
+# while the running application connects with the decoded password —
+# "Access denied," with nothing about the error pointing at the real
+# cause. See `packages/db-postgres/src/database/common.sh`'s identical
+# helper — node-postgres decodes the same way.
+#
+# Deliberately does NOT decode `+` to space: that is HTML form encoding
+# (`application/x-www-form-urlencoded`), which is a different convention
+# from URL-userinfo percent-encoding and is not what mysql2 or
+# node-postgres do when parsing a connection string.
+#
+# Escapes literal backslashes in the input *before* handing it to
+# `printf %b`, which otherwise treats `\` as the start of its own escape
+# sequence and would mangle a password that legitimately contains one.
+#
+###~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~##
+urldecode() {
+  local encoded="$1"
+  encoded="${encoded//\\/\\\\}"
+  printf '%b' "${encoded//%/\\x}"
+}
+
+###~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~##
+#
 # FUNCTION: parse_mysql_url
 # Parse a MySQL connection URL into MYSQL_USER, MYSQL_PASSWORD,
 # MYSQL_HOSTNAME, MYSQL_PORT, MYSQL_DATABASE. The single env var
@@ -53,6 +87,9 @@ check_conf_var() {
 #   mysql://user:password@host:port/database
 #
 # Strips `?...` query string. Defaults MYSQL_PORT to 3306 if absent.
+# MYSQL_USER and MYSQL_PASSWORD are percent-decoded (see `urldecode`
+# above) so a password with URL-reserved characters resolves to the same
+# literal value mysql2 resolves it to.
 #
 ###~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~##
 parse_mysql_url() {
@@ -86,8 +123,8 @@ parse_mysql_url() {
     return
   fi
 
-  MYSQL_USER="${userinfo%%:*}"
-  MYSQL_PASSWORD="${userinfo#*:}"
+  MYSQL_USER="$(urldecode "${userinfo%%:*}")"
+  MYSQL_PASSWORD="$(urldecode "${userinfo#*:}")"
 
   local hostport="${hostpart%%/*}"
   local dbpath="${hostpart#*/}"

--- a/packages/db-mysql/src/database/common.sh
+++ b/packages/db-mysql/src/database/common.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+
+###~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~##
+#
+# FUNCTION: get_required_input
+# Get user input from the terminal.
+# Params: $1 = the message prompting the user.
+# Params: $2 = the error message if no input is received.
+#
+###~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~##
+get_required_input() {
+  if [ -z "$1" -o -z "$2" ]; then
+    echo "get_required_input requires a prompt and an error message as first and second parameters." >&2
+    exit 1
+  fi
+
+  while true; do
+    echo -n "$1" >&2
+    read input
+    if [ -z "$input" ]; then
+      echo "$2" >&2
+    else
+      break
+    fi
+  done
+  echo $input
+}
+
+###~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~##
+#
+# FUNCTION: check_conf_var
+# Sanity check to ensure variable is defined, and exit if not
+# Params: $1 = Name of the variable
+#
+###~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~##
+check_conf_var() {
+  if [[ -z ${!1} ]]
+  then
+    echo "$1 not defined"
+    CONF_BAD=true
+  fi
+}
+
+###~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~##
+#
+# FUNCTION: parse_mysql_url
+# Parse a MySQL connection URL into MYSQL_USER, MYSQL_PASSWORD,
+# MYSQL_HOSTNAME, MYSQL_PORT, MYSQL_DATABASE. The single env var
+# BYLINE_DB_MYSQL_CONNECTION_STRING is the source of truth; the
+# downstream sed templates here and in db_init.sh consume the individual
+# variables. Expected shape:
+#
+#   mysql://user:password@host:port/database
+#
+# Strips `?...` query string. Defaults MYSQL_PORT to 3306 if absent.
+#
+###~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~##
+parse_mysql_url() {
+  local url="$1"
+  if [[ -z "${url}" ]]; then
+    echo "BYLINE_DB_MYSQL_CONNECTION_STRING not defined"
+    CONF_BAD=true
+    return
+  fi
+  if [[ "${url}" != mysql://* ]]; then
+    echo "BYLINE_DB_MYSQL_CONNECTION_STRING must start with mysql://"
+    CONF_BAD=true
+    return
+  fi
+
+  local rest="${url#*://}"
+
+  if [[ "${rest}" != *@* ]]; then
+    echo "BYLINE_DB_MYSQL_CONNECTION_STRING is missing user:password@ portion"
+    CONF_BAD=true
+    return
+  fi
+
+  # Split on the LAST `@` so passwords containing `@` survive.
+  local userinfo="${rest%@*}"
+  local hostpart="${rest##*@}"
+
+  if [[ "${userinfo}" != *:* ]]; then
+    echo "BYLINE_DB_MYSQL_CONNECTION_STRING is missing user:password@ portion"
+    CONF_BAD=true
+    return
+  fi
+
+  MYSQL_USER="${userinfo%%:*}"
+  MYSQL_PASSWORD="${userinfo#*:}"
+
+  local hostport="${hostpart%%/*}"
+  local dbpath="${hostpart#*/}"
+
+  if [[ "${hostport}" == *:* ]]; then
+    MYSQL_HOSTNAME="${hostport%%:*}"
+    MYSQL_PORT="${hostport#*:}"
+  else
+    MYSQL_HOSTNAME="${hostport}"
+    MYSQL_PORT="3306"
+  fi
+
+  MYSQL_DATABASE="${dbpath%%\?*}"
+}
+
+###~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~##
+#
+# FUNCTION: check_db_suffix
+# Foot-gun guard: refuse to continue unless MYSQL_DATABASE ends in
+# `_dev` or `_test`. Replaces the previous hard-coded `byline_dev`
+# assignment so the same scripts can target a dedicated test database
+# (e.g. `byline_test`) without ever pointing at a production-shaped name.
+#
+###~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~##
+check_db_suffix() {
+  if [[ "${MYSQL_DATABASE}" != *_dev && "${MYSQL_DATABASE}" != *_test ]]
+  then
+    echo "Refusing to operate on database='${MYSQL_DATABASE}'."
+    echo "These scripts will only target a database whose name ends in '_dev' or '_test'."
+    CONF_BAD=true
+  fi
+}
+
+###~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~##
+#
+# Resolve which .env file to source. Callers may set ENV_FILE before
+# sourcing this script (db_init.sh forwards a `--env-file <path>` arg)
+# to switch between dev and test environments. Defaults to ../../.env,
+# which resolves to packages/db-mysql/.env from src/database/.
+#
+###~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~##
+: "${ENV_FILE:=../../.env}"
+
+if [[ -e "${ENV_FILE}" ]]
+then
+  source "${ENV_FILE}"
+else
+  echo "env file not found: ${ENV_FILE}"
+  exit 1
+fi
+
+CONF_BAD=false
+check_conf_var BYLINE_DB_MYSQL_CONNECTION_STRING
+if $CONF_BAD; then exit 1; fi
+
+parse_mysql_url "${BYLINE_DB_MYSQL_CONNECTION_STRING}"
+if $CONF_BAD; then exit 1; fi
+
+check_db_suffix
+if $CONF_BAD; then exit 1; fi
+
+# Escape for MySQL -- the password will appear in our generated sql as a
+# single-quoted string literal, so we need to insert a \ character before
+# every \ and ' character in the original password.
+# https://dev.mysql.com/doc/refman/8.4/en/string-literals.html
+MYSQL_PASSWORD_ESC=$(sed -e 's/\\/\\\\/g' -e "s/[']/\\\\&/g" <<< $MYSQL_PASSWORD)
+
+# Escape for sed -- we'll use the password as a sed replacement pattern,
+# meaning we must insert a \ character before every \, / and & character
+# in the sql-escaped password from above.
+# https://stackoverflow.com/questions/407523/escape-a-string-for-a-sed-replace-pattern/2705678#2705678
+MYSQL_PASSWORD_ESC=$(sed -e 's/[\/&]/\\&/g' <<< $MYSQL_PASSWORD_ESC)

--- a/packages/db-mysql/src/database/common.sh
+++ b/packages/db-mysql/src/database/common.sh
@@ -68,9 +68,24 @@ check_conf_var() {
 # `printf %b`, which otherwise treats `\` as the start of its own escape
 # sequence and would mangle a password that legitimately contains one.
 #
+# Rejects a malformed percent-escape (a `%` not followed by exactly two
+# hex digits) instead of silently mis-decoding it — `printf %b` either
+# swallows a short/invalid escape into garbage bytes or prints its own
+# "missing hex digit" warning to stderr while still exiting 0, and either
+# way the caller would otherwise sail on with a corrupted value. A raw,
+# un-encoded `%` in a connection string violates RFC 3986, so this is
+# exactly the input mysql2 would independently reject with
+# `URIError: URI malformed` — failing here just fails at the same input
+# with a message that names the actual problem instead of a downstream
+# "Access denied."
+#
 ###~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~##
 urldecode() {
   local encoded="$1"
+  if [[ "${encoded}" =~ %([^0-9A-Fa-f]|[0-9A-Fa-f][^0-9A-Fa-f]|[0-9A-Fa-f]?$) ]]; then
+    echo "urldecode: malformed percent-escape in '${encoded}' -- every '%' must be followed by exactly two hex digits (e.g. '%40')" >&2
+    return 1
+  fi
   encoded="${encoded//\\/\\\\}"
   printf '%b' "${encoded//%/\\x}"
 }
@@ -123,8 +138,8 @@ parse_mysql_url() {
     return
   fi
 
-  MYSQL_USER="$(urldecode "${userinfo%%:*}")"
-  MYSQL_PASSWORD="$(urldecode "${userinfo#*:}")"
+  MYSQL_USER="$(urldecode "${userinfo%%:*}")" || { CONF_BAD=true; return; }
+  MYSQL_PASSWORD="$(urldecode "${userinfo#*:}")" || { CONF_BAD=true; return; }
 
   local hostport="${hostpart%%/*}"
   local dbpath="${hostpart#*/}"
@@ -197,3 +212,17 @@ MYSQL_PASSWORD_ESC=$(sed -e 's/\\/\\\\/g' -e "s/[']/\\\\&/g" <<< $MYSQL_PASSWORD
 # in the sql-escaped password from above.
 # https://stackoverflow.com/questions/407523/escape-a-string-for-a-sed-replace-pattern/2705678#2705678
 MYSQL_PASSWORD_ESC=$(sed -e 's/[\/&]/\\&/g' <<< $MYSQL_PASSWORD_ESC)
+
+# Escape the username for the same sed substitution in db_init.sh. Before
+# `urldecode` (above) existed, a raw `/`, `&`, or `\` in the username was
+# structurally impossible — it would have broken URL parsing before
+# `parse_mysql_url` ever ran. Now a percent-encoded username (`%2F`,
+# `%26`, `%5C`) decodes into exactly those sed-special characters and
+# reaches db_init.sh's `s/${db_user}/.../ ` substitution unescaped,
+# corrupting the generated SQL (or, for `&`, silently substituting the
+# whole matched text instead of the literal username). Unlike the
+# password, the username never appears through this script as a SQL
+# string literal that also needs quote/backslash escaping — it only ever
+# reaches sed as a replacement value — so it gets this one escaping stage
+# and not the SQL-literal stage above.
+MYSQL_USER_ESC=$(sed -e 's/[\/&]/\\&/g' <<< $MYSQL_USER)

--- a/packages/db-mysql/src/database/db-reset.sql.template
+++ b/packages/db-mysql/src/database/db-reset.sql.template
@@ -1,0 +1,17 @@
+/*
+  MYSQL script to drop and recreate the development database.
+  NOTE: Only do this if you are sure you have exported the latest configuration,
+  and know how to use the config_installer installation profile.
+*/
+
+CREATE USER IF NOT EXISTS '${db_user}'@'%' IDENTIFIED BY '${db_pass}';
+
+ALTER USER '${db_user}'@'%' IDENTIFIED BY '${db_pass}';
+
+DROP DATABASE IF EXISTS ${db_name};
+
+CREATE DATABASE ${db_name} CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+
+GRANT ALL PRIVILEGES ON ${db_name}.* TO '${db_user}'@'%';
+
+FLUSH PRIVILEGES;

--- a/packages/db-mysql/src/database/db_init.sh
+++ b/packages/db-mysql/src/database/db_init.sh
@@ -8,6 +8,13 @@
 #
 #  NOTE: Only do this if you are sure you know what you're doing.
 
+# Without this, a failure in the `sed` stage of the pipeline below is
+# invisible: bash reports a pipeline's exit status as its LAST command's
+# status by default, and the `mysql` client exits 0 on empty stdin (sed
+# having produced nothing) — a silent, successful-looking no-op instead
+# of the actual failure.
+set -o pipefail
+
 # Parse args: --env-file <path>
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -43,7 +50,7 @@ source common.sh
 export MYSQL_PWD="${MYSQL_ROOT_PASSWORD}"
 
 if command -v mysql >/dev/null 2>&1; then
-  MYSQL_CLIENT=(mysql -h 127.0.0.1 -u root)
+  MYSQL_CLIENT=(mysql -h "${MYSQL_HOSTNAME}" -P "${MYSQL_PORT}" -u root)
 else
   MYSQL_CLIENT=(docker exec -i -e MYSQL_PWD byline_dev_mysql mysql -u root)
 fi

--- a/packages/db-mysql/src/database/db_init.sh
+++ b/packages/db-mysql/src/database/db_init.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#  Script to drop and recreate a Byline database (dev or test).
+#
+#  Usage:
+#    ./db_init.sh                          # uses ../../.env (DB name in BYLINE_DB_MYSQL_CONNECTION_STRING must end _dev or _test)
+#    ./db_init.sh --env-file ../../.env.test
+#
+#  NOTE: Only do this if you are sure you know what you're doing.
+
+# Parse args: --env-file <path>
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --env-file)
+      ENV_FILE="$2"
+      shift 2
+      ;;
+    --env-file=*)
+      ENV_FILE="${1#*=}"
+      shift
+      ;;
+    *)
+      echo "unknown arg: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+export ENV_FILE
+
+source common.sh
+
+# Prefer a host `mysql` client if one is on PATH; otherwise fall back to the
+# server container's own client via `docker exec`. Connect as root, taking
+# the root password from MYSQL_ROOT_PASSWORD (defaulting to the compose
+# file's `test`) via MYSQL_PWD so it doesn't appear in `ps` output or
+# trigger the "password on the command line is insecure" warning. In both
+# branches MYSQL_PWD is exported on the host and referenced by name only
+# (`-e MYSQL_PWD` with no `=value`) so `docker exec` forwards the value from
+# the calling shell's environment without it ever appearing in the
+# `docker exec` argv itself.
+: "${MYSQL_ROOT_PASSWORD:=test}"
+export MYSQL_PWD="${MYSQL_ROOT_PASSWORD}"
+
+if command -v mysql >/dev/null 2>&1; then
+  MYSQL_CLIENT=(mysql -h 127.0.0.1 -u root)
+else
+  MYSQL_CLIENT=(docker exec -i -e MYSQL_PWD byline_dev_mysql mysql -u root)
+fi
+
+echo "Initializing DB '${MYSQL_DATABASE}'"
+sed -e "s/\${db_name}/${MYSQL_DATABASE}/" \
+    -e "s/\${db_user}/${MYSQL_USER}/" \
+    -e "s/\${db_pass}/${MYSQL_PASSWORD_ESC}/" db-reset.sql.template \
+  | "${MYSQL_CLIENT[@]}"

--- a/packages/db-mysql/src/database/db_init.sh
+++ b/packages/db-mysql/src/database/db_init.sh
@@ -50,6 +50,6 @@ fi
 
 echo "Initializing DB '${MYSQL_DATABASE}'"
 sed -e "s/\${db_name}/${MYSQL_DATABASE}/" \
-    -e "s/\${db_user}/${MYSQL_USER}/" \
+    -e "s/\${db_user}/${MYSQL_USER_ESC}/" \
     -e "s/\${db_pass}/${MYSQL_PASSWORD_ESC}/" db-reset.sql.template \
   | "${MYSQL_CLIENT[@]}"

--- a/packages/db-mysql/src/database/db_init_test.sh
+++ b/packages/db-mysql/src/database/db_init_test.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#  Convenience wrapper: initialise the dedicated test database (byline_test).
+#  Equivalent to: ./db_init.sh --env-file ../../.env.test
+
+exec ./db_init.sh --env-file ../../.env.test "$@"

--- a/packages/db-mysql/src/database/migrations/0000_empty_naoko.sql
+++ b/packages/db-mysql/src/database/migrations/0000_empty_naoko.sql
@@ -140,7 +140,7 @@ CREATE TABLE `byline_store_datetime` (
 	`updated_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
 	`date_type` varchar(20) NOT NULL,
 	`value_date` date,
-	`value_time` time,
+	`value_time` time(3),
 	`value_timestamp_tz` datetime(3),
 	CONSTRAINT `byline_store_datetime_id` PRIMARY KEY(`id`),
 	CONSTRAINT `unique_datetime_field` UNIQUE(`document_version_id`,`field_path`,`locale`)
@@ -159,7 +159,7 @@ CREATE TABLE `byline_document_paths` (
 	`document_id` char(36) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
 	`locale` varchar(10) NOT NULL,
 	`collection_id` char(36) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
-	`path` varchar(255) NOT NULL,
+	`path` varchar(255) COLLATE utf8mb4_bin NOT NULL,
 	`created_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
 	`updated_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
 	CONSTRAINT `unique_document_paths_document_locale` UNIQUE(`document_id`,`locale`),

--- a/packages/db-mysql/src/database/migrations/0000_past_nightcrawler.sql
+++ b/packages/db-mysql/src/database/migrations/0000_past_nightcrawler.sql
@@ -1,0 +1,411 @@
+CREATE TABLE `byline_admin_permissions` (
+	`id` char(36) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+	`vid` int NOT NULL DEFAULT 1,
+	`admin_role_id` char(36) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+	`ability` varchar(128) NOT NULL,
+	`created_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+	`updated_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+	CONSTRAINT `byline_admin_permissions_id` PRIMARY KEY(`id`),
+	CONSTRAINT `uq_byline_admin_permissions_role_ability` UNIQUE(`admin_role_id`,`ability`)
+);
+--> statement-breakpoint
+CREATE TABLE `byline_admin_refresh_tokens` (
+	`id` char(36) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+	`admin_user_id` char(36) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+	`token_hash` varchar(64) NOT NULL,
+	`issued_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+	`expires_at` datetime(3) NOT NULL,
+	`revoked_at` datetime(3),
+	`rotated_to_id` char(36) CHARACTER SET ascii COLLATE ascii_bin,
+	`last_used_at` datetime(3),
+	`user_agent` varchar(512),
+	`ip` varchar(45),
+	`created_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+	`updated_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+	CONSTRAINT `byline_admin_refresh_tokens_id` PRIMARY KEY(`id`),
+	CONSTRAINT `byline_admin_refresh_tokens_token_hash_unique` UNIQUE(`token_hash`)
+);
+--> statement-breakpoint
+CREATE TABLE `byline_admin_role_admin_user` (
+	`admin_role_id` char(36) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+	`admin_user_id` char(36) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+	`created_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+	CONSTRAINT `byline_admin_role_admin_user_admin_role_id_admin_user_id_pk` PRIMARY KEY(`admin_role_id`,`admin_user_id`)
+);
+--> statement-breakpoint
+CREATE TABLE `byline_admin_roles` (
+	`id` char(36) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+	`vid` int NOT NULL DEFAULT 1,
+	`name` varchar(128) NOT NULL,
+	`machine_name` varchar(128) NOT NULL,
+	`description` text,
+	`order` int NOT NULL DEFAULT 0,
+	`created_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+	`updated_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+	CONSTRAINT `byline_admin_roles_id` PRIMARY KEY(`id`),
+	CONSTRAINT `byline_admin_roles_machine_name_unique` UNIQUE(`machine_name`)
+);
+--> statement-breakpoint
+CREATE TABLE `byline_admin_user_preferences` (
+	`user_id` char(36) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+	`scope` varchar(255) NOT NULL,
+	`value` json NOT NULL,
+	`created_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+	`updated_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+	CONSTRAINT `byline_admin_user_preferences_user_id_scope_pk` PRIMARY KEY(`user_id`,`scope`)
+);
+--> statement-breakpoint
+CREATE TABLE `byline_admin_users` (
+	`id` char(36) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+	`vid` int NOT NULL DEFAULT 1,
+	`given_name` varchar(100),
+	`family_name` varchar(100),
+	`username` varchar(64),
+	`email` varchar(254) NOT NULL,
+	`password` varchar(255) NOT NULL,
+	`remember_me` boolean NOT NULL DEFAULT false,
+	`last_login` datetime(3),
+	`last_login_ip` varchar(45),
+	`failed_login_attempts` int NOT NULL DEFAULT 0,
+	`is_super_admin` boolean NOT NULL DEFAULT false,
+	`is_enabled` boolean NOT NULL DEFAULT false,
+	`is_email_verified` boolean NOT NULL DEFAULT false,
+	`preferred_locale` varchar(16),
+	`created_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+	`updated_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+	CONSTRAINT `byline_admin_users_id` PRIMARY KEY(`id`),
+	CONSTRAINT `byline_admin_users_username_unique` UNIQUE(`username`),
+	CONSTRAINT `byline_admin_users_email_unique` UNIQUE(`email`)
+);
+--> statement-breakpoint
+CREATE TABLE `byline_audit_log` (
+	`id` char(36) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+	`document_id` char(36) CHARACTER SET ascii COLLATE ascii_bin,
+	`collection_id` char(36) CHARACTER SET ascii COLLATE ascii_bin,
+	`actor_id` char(36) CHARACTER SET ascii COLLATE ascii_bin,
+	`actor_realm` varchar(16) NOT NULL,
+	`action` varchar(64) NOT NULL,
+	`field` varchar(128),
+	`before` json,
+	`after` json,
+	`occurred_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+	CONSTRAINT `byline_audit_log_id` PRIMARY KEY(`id`)
+);
+--> statement-breakpoint
+CREATE TABLE `byline_store_boolean` (
+	`id` char(36) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+	`document_version_id` char(36) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+	`collection_id` char(36) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+	`field_path` varchar(500) NOT NULL,
+	`field_name` varchar(255) NOT NULL,
+	`locale` varchar(10) NOT NULL DEFAULT 'default',
+	`parent_path` varchar(500),
+	`created_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+	`updated_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+	`value` boolean NOT NULL,
+	CONSTRAINT `byline_store_boolean_id` PRIMARY KEY(`id`),
+	CONSTRAINT `unique_boolean_field` UNIQUE(`document_version_id`,`field_path`,`locale`)
+);
+--> statement-breakpoint
+CREATE TABLE `byline_collections` (
+	`id` char(36) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+	`path` varchar(255) NOT NULL,
+	`singular` text NOT NULL,
+	`plural` text NOT NULL,
+	`config` json NOT NULL,
+	`version` int NOT NULL DEFAULT 1,
+	`schema_hash` varchar(64),
+	`created_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+	`updated_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+	CONSTRAINT `byline_collections_id` PRIMARY KEY(`id`),
+	CONSTRAINT `byline_collections_path_unique` UNIQUE(`path`)
+);
+--> statement-breakpoint
+CREATE TABLE `byline_counter_groups` (
+	`group_name` varchar(255) NOT NULL,
+	`sequence_name` text NOT NULL,
+	`created_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+	CONSTRAINT `byline_counter_groups_group_name` PRIMARY KEY(`group_name`)
+);
+--> statement-breakpoint
+CREATE TABLE `byline_store_datetime` (
+	`id` char(36) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+	`document_version_id` char(36) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+	`collection_id` char(36) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+	`field_path` varchar(500) NOT NULL,
+	`field_name` varchar(255) NOT NULL,
+	`locale` varchar(10) NOT NULL DEFAULT 'default',
+	`parent_path` varchar(500),
+	`created_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+	`updated_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+	`date_type` varchar(20) NOT NULL,
+	`value_date` date,
+	`value_time` time,
+	`value_timestamp_tz` datetime(3),
+	CONSTRAINT `byline_store_datetime_id` PRIMARY KEY(`id`),
+	CONSTRAINT `unique_datetime_field` UNIQUE(`document_version_id`,`field_path`,`locale`)
+);
+--> statement-breakpoint
+CREATE TABLE `byline_document_available_locales` (
+	`document_id` char(36) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+	`locale` varchar(10) NOT NULL,
+	`collection_id` char(36) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+	`created_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+	`updated_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+	CONSTRAINT `byline_document_available_locales_document_id_locale_pk` PRIMARY KEY(`document_id`,`locale`)
+);
+--> statement-breakpoint
+CREATE TABLE `byline_document_paths` (
+	`document_id` char(36) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+	`locale` varchar(10) NOT NULL,
+	`collection_id` char(36) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+	`path` varchar(255) NOT NULL,
+	`created_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+	`updated_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+	CONSTRAINT `unique_document_paths_document_locale` UNIQUE(`document_id`,`locale`),
+	CONSTRAINT `idx_document_paths_collection_locale_path` UNIQUE(`collection_id`,`locale`,`path`)
+);
+--> statement-breakpoint
+CREATE TABLE `byline_document_relationships` (
+	`child_document_id` char(36) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+	`parent_document_id` char(36) CHARACTER SET ascii COLLATE ascii_bin,
+	`order_key` varchar(128) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+	`created_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+	`updated_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+	CONSTRAINT `uq_document_relationships_child` UNIQUE(`child_document_id`)
+);
+--> statement-breakpoint
+CREATE TABLE `byline_document_version_locales` (
+	`document_version_id` char(36) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+	`locale` varchar(10) NOT NULL,
+	CONSTRAINT `byline_document_version_locales_document_version_id_locale_pk` PRIMARY KEY(`document_version_id`,`locale`)
+);
+--> statement-breakpoint
+CREATE TABLE `byline_document_versions` (
+	`id` char(36) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+	`document_id` char(36) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+	`collection_id` char(36) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+	`collection_version` int NOT NULL,
+	`doc` json,
+	`event_type` varchar(20) NOT NULL DEFAULT 'create',
+	`status` varchar(50) DEFAULT 'draft',
+	`is_deleted` boolean DEFAULT false,
+	`created_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+	`updated_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+	`created_by` char(36) CHARACTER SET ascii COLLATE ascii_bin,
+	`change_summary` text,
+	CONSTRAINT `byline_document_versions_id` PRIMARY KEY(`id`)
+);
+--> statement-breakpoint
+CREATE TABLE `byline_documents` (
+	`id` char(36) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+	`collection_id` char(36) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+	`order_key` varchar(128) CHARACTER SET ascii COLLATE ascii_bin,
+	`source_locale` varchar(10) NOT NULL,
+	`created_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+	`updated_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+	CONSTRAINT `byline_documents_id` PRIMARY KEY(`id`)
+);
+--> statement-breakpoint
+CREATE TABLE `byline_store_file` (
+	`id` char(36) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+	`document_version_id` char(36) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+	`collection_id` char(36) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+	`field_path` varchar(500) NOT NULL,
+	`field_name` varchar(255) NOT NULL,
+	`locale` varchar(10) NOT NULL DEFAULT 'default',
+	`parent_path` varchar(500),
+	`created_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+	`updated_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+	`file_id` char(36) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+	`filename` varchar(255) NOT NULL,
+	`original_filename` varchar(255) NOT NULL,
+	`mime_type` varchar(100) NOT NULL,
+	`file_size` bigint NOT NULL,
+	`file_hash` varchar(64),
+	`storage_provider` varchar(50) NOT NULL,
+	`storage_path` text NOT NULL,
+	`storage_url` text,
+	`image_width` int,
+	`image_height` int,
+	`image_format` varchar(20),
+	`processing_status` varchar(20) DEFAULT 'pending',
+	`thumbnail_generated` boolean DEFAULT false,
+	`variants` json,
+	CONSTRAINT `byline_store_file_id` PRIMARY KEY(`id`),
+	CONSTRAINT `unique_file_field` UNIQUE(`document_version_id`,`field_path`,`locale`)
+);
+--> statement-breakpoint
+CREATE TABLE `byline_store_json` (
+	`id` char(36) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+	`document_version_id` char(36) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+	`collection_id` char(36) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+	`field_path` varchar(500) NOT NULL,
+	`field_name` varchar(255) NOT NULL,
+	`locale` varchar(10) NOT NULL DEFAULT 'default',
+	`parent_path` varchar(500),
+	`created_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+	`updated_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+	`value` json NOT NULL,
+	`json_schema` varchar(100),
+	`object_keys` json,
+	CONSTRAINT `byline_store_json_id` PRIMARY KEY(`id`),
+	CONSTRAINT `unique_json_field` UNIQUE(`document_version_id`,`field_path`,`locale`)
+);
+--> statement-breakpoint
+CREATE TABLE `byline_store_meta` (
+	`id` char(36) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+	`document_version_id` char(36) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+	`collection_id` char(36) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+	`type` varchar(50) NOT NULL,
+	`path` varchar(512) NOT NULL,
+	`item_id` varchar(255) NOT NULL,
+	`meta` json,
+	`created_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+	`updated_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+	CONSTRAINT `byline_store_meta_id` PRIMARY KEY(`id`),
+	CONSTRAINT `unique_meta_node` UNIQUE(`document_version_id`,`type`,`path`)
+);
+--> statement-breakpoint
+CREATE TABLE `byline_store_numeric` (
+	`id` char(36) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+	`document_version_id` char(36) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+	`collection_id` char(36) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+	`field_path` varchar(500) NOT NULL,
+	`field_name` varchar(255) NOT NULL,
+	`locale` varchar(10) NOT NULL DEFAULT 'default',
+	`parent_path` varchar(500),
+	`created_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+	`updated_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+	`number_type` varchar(20) NOT NULL,
+	`value_integer` int,
+	`value_decimal` decimal(10,2),
+	`value_float` float,
+	CONSTRAINT `byline_store_numeric_id` PRIMARY KEY(`id`),
+	CONSTRAINT `unique_numeric_field` UNIQUE(`document_version_id`,`field_path`,`locale`)
+);
+--> statement-breakpoint
+CREATE TABLE `byline_store_relation` (
+	`id` char(36) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+	`document_version_id` char(36) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+	`collection_id` char(36) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+	`field_path` varchar(500) NOT NULL,
+	`field_name` varchar(255) NOT NULL,
+	`locale` varchar(10) NOT NULL DEFAULT 'default',
+	`parent_path` varchar(500),
+	`created_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+	`updated_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+	`target_document_id` char(36) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+	`target_collection_id` char(36) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+	`relationship_type` varchar(50) DEFAULT 'reference',
+	`cascade_delete` boolean DEFAULT false,
+	CONSTRAINT `byline_store_relation_id` PRIMARY KEY(`id`),
+	CONSTRAINT `unique_relation_field` UNIQUE(`document_version_id`,`field_path`,`locale`)
+);
+--> statement-breakpoint
+CREATE TABLE `byline_store_text` (
+	`id` char(36) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+	`document_version_id` char(36) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+	`collection_id` char(36) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+	`field_path` varchar(500) NOT NULL,
+	`field_name` varchar(255) NOT NULL,
+	`locale` varchar(10) NOT NULL DEFAULT 'default',
+	`parent_path` varchar(500),
+	`created_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+	`updated_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+	`value` text NOT NULL,
+	`word_count` int,
+	CONSTRAINT `byline_store_text_id` PRIMARY KEY(`id`),
+	CONSTRAINT `unique_text_field` UNIQUE(`document_version_id`,`field_path`,`locale`)
+);
+--> statement-breakpoint
+ALTER TABLE `byline_admin_permissions` ADD CONSTRAINT `fk_admin_permissions_admin_role_id` FOREIGN KEY (`admin_role_id`) REFERENCES `byline_admin_roles`(`id`) ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE `byline_admin_refresh_tokens` ADD CONSTRAINT `fk_admin_refresh_tokens_admin_user_id` FOREIGN KEY (`admin_user_id`) REFERENCES `byline_admin_users`(`id`) ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE `byline_admin_role_admin_user` ADD CONSTRAINT `fk_admin_role_admin_user_admin_role_id` FOREIGN KEY (`admin_role_id`) REFERENCES `byline_admin_roles`(`id`) ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE `byline_admin_role_admin_user` ADD CONSTRAINT `fk_admin_role_admin_user_admin_user_id` FOREIGN KEY (`admin_user_id`) REFERENCES `byline_admin_users`(`id`) ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE `byline_admin_user_preferences` ADD CONSTRAINT `fk_admin_user_preferences_user_id` FOREIGN KEY (`user_id`) REFERENCES `byline_admin_users`(`id`) ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE `byline_store_boolean` ADD CONSTRAINT `fk_store_boolean_document_version_id` FOREIGN KEY (`document_version_id`) REFERENCES `byline_document_versions`(`id`) ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE `byline_store_boolean` ADD CONSTRAINT `fk_store_boolean_collection_id` FOREIGN KEY (`collection_id`) REFERENCES `byline_collections`(`id`) ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE `byline_store_datetime` ADD CONSTRAINT `fk_store_datetime_document_version_id` FOREIGN KEY (`document_version_id`) REFERENCES `byline_document_versions`(`id`) ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE `byline_store_datetime` ADD CONSTRAINT `fk_store_datetime_collection_id` FOREIGN KEY (`collection_id`) REFERENCES `byline_collections`(`id`) ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE `byline_document_available_locales` ADD CONSTRAINT `fk_document_available_locales_document_id` FOREIGN KEY (`document_id`) REFERENCES `byline_documents`(`id`) ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE `byline_document_available_locales` ADD CONSTRAINT `fk_document_available_locales_collection_id` FOREIGN KEY (`collection_id`) REFERENCES `byline_collections`(`id`) ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE `byline_document_paths` ADD CONSTRAINT `fk_document_paths_document_id` FOREIGN KEY (`document_id`) REFERENCES `byline_documents`(`id`) ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE `byline_document_paths` ADD CONSTRAINT `fk_document_paths_collection_id` FOREIGN KEY (`collection_id`) REFERENCES `byline_collections`(`id`) ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE `byline_document_relationships` ADD CONSTRAINT `fk_document_relationships_child_document_id` FOREIGN KEY (`child_document_id`) REFERENCES `byline_documents`(`id`) ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE `byline_document_relationships` ADD CONSTRAINT `fk_document_relationships_parent_document_id` FOREIGN KEY (`parent_document_id`) REFERENCES `byline_documents`(`id`) ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE `byline_document_version_locales` ADD CONSTRAINT `fk_document_version_locales_document_version_id` FOREIGN KEY (`document_version_id`) REFERENCES `byline_document_versions`(`id`) ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE `byline_document_versions` ADD CONSTRAINT `fk_document_versions_document_id` FOREIGN KEY (`document_id`) REFERENCES `byline_documents`(`id`) ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE `byline_document_versions` ADD CONSTRAINT `fk_document_versions_collection_id` FOREIGN KEY (`collection_id`) REFERENCES `byline_collections`(`id`) ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE `byline_documents` ADD CONSTRAINT `fk_documents_collection_id` FOREIGN KEY (`collection_id`) REFERENCES `byline_collections`(`id`) ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE `byline_store_file` ADD CONSTRAINT `fk_store_file_document_version_id` FOREIGN KEY (`document_version_id`) REFERENCES `byline_document_versions`(`id`) ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE `byline_store_file` ADD CONSTRAINT `fk_store_file_collection_id` FOREIGN KEY (`collection_id`) REFERENCES `byline_collections`(`id`) ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE `byline_store_json` ADD CONSTRAINT `fk_store_json_document_version_id` FOREIGN KEY (`document_version_id`) REFERENCES `byline_document_versions`(`id`) ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE `byline_store_json` ADD CONSTRAINT `fk_store_json_collection_id` FOREIGN KEY (`collection_id`) REFERENCES `byline_collections`(`id`) ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE `byline_store_meta` ADD CONSTRAINT `fk_store_meta_document_version_id` FOREIGN KEY (`document_version_id`) REFERENCES `byline_document_versions`(`id`) ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE `byline_store_meta` ADD CONSTRAINT `fk_store_meta_collection_id` FOREIGN KEY (`collection_id`) REFERENCES `byline_collections`(`id`) ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE `byline_store_numeric` ADD CONSTRAINT `fk_store_numeric_document_version_id` FOREIGN KEY (`document_version_id`) REFERENCES `byline_document_versions`(`id`) ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE `byline_store_numeric` ADD CONSTRAINT `fk_store_numeric_collection_id` FOREIGN KEY (`collection_id`) REFERENCES `byline_collections`(`id`) ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE `byline_store_relation` ADD CONSTRAINT `fk_store_relation_document_version_id` FOREIGN KEY (`document_version_id`) REFERENCES `byline_document_versions`(`id`) ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE `byline_store_relation` ADD CONSTRAINT `fk_store_relation_collection_id` FOREIGN KEY (`collection_id`) REFERENCES `byline_collections`(`id`) ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE `byline_store_relation` ADD CONSTRAINT `fk_store_relation_target_document_id` FOREIGN KEY (`target_document_id`) REFERENCES `byline_documents`(`id`) ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE `byline_store_relation` ADD CONSTRAINT `fk_store_relation_target_collection_id` FOREIGN KEY (`target_collection_id`) REFERENCES `byline_collections`(`id`) ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE `byline_store_text` ADD CONSTRAINT `fk_store_text_document_version_id` FOREIGN KEY (`document_version_id`) REFERENCES `byline_document_versions`(`id`) ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE `byline_store_text` ADD CONSTRAINT `fk_store_text_collection_id` FOREIGN KEY (`collection_id`) REFERENCES `byline_collections`(`id`) ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX `idx_byline_admin_permissions_role` ON `byline_admin_permissions` (`admin_role_id`);--> statement-breakpoint
+CREATE INDEX `idx_byline_admin_refresh_tokens_user` ON `byline_admin_refresh_tokens` (`admin_user_id`);--> statement-breakpoint
+CREATE INDEX `idx_byline_admin_refresh_tokens_token_hash` ON `byline_admin_refresh_tokens` (`token_hash`);--> statement-breakpoint
+CREATE INDEX `idx_byline_admin_role_admin_user_user` ON `byline_admin_role_admin_user` (`admin_user_id`);--> statement-breakpoint
+CREATE INDEX `idx_byline_admin_roles_machine_name` ON `byline_admin_roles` (`machine_name`);--> statement-breakpoint
+CREATE INDEX `idx_byline_admin_users_email` ON `byline_admin_users` (`email`);--> statement-breakpoint
+CREATE INDEX `idx_audit_log_document_id` ON `byline_audit_log` (`document_id`,`id`);--> statement-breakpoint
+CREATE INDEX `idx_audit_log_actor_id` ON `byline_audit_log` (`actor_id`,`id`);--> statement-breakpoint
+CREATE INDEX `idx_audit_log_action` ON `byline_audit_log` (`action`,`id`);--> statement-breakpoint
+CREATE INDEX `idx_boolean_value` ON `byline_store_boolean` (`value`);--> statement-breakpoint
+CREATE INDEX `idx_boolean_path_value` ON `byline_store_boolean` (`field_path`,`value`);--> statement-breakpoint
+CREATE INDEX `idx_boolean_collection_value` ON `byline_store_boolean` (`collection_id`,`field_path`,`value`);--> statement-breakpoint
+CREATE INDEX `idx_datetime_date` ON `byline_store_datetime` (`value_date`);--> statement-breakpoint
+CREATE INDEX `idx_datetime_timestamp_tz` ON `byline_store_datetime` (`value_timestamp_tz`);--> statement-breakpoint
+CREATE INDEX `idx_datetime_path_date` ON `byline_store_datetime` (`field_path`,`value_timestamp_tz`);--> statement-breakpoint
+CREATE INDEX `idx_datetime_collection_date` ON `byline_store_datetime` (`collection_id`,`value_timestamp_tz`);--> statement-breakpoint
+CREATE INDEX `idx_document_available_locales_document_id` ON `byline_document_available_locales` (`document_id`);--> statement-breakpoint
+CREATE INDEX `idx_document_paths_document_id` ON `byline_document_paths` (`document_id`);--> statement-breakpoint
+CREATE INDEX `idx_document_relationships_parent_order` ON `byline_document_relationships` (`parent_document_id`,`order_key`);--> statement-breakpoint
+CREATE INDEX `idx_documents_document_id` ON `byline_document_versions` (`document_id`);--> statement-breakpoint
+CREATE INDEX `idx_documents_collection_document_deleted` ON `byline_document_versions` (`collection_id`,`document_id`,`is_deleted`);--> statement-breakpoint
+CREATE INDEX `idx_documents_current_view` ON `byline_document_versions` (`collection_id`,`document_id`,`is_deleted`,`id`);--> statement-breakpoint
+CREATE INDEX `idx_documents_event_type` ON `byline_document_versions` (`event_type`);--> statement-breakpoint
+CREATE INDEX `idx_documents_created_at` ON `byline_document_versions` (`created_at`);--> statement-breakpoint
+CREATE INDEX `idx_documents_document_collection` ON `byline_document_versions` (`document_id`,`collection_id`);--> statement-breakpoint
+CREATE INDEX `idx_documents_collection` ON `byline_documents` (`collection_id`);--> statement-breakpoint
+CREATE INDEX `idx_documents_collection_order` ON `byline_documents` (`collection_id`,`order_key`);--> statement-breakpoint
+CREATE INDEX `idx_file_file_id` ON `byline_store_file` (`file_id`);--> statement-breakpoint
+CREATE INDEX `idx_file_mime_type` ON `byline_store_file` (`mime_type`);--> statement-breakpoint
+CREATE INDEX `idx_file_size` ON `byline_store_file` (`file_size`);--> statement-breakpoint
+CREATE INDEX `idx_file_hash` ON `byline_store_file` (`file_hash`);--> statement-breakpoint
+CREATE INDEX `idx_file_image_dimensions` ON `byline_store_file` (`image_width`,`image_height`);--> statement-breakpoint
+CREATE INDEX `idx_file_storage_provider` ON `byline_store_file` (`storage_provider`);--> statement-breakpoint
+CREATE INDEX `idx_file_processing_status` ON `byline_store_file` (`processing_status`);--> statement-breakpoint
+CREATE INDEX `idx_json_schema` ON `byline_store_json` (`json_schema`);--> statement-breakpoint
+CREATE INDEX `idx_meta_document_type_path` ON `byline_store_meta` (`document_version_id`,`type`,`path`);--> statement-breakpoint
+CREATE INDEX `idx_meta_item_id` ON `byline_store_meta` (`item_id`);--> statement-breakpoint
+CREATE INDEX `idx_meta_collection_type` ON `byline_store_meta` (`collection_id`,`type`);--> statement-breakpoint
+CREATE INDEX `idx_numeric_integer` ON `byline_store_numeric` (`value_integer`);--> statement-breakpoint
+CREATE INDEX `idx_numeric_decimal` ON `byline_store_numeric` (`value_decimal`);--> statement-breakpoint
+CREATE INDEX `idx_numeric_float` ON `byline_store_numeric` (`value_float`);--> statement-breakpoint
+CREATE INDEX `idx_numeric_integer_range` ON `byline_store_numeric` (`field_path`,`value_integer`);--> statement-breakpoint
+CREATE INDEX `idx_numeric_decimal_range` ON `byline_store_numeric` (`field_path`,`value_decimal`);--> statement-breakpoint
+CREATE INDEX `idx_relation_target_document` ON `byline_store_relation` (`target_document_id`);--> statement-breakpoint
+CREATE INDEX `idx_relation_target_collection` ON `byline_store_relation` (`target_collection_id`);--> statement-breakpoint
+CREATE INDEX `idx_relation_type` ON `byline_store_relation` (`relationship_type`);--> statement-breakpoint
+CREATE INDEX `idx_relation_reverse` ON `byline_store_relation` (`target_document_id`,`field_path`);--> statement-breakpoint
+CREATE INDEX `idx_relation_collection_to_collection` ON `byline_store_relation` (`collection_id`,`target_collection_id`);--> statement-breakpoint
+CREATE INDEX `idx_text_value` ON `byline_store_text` (`value`(191));--> statement-breakpoint
+CREATE INDEX `idx_text_locale_value` ON `byline_store_text` (`locale`,`value`(191));--> statement-breakpoint
+CREATE INDEX `idx_text_path_value` ON `byline_store_text` (`field_path`,`value`(191));--> statement-breakpoint
+CREATE ALGORITHM = undefined
+SQL SECURITY definer
+VIEW `byline_current_documents` AS (with `sq` as (select `id`, `document_id`, `collection_id`, `collection_version`, `event_type`, `status`, `is_deleted`, `created_at`, `updated_at`, `created_by`, `change_summary`, row_number() OVER (PARTITION BY `document_id` ORDER BY `id` DESC) as `rn` from `byline_document_versions` where `byline_document_versions`.`is_deleted` = false) select `sq`.`id`, `sq`.`document_id`, `sq`.`collection_id`, `sq`.`collection_version`, `sq`.`event_type`, `sq`.`status`, `sq`.`is_deleted`, `sq`.`created_at`, `sq`.`updated_at`, `sq`.`created_by`, `sq`.`change_summary`, `byline_documents`.`order_key`, `byline_documents`.`source_locale` from `sq` inner join `byline_documents` on `byline_documents`.`id` = `sq`.`document_id` where `rn` = 1);--> statement-breakpoint
+CREATE ALGORITHM = undefined
+SQL SECURITY definer
+VIEW `byline_current_published_documents` AS (with `sq` as (select `id`, `document_id`, `collection_id`, `collection_version`, `event_type`, `status`, `is_deleted`, `created_at`, `updated_at`, `created_by`, `change_summary`, row_number() OVER (PARTITION BY `document_id` ORDER BY `id` DESC) as `rn` from `byline_document_versions` where `byline_document_versions`.`is_deleted` = false AND `byline_document_versions`.`status` = 'published') select `sq`.`id`, `sq`.`document_id`, `sq`.`collection_id`, `sq`.`collection_version`, `sq`.`event_type`, `sq`.`status`, `sq`.`is_deleted`, `sq`.`created_at`, `sq`.`updated_at`, `sq`.`created_by`, `sq`.`change_summary`, `byline_documents`.`order_key`, `byline_documents`.`source_locale` from `sq` inner join `byline_documents` on `byline_documents`.`id` = `sq`.`document_id` where `rn` = 1);

--- a/packages/db-mysql/src/database/migrations/meta/0000_snapshot.json
+++ b/packages/db-mysql/src/database/migrations/meta/0000_snapshot.json
@@ -1,0 +1,3182 @@
+{
+  "version": "5",
+  "dialect": "mysql",
+  "id": "89d616bc-62da-4e2d-85e6-61a0d297bec8",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "tables": {
+    "byline_admin_permissions": {
+      "name": "byline_admin_permissions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "vid": {
+          "name": "vid",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "admin_role_id": {
+          "name": "admin_role_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ability": {
+          "name": "ability",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "idx_byline_admin_permissions_role": {
+          "name": "idx_byline_admin_permissions_role",
+          "columns": [
+            "admin_role_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "fk_admin_permissions_admin_role_id": {
+          "name": "fk_admin_permissions_admin_role_id",
+          "tableFrom": "byline_admin_permissions",
+          "tableTo": "byline_admin_roles",
+          "columnsFrom": [
+            "admin_role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "byline_admin_permissions_id": {
+          "name": "byline_admin_permissions_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "uq_byline_admin_permissions_role_ability": {
+          "name": "uq_byline_admin_permissions_role_ability",
+          "columns": [
+            "admin_role_id",
+            "ability"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "byline_admin_refresh_tokens": {
+      "name": "byline_admin_refresh_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rotated_to_id": {
+          "name": "rotated_to_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "idx_byline_admin_refresh_tokens_user": {
+          "name": "idx_byline_admin_refresh_tokens_user",
+          "columns": [
+            "admin_user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_byline_admin_refresh_tokens_token_hash": {
+          "name": "idx_byline_admin_refresh_tokens_token_hash",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "fk_admin_refresh_tokens_admin_user_id": {
+          "name": "fk_admin_refresh_tokens_admin_user_id",
+          "tableFrom": "byline_admin_refresh_tokens",
+          "tableTo": "byline_admin_users",
+          "columnsFrom": [
+            "admin_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "byline_admin_refresh_tokens_id": {
+          "name": "byline_admin_refresh_tokens_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "byline_admin_refresh_tokens_token_hash_unique": {
+          "name": "byline_admin_refresh_tokens_token_hash_unique",
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "byline_admin_role_admin_user": {
+      "name": "byline_admin_role_admin_user",
+      "columns": {
+        "admin_role_id": {
+          "name": "admin_role_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "idx_byline_admin_role_admin_user_user": {
+          "name": "idx_byline_admin_role_admin_user_user",
+          "columns": [
+            "admin_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "fk_admin_role_admin_user_admin_role_id": {
+          "name": "fk_admin_role_admin_user_admin_role_id",
+          "tableFrom": "byline_admin_role_admin_user",
+          "tableTo": "byline_admin_roles",
+          "columnsFrom": [
+            "admin_role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_admin_role_admin_user_admin_user_id": {
+          "name": "fk_admin_role_admin_user_admin_user_id",
+          "tableFrom": "byline_admin_role_admin_user",
+          "tableTo": "byline_admin_users",
+          "columnsFrom": [
+            "admin_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "byline_admin_role_admin_user_admin_role_id_admin_user_id_pk": {
+          "name": "byline_admin_role_admin_user_admin_role_id_admin_user_id_pk",
+          "columns": [
+            "admin_role_id",
+            "admin_user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "byline_admin_roles": {
+      "name": "byline_admin_roles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "vid": {
+          "name": "vid",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "machine_name": {
+          "name": "machine_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "idx_byline_admin_roles_machine_name": {
+          "name": "idx_byline_admin_roles_machine_name",
+          "columns": [
+            "machine_name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "byline_admin_roles_id": {
+          "name": "byline_admin_roles_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "byline_admin_roles_machine_name_unique": {
+          "name": "byline_admin_roles_machine_name_unique",
+          "columns": [
+            "machine_name"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "byline_admin_user_preferences": {
+      "name": "byline_admin_user_preferences",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fk_admin_user_preferences_user_id": {
+          "name": "fk_admin_user_preferences_user_id",
+          "tableFrom": "byline_admin_user_preferences",
+          "tableTo": "byline_admin_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "byline_admin_user_preferences_user_id_scope_pk": {
+          "name": "byline_admin_user_preferences_user_id_scope_pk",
+          "columns": [
+            "user_id",
+            "scope"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "byline_admin_users": {
+      "name": "byline_admin_users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "vid": {
+          "name": "vid",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "given_name": {
+          "name": "given_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "family_name": {
+          "name": "family_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(254)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remember_me": {
+          "name": "remember_me",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "last_login": {
+          "name": "last_login",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_login_ip": {
+          "name": "last_login_ip",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failed_login_attempts": {
+          "name": "failed_login_attempts",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_super_admin": {
+          "name": "is_super_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_email_verified": {
+          "name": "is_email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "preferred_locale": {
+          "name": "preferred_locale",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "idx_byline_admin_users_email": {
+          "name": "idx_byline_admin_users_email",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "byline_admin_users_id": {
+          "name": "byline_admin_users_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "byline_admin_users_username_unique": {
+          "name": "byline_admin_users_username_unique",
+          "columns": [
+            "username"
+          ]
+        },
+        "byline_admin_users_email_unique": {
+          "name": "byline_admin_users_email_unique",
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "byline_audit_log": {
+      "name": "byline_audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_realm": {
+          "name": "actor_realm",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field": {
+          "name": "field",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "before": {
+          "name": "before",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "after": {
+          "name": "after",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "idx_audit_log_document_id": {
+          "name": "idx_audit_log_document_id",
+          "columns": [
+            "document_id",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "idx_audit_log_actor_id": {
+          "name": "idx_audit_log_actor_id",
+          "columns": [
+            "actor_id",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "idx_audit_log_action": {
+          "name": "idx_audit_log_action",
+          "columns": [
+            "action",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "byline_audit_log_id": {
+          "name": "byline_audit_log_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "byline_store_boolean": {
+      "name": "byline_store_boolean",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_version_id": {
+          "name": "document_version_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_path": {
+          "name": "field_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_name": {
+          "name": "field_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "parent_path": {
+          "name": "parent_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "value": {
+          "name": "value",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_boolean_value": {
+          "name": "idx_boolean_value",
+          "columns": [
+            "value"
+          ],
+          "isUnique": false
+        },
+        "idx_boolean_path_value": {
+          "name": "idx_boolean_path_value",
+          "columns": [
+            "field_path",
+            "value"
+          ],
+          "isUnique": false
+        },
+        "idx_boolean_collection_value": {
+          "name": "idx_boolean_collection_value",
+          "columns": [
+            "collection_id",
+            "field_path",
+            "value"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "fk_store_boolean_document_version_id": {
+          "name": "fk_store_boolean_document_version_id",
+          "tableFrom": "byline_store_boolean",
+          "tableTo": "byline_document_versions",
+          "columnsFrom": [
+            "document_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_store_boolean_collection_id": {
+          "name": "fk_store_boolean_collection_id",
+          "tableFrom": "byline_store_boolean",
+          "tableTo": "byline_collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "byline_store_boolean_id": {
+          "name": "byline_store_boolean_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_boolean_field": {
+          "name": "unique_boolean_field",
+          "columns": [
+            "document_version_id",
+            "field_path",
+            "locale"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "byline_collections": {
+      "name": "byline_collections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "singular": {
+          "name": "singular",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plural": {
+          "name": "plural",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "schema_hash": {
+          "name": "schema_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "byline_collections_id": {
+          "name": "byline_collections_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "byline_collections_path_unique": {
+          "name": "byline_collections_path_unique",
+          "columns": [
+            "path"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "byline_counter_groups": {
+      "name": "byline_counter_groups",
+      "columns": {
+        "group_name": {
+          "name": "group_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence_name": {
+          "name": "sequence_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "byline_counter_groups_group_name": {
+          "name": "byline_counter_groups_group_name",
+          "columns": [
+            "group_name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "byline_store_datetime": {
+      "name": "byline_store_datetime",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_version_id": {
+          "name": "document_version_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_path": {
+          "name": "field_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_name": {
+          "name": "field_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "parent_path": {
+          "name": "parent_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "date_type": {
+          "name": "date_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value_date": {
+          "name": "value_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "value_time": {
+          "name": "value_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "value_timestamp_tz": {
+          "name": "value_timestamp_tz",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_datetime_date": {
+          "name": "idx_datetime_date",
+          "columns": [
+            "value_date"
+          ],
+          "isUnique": false
+        },
+        "idx_datetime_timestamp_tz": {
+          "name": "idx_datetime_timestamp_tz",
+          "columns": [
+            "value_timestamp_tz"
+          ],
+          "isUnique": false
+        },
+        "idx_datetime_path_date": {
+          "name": "idx_datetime_path_date",
+          "columns": [
+            "field_path",
+            "value_timestamp_tz"
+          ],
+          "isUnique": false
+        },
+        "idx_datetime_collection_date": {
+          "name": "idx_datetime_collection_date",
+          "columns": [
+            "collection_id",
+            "value_timestamp_tz"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "fk_store_datetime_document_version_id": {
+          "name": "fk_store_datetime_document_version_id",
+          "tableFrom": "byline_store_datetime",
+          "tableTo": "byline_document_versions",
+          "columnsFrom": [
+            "document_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_store_datetime_collection_id": {
+          "name": "fk_store_datetime_collection_id",
+          "tableFrom": "byline_store_datetime",
+          "tableTo": "byline_collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "byline_store_datetime_id": {
+          "name": "byline_store_datetime_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_datetime_field": {
+          "name": "unique_datetime_field",
+          "columns": [
+            "document_version_id",
+            "field_path",
+            "locale"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "byline_document_available_locales": {
+      "name": "byline_document_available_locales",
+      "columns": {
+        "document_id": {
+          "name": "document_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "idx_document_available_locales_document_id": {
+          "name": "idx_document_available_locales_document_id",
+          "columns": [
+            "document_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "fk_document_available_locales_document_id": {
+          "name": "fk_document_available_locales_document_id",
+          "tableFrom": "byline_document_available_locales",
+          "tableTo": "byline_documents",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_document_available_locales_collection_id": {
+          "name": "fk_document_available_locales_collection_id",
+          "tableFrom": "byline_document_available_locales",
+          "tableTo": "byline_collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "byline_document_available_locales_document_id_locale_pk": {
+          "name": "byline_document_available_locales_document_id_locale_pk",
+          "columns": [
+            "document_id",
+            "locale"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "byline_document_paths": {
+      "name": "byline_document_paths",
+      "columns": {
+        "document_id": {
+          "name": "document_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "idx_document_paths_document_id": {
+          "name": "idx_document_paths_document_id",
+          "columns": [
+            "document_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "fk_document_paths_document_id": {
+          "name": "fk_document_paths_document_id",
+          "tableFrom": "byline_document_paths",
+          "tableTo": "byline_documents",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_document_paths_collection_id": {
+          "name": "fk_document_paths_collection_id",
+          "tableFrom": "byline_document_paths",
+          "tableTo": "byline_collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_document_paths_document_locale": {
+          "name": "unique_document_paths_document_locale",
+          "columns": [
+            "document_id",
+            "locale"
+          ]
+        },
+        "idx_document_paths_collection_locale_path": {
+          "name": "idx_document_paths_collection_locale_path",
+          "columns": [
+            "collection_id",
+            "locale",
+            "path"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "byline_document_relationships": {
+      "name": "byline_document_relationships",
+      "columns": {
+        "child_document_id": {
+          "name": "child_document_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_document_id": {
+          "name": "parent_document_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "varchar(128) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "idx_document_relationships_parent_order": {
+          "name": "idx_document_relationships_parent_order",
+          "columns": [
+            "parent_document_id",
+            "order_key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "fk_document_relationships_child_document_id": {
+          "name": "fk_document_relationships_child_document_id",
+          "tableFrom": "byline_document_relationships",
+          "tableTo": "byline_documents",
+          "columnsFrom": [
+            "child_document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_document_relationships_parent_document_id": {
+          "name": "fk_document_relationships_parent_document_id",
+          "tableFrom": "byline_document_relationships",
+          "tableTo": "byline_documents",
+          "columnsFrom": [
+            "parent_document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_document_relationships_child": {
+          "name": "uq_document_relationships_child",
+          "columns": [
+            "child_document_id"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "byline_document_version_locales": {
+      "name": "byline_document_version_locales",
+      "columns": {
+        "document_version_id": {
+          "name": "document_version_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fk_document_version_locales_document_version_id": {
+          "name": "fk_document_version_locales_document_version_id",
+          "tableFrom": "byline_document_version_locales",
+          "tableTo": "byline_document_versions",
+          "columnsFrom": [
+            "document_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "byline_document_version_locales_document_version_id_locale_pk": {
+          "name": "byline_document_version_locales_document_version_id_locale_pk",
+          "columns": [
+            "document_version_id",
+            "locale"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "byline_document_versions": {
+      "name": "byline_document_versions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection_version": {
+          "name": "collection_version",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "doc": {
+          "name": "doc",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'create'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "change_summary": {
+          "name": "change_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_documents_document_id": {
+          "name": "idx_documents_document_id",
+          "columns": [
+            "document_id"
+          ],
+          "isUnique": false
+        },
+        "idx_documents_collection_document_deleted": {
+          "name": "idx_documents_collection_document_deleted",
+          "columns": [
+            "collection_id",
+            "document_id",
+            "is_deleted"
+          ],
+          "isUnique": false
+        },
+        "idx_documents_current_view": {
+          "name": "idx_documents_current_view",
+          "columns": [
+            "collection_id",
+            "document_id",
+            "is_deleted",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "idx_documents_event_type": {
+          "name": "idx_documents_event_type",
+          "columns": [
+            "event_type"
+          ],
+          "isUnique": false
+        },
+        "idx_documents_created_at": {
+          "name": "idx_documents_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_documents_document_collection": {
+          "name": "idx_documents_document_collection",
+          "columns": [
+            "document_id",
+            "collection_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "fk_document_versions_document_id": {
+          "name": "fk_document_versions_document_id",
+          "tableFrom": "byline_document_versions",
+          "tableTo": "byline_documents",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_document_versions_collection_id": {
+          "name": "fk_document_versions_collection_id",
+          "tableFrom": "byline_document_versions",
+          "tableTo": "byline_collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "byline_document_versions_id": {
+          "name": "byline_document_versions_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "byline_documents": {
+      "name": "byline_documents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "varchar(128) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_locale": {
+          "name": "source_locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "idx_documents_collection": {
+          "name": "idx_documents_collection",
+          "columns": [
+            "collection_id"
+          ],
+          "isUnique": false
+        },
+        "idx_documents_collection_order": {
+          "name": "idx_documents_collection_order",
+          "columns": [
+            "collection_id",
+            "order_key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "fk_documents_collection_id": {
+          "name": "fk_documents_collection_id",
+          "tableFrom": "byline_documents",
+          "tableTo": "byline_collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "byline_documents_id": {
+          "name": "byline_documents_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "byline_store_file": {
+      "name": "byline_store_file",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_version_id": {
+          "name": "document_version_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_path": {
+          "name": "field_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_name": {
+          "name": "field_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "parent_path": {
+          "name": "parent_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_filename": {
+          "name": "original_filename",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "storage_provider": {
+          "name": "storage_provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "storage_url": {
+          "name": "storage_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_width": {
+          "name": "image_width",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_height": {
+          "name": "image_height",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_format": {
+          "name": "image_format",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "processing_status": {
+          "name": "processing_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "thumbnail_generated": {
+          "name": "thumbnail_generated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "variants": {
+          "name": "variants",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_file_file_id": {
+          "name": "idx_file_file_id",
+          "columns": [
+            "file_id"
+          ],
+          "isUnique": false
+        },
+        "idx_file_mime_type": {
+          "name": "idx_file_mime_type",
+          "columns": [
+            "mime_type"
+          ],
+          "isUnique": false
+        },
+        "idx_file_size": {
+          "name": "idx_file_size",
+          "columns": [
+            "file_size"
+          ],
+          "isUnique": false
+        },
+        "idx_file_hash": {
+          "name": "idx_file_hash",
+          "columns": [
+            "file_hash"
+          ],
+          "isUnique": false
+        },
+        "idx_file_image_dimensions": {
+          "name": "idx_file_image_dimensions",
+          "columns": [
+            "image_width",
+            "image_height"
+          ],
+          "isUnique": false
+        },
+        "idx_file_storage_provider": {
+          "name": "idx_file_storage_provider",
+          "columns": [
+            "storage_provider"
+          ],
+          "isUnique": false
+        },
+        "idx_file_processing_status": {
+          "name": "idx_file_processing_status",
+          "columns": [
+            "processing_status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "fk_store_file_document_version_id": {
+          "name": "fk_store_file_document_version_id",
+          "tableFrom": "byline_store_file",
+          "tableTo": "byline_document_versions",
+          "columnsFrom": [
+            "document_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_store_file_collection_id": {
+          "name": "fk_store_file_collection_id",
+          "tableFrom": "byline_store_file",
+          "tableTo": "byline_collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "byline_store_file_id": {
+          "name": "byline_store_file_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_file_field": {
+          "name": "unique_file_field",
+          "columns": [
+            "document_version_id",
+            "field_path",
+            "locale"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "byline_store_json": {
+      "name": "byline_store_json",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_version_id": {
+          "name": "document_version_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_path": {
+          "name": "field_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_name": {
+          "name": "field_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "parent_path": {
+          "name": "parent_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "value": {
+          "name": "value",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "json_schema": {
+          "name": "json_schema",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "object_keys": {
+          "name": "object_keys",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_json_schema": {
+          "name": "idx_json_schema",
+          "columns": [
+            "json_schema"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "fk_store_json_document_version_id": {
+          "name": "fk_store_json_document_version_id",
+          "tableFrom": "byline_store_json",
+          "tableTo": "byline_document_versions",
+          "columnsFrom": [
+            "document_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_store_json_collection_id": {
+          "name": "fk_store_json_collection_id",
+          "tableFrom": "byline_store_json",
+          "tableTo": "byline_collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "byline_store_json_id": {
+          "name": "byline_store_json_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_json_field": {
+          "name": "unique_json_field",
+          "columns": [
+            "document_version_id",
+            "field_path",
+            "locale"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "byline_store_meta": {
+      "name": "byline_store_meta",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_version_id": {
+          "name": "document_version_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "idx_meta_document_type_path": {
+          "name": "idx_meta_document_type_path",
+          "columns": [
+            "document_version_id",
+            "type",
+            "path"
+          ],
+          "isUnique": false
+        },
+        "idx_meta_item_id": {
+          "name": "idx_meta_item_id",
+          "columns": [
+            "item_id"
+          ],
+          "isUnique": false
+        },
+        "idx_meta_collection_type": {
+          "name": "idx_meta_collection_type",
+          "columns": [
+            "collection_id",
+            "type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "fk_store_meta_document_version_id": {
+          "name": "fk_store_meta_document_version_id",
+          "tableFrom": "byline_store_meta",
+          "tableTo": "byline_document_versions",
+          "columnsFrom": [
+            "document_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_store_meta_collection_id": {
+          "name": "fk_store_meta_collection_id",
+          "tableFrom": "byline_store_meta",
+          "tableTo": "byline_collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "byline_store_meta_id": {
+          "name": "byline_store_meta_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_meta_node": {
+          "name": "unique_meta_node",
+          "columns": [
+            "document_version_id",
+            "type",
+            "path"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "byline_store_numeric": {
+      "name": "byline_store_numeric",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_version_id": {
+          "name": "document_version_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_path": {
+          "name": "field_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_name": {
+          "name": "field_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "parent_path": {
+          "name": "parent_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "number_type": {
+          "name": "number_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value_integer": {
+          "name": "value_integer",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "value_decimal": {
+          "name": "value_decimal",
+          "type": "decimal(10,2)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "value_float": {
+          "name": "value_float",
+          "type": "float",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_numeric_integer": {
+          "name": "idx_numeric_integer",
+          "columns": [
+            "value_integer"
+          ],
+          "isUnique": false
+        },
+        "idx_numeric_decimal": {
+          "name": "idx_numeric_decimal",
+          "columns": [
+            "value_decimal"
+          ],
+          "isUnique": false
+        },
+        "idx_numeric_float": {
+          "name": "idx_numeric_float",
+          "columns": [
+            "value_float"
+          ],
+          "isUnique": false
+        },
+        "idx_numeric_integer_range": {
+          "name": "idx_numeric_integer_range",
+          "columns": [
+            "field_path",
+            "value_integer"
+          ],
+          "isUnique": false
+        },
+        "idx_numeric_decimal_range": {
+          "name": "idx_numeric_decimal_range",
+          "columns": [
+            "field_path",
+            "value_decimal"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "fk_store_numeric_document_version_id": {
+          "name": "fk_store_numeric_document_version_id",
+          "tableFrom": "byline_store_numeric",
+          "tableTo": "byline_document_versions",
+          "columnsFrom": [
+            "document_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_store_numeric_collection_id": {
+          "name": "fk_store_numeric_collection_id",
+          "tableFrom": "byline_store_numeric",
+          "tableTo": "byline_collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "byline_store_numeric_id": {
+          "name": "byline_store_numeric_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_numeric_field": {
+          "name": "unique_numeric_field",
+          "columns": [
+            "document_version_id",
+            "field_path",
+            "locale"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "byline_store_relation": {
+      "name": "byline_store_relation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_version_id": {
+          "name": "document_version_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_path": {
+          "name": "field_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_name": {
+          "name": "field_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "parent_path": {
+          "name": "parent_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "target_document_id": {
+          "name": "target_document_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_collection_id": {
+          "name": "target_collection_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "relationship_type": {
+          "name": "relationship_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'reference'"
+        },
+        "cascade_delete": {
+          "name": "cascade_delete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "idx_relation_target_document": {
+          "name": "idx_relation_target_document",
+          "columns": [
+            "target_document_id"
+          ],
+          "isUnique": false
+        },
+        "idx_relation_target_collection": {
+          "name": "idx_relation_target_collection",
+          "columns": [
+            "target_collection_id"
+          ],
+          "isUnique": false
+        },
+        "idx_relation_type": {
+          "name": "idx_relation_type",
+          "columns": [
+            "relationship_type"
+          ],
+          "isUnique": false
+        },
+        "idx_relation_reverse": {
+          "name": "idx_relation_reverse",
+          "columns": [
+            "target_document_id",
+            "field_path"
+          ],
+          "isUnique": false
+        },
+        "idx_relation_collection_to_collection": {
+          "name": "idx_relation_collection_to_collection",
+          "columns": [
+            "collection_id",
+            "target_collection_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "fk_store_relation_document_version_id": {
+          "name": "fk_store_relation_document_version_id",
+          "tableFrom": "byline_store_relation",
+          "tableTo": "byline_document_versions",
+          "columnsFrom": [
+            "document_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_store_relation_collection_id": {
+          "name": "fk_store_relation_collection_id",
+          "tableFrom": "byline_store_relation",
+          "tableTo": "byline_collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_store_relation_target_document_id": {
+          "name": "fk_store_relation_target_document_id",
+          "tableFrom": "byline_store_relation",
+          "tableTo": "byline_documents",
+          "columnsFrom": [
+            "target_document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "fk_store_relation_target_collection_id": {
+          "name": "fk_store_relation_target_collection_id",
+          "tableFrom": "byline_store_relation",
+          "tableTo": "byline_collections",
+          "columnsFrom": [
+            "target_collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "byline_store_relation_id": {
+          "name": "byline_store_relation_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_relation_field": {
+          "name": "unique_relation_field",
+          "columns": [
+            "document_version_id",
+            "field_path",
+            "locale"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "byline_store_text": {
+      "name": "byline_store_text",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_version_id": {
+          "name": "document_version_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_path": {
+          "name": "field_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_name": {
+          "name": "field_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "parent_path": {
+          "name": "parent_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "word_count": {
+          "name": "word_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_text_value": {
+          "name": "idx_text_value",
+          "columns": [
+            "`value`(191)"
+          ],
+          "isUnique": false
+        },
+        "idx_text_locale_value": {
+          "name": "idx_text_locale_value",
+          "columns": [
+            "locale",
+            "`value`(191)"
+          ],
+          "isUnique": false
+        },
+        "idx_text_path_value": {
+          "name": "idx_text_path_value",
+          "columns": [
+            "field_path",
+            "`value`(191)"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "fk_store_text_document_version_id": {
+          "name": "fk_store_text_document_version_id",
+          "tableFrom": "byline_store_text",
+          "tableTo": "byline_document_versions",
+          "columnsFrom": [
+            "document_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_store_text_collection_id": {
+          "name": "fk_store_text_collection_id",
+          "tableFrom": "byline_store_text",
+          "tableTo": "byline_collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "byline_store_text_id": {
+          "name": "byline_store_text_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_text_field": {
+          "name": "unique_text_field",
+          "columns": [
+            "document_version_id",
+            "field_path",
+            "locale"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    }
+  },
+  "views": {
+    "byline_current_documents": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection_version": {
+          "name": "collection_version",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'create'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "change_summary": {
+          "name": "change_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "varchar(128) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_locale": {
+          "name": "source_locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "name": "byline_current_documents",
+      "isExisting": false,
+      "definition": "with `sq` as (select `id`, `document_id`, `collection_id`, `collection_version`, `event_type`, `status`, `is_deleted`, `created_at`, `updated_at`, `created_by`, `change_summary`, row_number() OVER (PARTITION BY `document_id` ORDER BY `id` DESC) as `rn` from `byline_document_versions` where `byline_document_versions`.`is_deleted` = false) select `sq`.`id`, `sq`.`document_id`, `sq`.`collection_id`, `sq`.`collection_version`, `sq`.`event_type`, `sq`.`status`, `sq`.`is_deleted`, `sq`.`created_at`, `sq`.`updated_at`, `sq`.`created_by`, `sq`.`change_summary`, `byline_documents`.`order_key`, `byline_documents`.`source_locale` from `sq` inner join `byline_documents` on `byline_documents`.`id` = `sq`.`document_id` where `rn` = 1",
+      "algorithm": "undefined",
+      "sqlSecurity": "definer"
+    },
+    "byline_current_published_documents": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection_version": {
+          "name": "collection_version",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'create'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "change_summary": {
+          "name": "change_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "varchar(128) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_locale": {
+          "name": "source_locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "name": "byline_current_published_documents",
+      "isExisting": false,
+      "definition": "with `sq` as (select `id`, `document_id`, `collection_id`, `collection_version`, `event_type`, `status`, `is_deleted`, `created_at`, `updated_at`, `created_by`, `change_summary`, row_number() OVER (PARTITION BY `document_id` ORDER BY `id` DESC) as `rn` from `byline_document_versions` where `byline_document_versions`.`is_deleted` = false AND `byline_document_versions`.`status` = 'published') select `sq`.`id`, `sq`.`document_id`, `sq`.`collection_id`, `sq`.`collection_version`, `sq`.`event_type`, `sq`.`status`, `sq`.`is_deleted`, `sq`.`created_at`, `sq`.`updated_at`, `sq`.`created_by`, `sq`.`change_summary`, `byline_documents`.`order_key`, `byline_documents`.`source_locale` from `sq` inner join `byline_documents` on `byline_documents`.`id` = `sq`.`document_id` where `rn` = 1",
+      "algorithm": "undefined",
+      "sqlSecurity": "definer"
+    }
+  },
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {
+      "idx_text_value": {
+        "columns": {
+          "`value`(191)": {
+            "isExpression": true
+          }
+        }
+      },
+      "idx_text_locale_value": {
+        "columns": {
+          "`value`(191)": {
+            "isExpression": true
+          }
+        }
+      },
+      "idx_text_path_value": {
+        "columns": {
+          "`value`(191)": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/db-mysql/src/database/migrations/meta/0000_snapshot.json
+++ b/packages/db-mysql/src/database/migrations/meta/0000_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "5",
   "dialect": "mysql",
-  "id": "89d616bc-62da-4e2d-85e6-61a0d297bec8",
+  "id": "54b6ad03-c719-4832-a3f2-32cc0fd2794d",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "tables": {
     "byline_admin_permissions": {
@@ -1115,7 +1115,7 @@
         },
         "value_time": {
           "name": "value_time",
-          "type": "time",
+          "type": "time(3)",
           "primaryKey": false,
           "notNull": false,
           "autoincrement": false
@@ -1324,7 +1324,7 @@
         },
         "path": {
           "name": "path",
-          "type": "varchar(255)",
+          "type": "varchar(255) COLLATE utf8mb4_bin",
           "primaryKey": false,
           "notNull": true,
           "autoincrement": false

--- a/packages/db-mysql/src/database/migrations/meta/_journal.json
+++ b/packages/db-mysql/src/database/migrations/meta/_journal.json
@@ -5,8 +5,8 @@
     {
       "idx": 0,
       "version": "5",
-      "when": 1784940547623,
-      "tag": "0000_past_nightcrawler",
+      "when": 1784944142980,
+      "tag": "0000_empty_naoko",
       "breakpoints": true
     }
   ]

--- a/packages/db-mysql/src/database/migrations/meta/_journal.json
+++ b/packages/db-mysql/src/database/migrations/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "mysql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "5",
+      "when": 1784940547623,
+      "tag": "0000_past_nightcrawler",
+      "breakpoints": true
+    }
+  ]
+}

--- a/packages/db-mysql/src/database/schema/auth.ts
+++ b/packages/db-mysql/src/database/schema/auth.ts
@@ -1,0 +1,278 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+/**
+ * Auth schema — admin identity, roles, role-user assignment, and per-role
+ * ability grants.
+ *
+ * All tables carry the `byline_` prefix so Byline can coexist with other
+ * schemas in a shared database. The TypeScript exports are unprefixed —
+ * the prefix is a DB-side concern.
+ *
+ * Shape mirrors the mature Modulus Learning implementation with minor
+ * Byline conventions:
+ *   - UUIDv7 primary keys (generated at insert time in the repository).
+ *   - `vid` integer version column for optimistic concurrency (defaults
+ *     to 1; bumped by write paths when needed).
+ *   - snake_case column names matching the rest of the Byline schema.
+ *
+ * See docs/06-auth-and-security/01-authn-authz.md for the full data model and present-state
+ * reference.
+ */
+
+import { relations, sql } from 'drizzle-orm'
+import {
+  boolean,
+  datetime,
+  foreignKey,
+  index,
+  int,
+  json,
+  mysqlTable,
+  primaryKey,
+  text,
+  unique,
+  varchar,
+} from 'drizzle-orm/mysql-core'
+
+import { createdAt, timestamps, uuidChar } from './common.js'
+
+// Foreign keys below use the table-level `foreignKey()` builder with an
+// explicit, short `fk_<table>_<column>` name rather than the Postgres
+// schema's column-level `.references()` shorthand — MySQL enforces a hard
+// 64-character identifier cap that several of this schema's auto-generated
+// FK names exceed. See the longer explanation in `./index.ts`.
+
+// ---------------------------------------------------------------------------
+// byline_admin_users
+// ---------------------------------------------------------------------------
+
+export const adminUsers = mysqlTable(
+  'byline_admin_users',
+  {
+    id: uuidChar('id').primaryKey(),
+    vid: int('vid').notNull().default(1),
+    given_name: varchar('given_name', { length: 100 }),
+    family_name: varchar('family_name', { length: 100 }),
+    /** Optional — email is the primary identifier. Unique when present. */
+    username: varchar('username', { length: 64 }).unique(),
+    email: varchar('email', { length: 254 }).notNull().unique(),
+    /** Full PHC string, e.g. `$argon2id$v=19$m=…$…$…`. */
+    password: varchar('password', { length: 255 }).notNull(),
+    remember_me: boolean('remember_me').notNull().default(false),
+    last_login: datetime('last_login', { fsp: 3 }),
+    last_login_ip: varchar('last_login_ip', { length: 45 }),
+    failed_login_attempts: int('failed_login_attempts').notNull().default(0),
+    /**
+     * Actor-level super-admin bypass. When true, `AdminAuth.isSuperAdmin`
+     * short-circuits every ability check. Set only via the seed script
+     * (or manually by a DB admin) — never via the admin UI.
+     */
+    is_super_admin: boolean('is_super_admin').notNull().default(false),
+    /**
+     * Account enablement. Defaults to `false` so accounts created through
+     * any future admin UI require a deliberate enable step. The super-admin
+     * seed sets this to `true`.
+     */
+    is_enabled: boolean('is_enabled').notNull().default(false),
+    is_email_verified: boolean('is_email_verified').notNull().default(false),
+    /**
+     * Per-user admin interface locale preference. Nullable — `null` means
+     * "use the detection cascade" (cookie → Accept-Language → defaultLocale).
+     * Stored as a BCP 47 code (`en`, `pt-BR`, `zh-Hans-CN`); validated at
+     * write time against the host's `i18n.interface.locales` set.
+     */
+    preferred_locale: varchar('preferred_locale', { length: 16 }),
+    ...timestamps,
+  },
+  (table) => [index('idx_byline_admin_users_email').on(table.email)]
+)
+
+// ---------------------------------------------------------------------------
+// byline_admin_user_preferences
+// ---------------------------------------------------------------------------
+
+/**
+ * Scoped per-user key-value preferences (e.g. sticky list-view page
+ * size and sort). One row per (user, scope); `scope` is a dot-separated
+ * key like `collections.docs.list` and `value` is a JSON object whose
+ * shape belongs to the scope's feature. Composite natural PK — writes
+ * are `INSERT … ON DUPLICATE KEY UPDATE` with a per-key JSON merge.
+ * See `@byline/admin/admin-preferences`.
+ */
+export const adminUserPreferences = mysqlTable(
+  'byline_admin_user_preferences',
+  {
+    user_id: uuidChar('user_id').notNull(),
+    scope: varchar('scope', { length: 255 }).notNull(),
+    value: json('value').notNull().$type<Record<string, unknown>>(),
+    ...timestamps,
+  },
+  (table) => [
+    foreignKey({
+      name: 'fk_admin_user_preferences_user_id',
+      columns: [table.user_id],
+      foreignColumns: [adminUsers.id],
+    }).onDelete('cascade'),
+    primaryKey({ columns: [table.user_id, table.scope] }),
+  ]
+)
+
+// ---------------------------------------------------------------------------
+// byline_admin_roles
+// ---------------------------------------------------------------------------
+
+export const adminRoles = mysqlTable(
+  'byline_admin_roles',
+  {
+    id: uuidChar('id').primaryKey(),
+    vid: int('vid').notNull().default(1),
+    /** Human-readable label, e.g. `'Editor'`. */
+    name: varchar('name', { length: 128 }).notNull(),
+    /** Stable identifier used in code, e.g. `'editor'`, `'super-admin'`. */
+    machine_name: varchar('machine_name', { length: 128 }).notNull().unique(),
+    description: text('description'),
+    /** Display ordering in the role-editor UI. */
+    order: int('order').notNull().default(0),
+    ...timestamps,
+  },
+  (table) => [index('idx_byline_admin_roles_machine_name').on(table.machine_name)]
+)
+
+// ---------------------------------------------------------------------------
+// byline_admin_role_admin_user — many-to-many join
+// ---------------------------------------------------------------------------
+
+export const adminRoleAdminUser = mysqlTable(
+  'byline_admin_role_admin_user',
+  {
+    admin_role_id: uuidChar('admin_role_id').notNull(),
+    admin_user_id: uuidChar('admin_user_id').notNull(),
+    ...createdAt,
+  },
+  (table) => [
+    foreignKey({
+      name: 'fk_admin_role_admin_user_admin_role_id',
+      columns: [table.admin_role_id],
+      foreignColumns: [adminRoles.id],
+    }).onDelete('cascade'),
+    foreignKey({
+      name: 'fk_admin_role_admin_user_admin_user_id',
+      columns: [table.admin_user_id],
+      foreignColumns: [adminUsers.id],
+    }).onDelete('cascade'),
+    primaryKey({ columns: [table.admin_role_id, table.admin_user_id] }),
+    index('idx_byline_admin_role_admin_user_user').on(table.admin_user_id),
+  ]
+)
+
+// ---------------------------------------------------------------------------
+// byline_admin_permissions — one row per (role, ability) grant
+// ---------------------------------------------------------------------------
+
+export const adminPermissions = mysqlTable(
+  'byline_admin_permissions',
+  {
+    id: uuidChar('id').primaryKey(),
+    vid: int('vid').notNull().default(1),
+    admin_role_id: uuidChar('admin_role_id').notNull(),
+    /** Flat dotted ability key — see `@byline/auth` AbilityRegistry. */
+    ability: varchar('ability', { length: 128 }).notNull(),
+    ...timestamps,
+  },
+  (table) => [
+    foreignKey({
+      name: 'fk_admin_permissions_admin_role_id',
+      columns: [table.admin_role_id],
+      foreignColumns: [adminRoles.id],
+    }).onDelete('cascade'),
+    unique('uq_byline_admin_permissions_role_ability').on(table.admin_role_id, table.ability),
+    index('idx_byline_admin_permissions_role').on(table.admin_role_id),
+  ]
+)
+
+// ---------------------------------------------------------------------------
+// byline_admin_refresh_tokens — JWT session provider's refresh-token store
+// ---------------------------------------------------------------------------
+
+/**
+ * Refresh tokens are opaque random strings minted by `JwtSessionProvider`.
+ * We never store the plaintext — only a SHA-256 hash (`token_hash`). When
+ * a token is rotated, `revoked_at` is stamped and `rotated_to_id` points
+ * at the replacement row; presenting a rotated token is treated as replay
+ * and revokes the whole chain.
+ */
+export const adminRefreshTokens = mysqlTable(
+  'byline_admin_refresh_tokens',
+  {
+    id: uuidChar('id').primaryKey(),
+    admin_user_id: uuidChar('admin_user_id').notNull(),
+    /** SHA-256 hex digest of the raw refresh-token string. 64 chars. */
+    token_hash: varchar('token_hash', { length: 64 }).notNull().unique(),
+    issued_at: datetime('issued_at', { fsp: 3 }).notNull().default(sql`CURRENT_TIMESTAMP(3)`),
+    expires_at: datetime('expires_at', { fsp: 3 }).notNull(),
+    revoked_at: datetime('revoked_at', { fsp: 3 }),
+    /**
+     * When this token was rotated, the id of the new token issued in its
+     * place. Self-referential; set atomically alongside `revoked_at`.
+     */
+    rotated_to_id: uuidChar('rotated_to_id'),
+    last_used_at: datetime('last_used_at', { fsp: 3 }),
+    user_agent: varchar('user_agent', { length: 512 }),
+    ip: varchar('ip', { length: 45 }),
+    ...timestamps,
+  },
+  (table) => [
+    foreignKey({
+      name: 'fk_admin_refresh_tokens_admin_user_id',
+      columns: [table.admin_user_id],
+      foreignColumns: [adminUsers.id],
+    }).onDelete('cascade'),
+    index('idx_byline_admin_refresh_tokens_user').on(table.admin_user_id),
+    index('idx_byline_admin_refresh_tokens_token_hash').on(table.token_hash),
+  ]
+)
+
+// ---------------------------------------------------------------------------
+// Relations (drizzle query helpers)
+// ---------------------------------------------------------------------------
+
+export const adminUsersRelations = relations(adminUsers, ({ many }) => ({
+  roleAssignments: many(adminRoleAdminUser),
+  refreshTokens: many(adminRefreshTokens),
+}))
+
+export const adminRolesRelations = relations(adminRoles, ({ many }) => ({
+  userAssignments: many(adminRoleAdminUser),
+  permissions: many(adminPermissions),
+}))
+
+export const adminRoleAdminUserRelations = relations(adminRoleAdminUser, ({ one }) => ({
+  role: one(adminRoles, {
+    fields: [adminRoleAdminUser.admin_role_id],
+    references: [adminRoles.id],
+  }),
+  user: one(adminUsers, {
+    fields: [adminRoleAdminUser.admin_user_id],
+    references: [adminUsers.id],
+  }),
+}))
+
+export const adminPermissionsRelations = relations(adminPermissions, ({ one }) => ({
+  role: one(adminRoles, {
+    fields: [adminPermissions.admin_role_id],
+    references: [adminRoles.id],
+  }),
+}))
+
+export const adminRefreshTokensRelations = relations(adminRefreshTokens, ({ one }) => ({
+  user: one(adminUsers, {
+    fields: [adminRefreshTokens.admin_user_id],
+    references: [adminUsers.id],
+  }),
+}))

--- a/packages/db-mysql/src/database/schema/common.ts
+++ b/packages/db-mysql/src/database/schema/common.ts
@@ -49,6 +49,42 @@ export const varcharByteSorted = customType<{
 })
 
 /**
+ * `varchar(...)` with the `utf8mb4_bin` collation — full `utf8mb4` charset
+ * (unlike `uuidChar/varcharByteSorted`'s ascii-only columns, this one must
+ * carry arbitrary Unicode), but byte-wise, case- and accent-sensitive
+ * comparison instead of the database's default `utf8mb4_0900_ai_ci`.
+ *
+ * Used for `byline_document_paths.path`. MySQL's default collation is
+ * accent- *and* case-insensitive, so `/About` and `/about` collide as the
+ * same path on MySQL while remaining two distinct paths on Postgres (whose
+ * default collation carries no such folding). The project owner's initial
+ * instinct was that MySQL's default might be the *better* semantic for
+ * URLs — until testing against a live server showed `ai_ci` also collapses
+ * combining marks Byline's slugifier deliberately preserves for non-Latin
+ * scripts: `กา` = `ก่า` (a Thai tone mark), `कान` = `कानं` (a Devanagari
+ * anusvara), `שלום` = `שָׁלוֹם` (Hebrew niqqud) — see
+ * `packages/core/src/utils/slugify.ts`, which folds Latin diacritics but
+ * explicitly keeps non-Latin combining marks, because those marks are
+ * meaning-bearing in a way a Latin accent mark on a URL slug typically
+ * isn't. Two Thai (or Devanagari, or Hebrew) slugs Byline intended as
+ * distinct documents would silently collide as one path on MySQL only.
+ * Ruling: pin `utf8mb4_bin` so the two adapters agree exactly. This is
+ * `path` only — the store *value* columns keep the database's default
+ * `ai_ci` collation; the resulting accent-insensitive `LIKE` divergence
+ * there was elected deliberately by the plan and stands.
+ */
+export const varcharCaseSensitive = customType<{
+  data: string
+  driverData: string
+  config: { length: number }
+}>({
+  dataType: (config) => {
+    const len = config?.length ?? 255
+    return `varchar(${len}) COLLATE utf8mb4_bin`
+  },
+})
+
+/**
  * Audit-timestamp column shape used across every Byline table.
  * `DATETIME(3)` — millisecond precision; stored and read as UTC by
  * convention (the mysql2 pool is opened with `timezone: 'Z'` so values

--- a/packages/db-mysql/src/database/schema/common.ts
+++ b/packages/db-mysql/src/database/schema/common.ts
@@ -1,0 +1,92 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import { sql } from 'drizzle-orm'
+import { customType, datetime } from 'drizzle-orm/mysql-core'
+
+/**
+ * `CHAR(36) CHARACTER SET ascii COLLATE ascii_bin` — canonical UUID text.
+ *
+ * Every id / FK column in the schema uses this type. `ascii_bin` is a
+ * byte-wise (case-sensitive) collation, so id equality comparisons and
+ * joins compare bytes rather than applying a case- or accent-insensitive
+ * collation — the MySQL analogue of comparing `uuid` values in Postgres,
+ * which has no notion of collation for that type at all. UUIDs are
+ * app-generated UUIDv7 (the `uuid` package's `v7()`), never DB-generated.
+ */
+export const uuidChar = customType<{ data: string; driverData: string }>({
+  dataType: () => 'char(36) CHARACTER SET ascii COLLATE ascii_bin',
+})
+
+/**
+ * `varchar(...)` with explicit byte-wise (`ascii_bin`) collation.
+ *
+ * Used for `byline_documents.order_key` (and `byline_document_relationships
+ * .order_key`) so the column sorts the same way JavaScript string
+ * comparison does. The fractional-index algorithm in `@byline/core`
+ * (`generateKeyBetween`, `generateNKeysBetween`) is designed against
+ * byte-wise ordering; MySQL's default collation (`utf8mb4_0900_ai_ci` on
+ * this database) is accent- and case-insensitive and disagrees with JS on
+ * cases like `'Zz' vs 'a0'` — which causes a refetch after a drag-reorder
+ * to "snap" the moved row back to its original position. Mirrors the
+ * Postgres adapter's `varcharByteSorted` (`COLLATE "C"`); see
+ * `packages/db-postgres/src/database/schema/index.ts`.
+ */
+export const varcharByteSorted = customType<{
+  data: string
+  driverData: string
+  config: { length: number }
+}>({
+  dataType: (config) => {
+    const len = config?.length ?? 255
+    return `varchar(${len}) CHARACTER SET ascii COLLATE ascii_bin`
+  },
+})
+
+/**
+ * Audit-timestamp column shape used across every Byline table.
+ * `DATETIME(3)` — millisecond precision; stored and read as UTC by
+ * convention (the mysql2 pool is opened with `timezone: 'Z'` so values
+ * round-trip without local-timezone reinterpretation). MySQL's `DATETIME`
+ * has no timezone-aware storage the way Postgres's `TIMESTAMPTZ` does, so
+ * the UTC discipline is enforced entirely at the connection layer rather
+ * than the column type.
+ *
+ * Defined once here so adding a new column to every table — or changing
+ * the precision across the schema — is a one-line edit.
+ */
+const auditTimestamp = (name: string) =>
+  datetime(name, { fsp: 3 }).notNull().default(sql`CURRENT_TIMESTAMP(3)`)
+
+/**
+ * Both `created_at` and `updated_at` for tables whose rows are
+ * mutated in place (most application tables — users, roles, documents,
+ * store rows, paths).
+ *
+ * Spread into a `mysqlTable` definition:
+ *
+ *   mysqlTable('byline_admin_users', {
+ *     id: uuidChar('id').primaryKey(),
+ *     ...timestamps,
+ *   })
+ */
+export const timestamps = {
+  created_at: auditTimestamp('created_at'),
+  updated_at: auditTimestamp('updated_at'),
+}
+
+/**
+ * `created_at` only — for tables whose rows are immutable once
+ * inserted (junction tables like `byline_admin_role_admin_user`,
+ * registry rows like `byline_counter_groups`).
+ *
+ * Spread into a `mysqlTable` definition the same way as `timestamps`.
+ */
+export const createdAt = {
+  created_at: auditTimestamp('created_at'),
+}

--- a/packages/db-mysql/src/database/schema/index.ts
+++ b/packages/db-mysql/src/database/schema/index.ts
@@ -27,7 +27,13 @@ import {
   varchar,
 } from 'drizzle-orm/mysql-core'
 
-import { createdAt, timestamps, uuidChar, varcharByteSorted } from './common.js'
+import {
+  createdAt,
+  timestamps,
+  uuidChar,
+  varcharByteSorted,
+  varcharCaseSensitive,
+} from './common.js'
 
 // Every foreign key below is declared with the table-level `foreignKey()`
 // builder and an explicit, short `fk_<table>_<column>` name, rather than
@@ -179,7 +185,10 @@ export const documentPaths = mysqlTable(
     document_id: uuidChar('document_id').notNull(),
     locale: varchar('locale', { length: 10 }).notNull(),
     collection_id: uuidChar('collection_id').notNull(),
-    path: varchar('path', { length: 255 }).notNull(),
+    // `utf8mb4_bin`, not the database default — see `varcharCaseSensitive`
+    // in `./common.ts` for why (case AND accent sensitivity, verified
+    // against live Thai/Devanagari/Hebrew slugs, not just Latin parity).
+    path: varcharCaseSensitive('path', { length: 255 }).notNull(),
     ...timestamps,
   },
   (table) => [
@@ -575,7 +584,16 @@ export const datetimeStore = mysqlTable(
     date_type: varchar('date_type', { length: 20 }).notNull(), // 'date', 'time', 'timestamptz'
 
     value_date: date('value_date'),
-    value_time: time('value_time'),
+    // fsp 3, matching the fsp discipline used everywhere else in this
+    // schema (spec §2). Without an explicit fsp, MySQL's `TIME` defaults
+    // to whole-second precision, silently truncating a fractional time
+    // value that round-trips fine on Postgres — whose `time` column (also
+    // declared with no explicit precision) defaults to microsecond
+    // precision instead. `time` is a real Byline field type
+    // (`packages/core/src/storage/field-store-map.ts`), so this isn't a
+    // hypothetical: a document with a fractional-second time value would
+    // read back truncated after a write, MySQL-only.
+    value_time: time('value_time', { fsp: 3 }),
     // Postgres `timestamptz` → `datetime(3)` (spec §2). UTC by convention —
     // see `common.ts`'s `auditTimestamp` doc comment.
     value_timestamp_tz: datetime('value_timestamp_tz', { fsp: 3 }),

--- a/packages/db-mysql/src/database/schema/index.ts
+++ b/packages/db-mysql/src/database/schema/index.ts
@@ -1,0 +1,1042 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import { eq, relations, sql } from 'drizzle-orm'
+import {
+  bigint,
+  boolean,
+  date,
+  datetime,
+  decimal,
+  float,
+  foreignKey,
+  index,
+  int,
+  json,
+  mysqlTable,
+  mysqlView,
+  primaryKey,
+  text,
+  time,
+  unique,
+  varchar,
+} from 'drizzle-orm/mysql-core'
+
+import { createdAt, timestamps, uuidChar, varcharByteSorted } from './common.js'
+
+// Every foreign key below is declared with the table-level `foreignKey()`
+// builder and an explicit, short `fk_<table>_<column>` name, rather than
+// the column-level `.references()` shorthand the Postgres schema uses.
+// This is a real dialect difference, not a style choice: MySQL enforces a
+// hard 64-character identifier cap (`ER_TOO_LONG_IDENT`) on every
+// constraint name, including auto-generated ones, whereas Postgres's
+// 63-byte `NAMEDATALEN` limit is enforced by silent truncation. Byline's
+// table/column names are long and descriptive enough (e.g.
+// `byline_document_version_locales` + `document_version_id` +
+// `byline_document_versions` + `id`) that drizzle-kit's auto-generated
+// `<table>_<column>_<foreignTable>_<foreignColumn>_fk` name exceeds 64
+// characters for roughly half the foreign keys in this schema — silently
+// on Postgres, but as a hard migration failure on MySQL. Explicit naming
+// throughout (not just for the offenders) keeps the convention uniform and
+// keeps a future column rename from reintroducing the failure.
+
+// Collections table
+export const collections = mysqlTable('byline_collections', {
+  id: uuidChar('id').primaryKey(),
+  path: varchar('path', { length: 255 }).unique().notNull(),
+  singular: text('singular').notNull(), // Singular label for the collection
+  plural: text('plural').notNull(), // Plural label for the collection
+  config: json('config').notNull(), // Store CollectionConfig
+  // Monotonically-increasing schema version. Incremented by the startup
+  // bootstrap whenever `schema_hash` changes (or to a value pinned
+  // explicitly via `CollectionDefinition.version`).
+  version: int('version').notNull().default(1),
+  // SHA-256 fingerprint of the data-shape-relevant portion of the
+  // collection's definition. Nullable in Phase 1 — populated on first
+  // `ensureCollections()` run post-migration, tightens to NOT NULL when
+  // the `collection_versions` history table lands.
+  schema_hash: varchar('schema_hash', { length: 64 }),
+  ...timestamps,
+})
+
+// Documents table
+export const documents = mysqlTable(
+  'byline_documents',
+  {
+    id: uuidChar('id').primaryKey(),
+    collection_id: uuidChar('collection_id').notNull(),
+    // Fractional-index sort key for collections with `orderable: true` in
+    // their admin config. Null on collections that haven't opted in, and on
+    // pre-existing rows in newly-`orderable` collections (sort NULLS LAST).
+    // Admin metadata — never per-version, never EAV; updated by the reorder
+    // server fn without bumping documentVersions.
+    //
+    // Uses `varcharByteSorted` (`ascii_bin`) so DB ordering matches JS string
+    // comparison — the fractional-index algorithm requires this. See
+    // `varcharByteSorted` in `./common.ts` and docs/04-collections/index.md (Orderable collections).
+    order_key: varcharByteSorted('order_key', { length: 128 }),
+    // The content locale this document was first authored in — its per-document
+    // data anchor. Set once at creation (= the global default content locale at
+    // that moment) and immutable in normal operation; changed only by the
+    // deliberate re-anchor operation. Re-bases the fallback floor, the path
+    // locale, and the completeness ledger off the mutable global config onto
+    // the document's own truth, so switching `i18n.content.defaultLocale` no
+    // longer silently re-interprets existing data. Backfilled by
+    // `backfillSourceLocales()` (boot-auto via initBylineCore).
+    //
+    source_locale: varchar('source_locale', { length: 10 }).notNull(),
+    ...timestamps,
+  },
+  (table) => [
+    foreignKey({
+      name: 'fk_documents_collection_id',
+      columns: [table.collection_id],
+      foreignColumns: [collections.id],
+    }).onDelete('cascade'),
+    index('idx_documents_collection').on(table.collection_id),
+    index('idx_documents_collection_order').on(table.collection_id, table.order_key),
+  ]
+)
+
+// Document versions table
+export const documentVersions = mysqlTable(
+  'byline_document_versions',
+  {
+    id: uuidChar('id').primaryKey(), // UUIDv7 versioning by default
+    document_id: uuidChar('document_id').notNull(),
+    collection_id: uuidChar('collection_id').notNull(),
+    // Collection schema version this row was authored against. Used by
+    // future in-memory migration code to resolve historical document
+    // shapes. Phase 1 records the number; no composite FK yet — that
+    // anchors in Phase 2 alongside the history table.
+    collection_version: int('collection_version').notNull(),
+    doc: json('doc'), // optionally store the original document
+    event_type: varchar('event_type', { length: 20 }).notNull().default('create'), // 'create', 'update', 'delete'
+    status: varchar('status', { length: 50 }).default('draft'),
+    is_deleted: boolean('is_deleted').default(false), // Tombstone for soft deletes
+    ...timestamps,
+    created_by: uuidChar('created_by'),
+    change_summary: text('change_summary'),
+  },
+  (table) => [
+    foreignKey({
+      name: 'fk_document_versions_document_id',
+      columns: [table.document_id],
+      foreignColumns: [documents.id],
+    }).onDelete('cascade'),
+    foreignKey({
+      name: 'fk_document_versions_collection_id',
+      columns: [table.collection_id],
+      foreignColumns: [collections.id],
+    }).onDelete('cascade'),
+    // Index for finding all versions of a logical document
+    index('idx_documents_document_id').on(table.document_id),
+    // Index for current document lookup by logical document ID
+    index('idx_documents_collection_document_deleted').on(
+      table.collection_id,
+      table.document_id,
+      table.is_deleted
+    ),
+    // Index to optimize the current documents view
+    index('idx_documents_current_view').on(
+      table.collection_id,
+      table.document_id,
+      table.is_deleted,
+      table.id
+    ),
+    // Event and audit indexes
+    index('idx_documents_event_type').on(table.event_type),
+    index('idx_documents_created_at').on(table.created_at),
+    // Ensure logical document belongs to only one collection
+    index('idx_documents_document_collection').on(table.document_id, table.collection_id),
+  ]
+)
+
+// Document paths — one row per (logical document, content locale).
+// Promotes `path` out of the version row so per-collection uniqueness can
+// be enforced at the DB layer without colliding with the sticky
+// carry-forward of path across versions. Phase 1 only ever writes the
+// installation's default content locale; per-locale UI is a future phase
+// that adds rows for additional locales without reshaping the schema.
+// History is intentionally not preserved here — path rows are updated in
+// place. See `docs/04-collections/05-document-paths.md` § "Path uniqueness".
+//
+// The `idx_document_paths_collection_locale_path` name below is
+// load-bearing beyond this file: `classifyError` reports MySQL's
+// duplicate-key error against the *index* name (unlike Postgres, which
+// reports the constraint name), and
+// `packages/core/src/services/document-lifecycle/internals.ts`
+// substring-matches this exact string to detect a path collision. Do not
+// rename it.
+export const documentPaths = mysqlTable(
+  'byline_document_paths',
+  {
+    document_id: uuidChar('document_id').notNull(),
+    locale: varchar('locale', { length: 10 }).notNull(),
+    collection_id: uuidChar('collection_id').notNull(),
+    path: varchar('path', { length: 255 }).notNull(),
+    ...timestamps,
+  },
+  (table) => [
+    foreignKey({
+      name: 'fk_document_paths_document_id',
+      columns: [table.document_id],
+      foreignColumns: [documents.id],
+    }).onDelete('cascade'),
+    foreignKey({
+      name: 'fk_document_paths_collection_id',
+      columns: [table.collection_id],
+      foreignColumns: [collections.id],
+    }).onDelete('cascade'),
+    // One path per (logical document, locale).
+    unique('unique_document_paths_document_locale').on(table.document_id, table.locale),
+    // Per-collection per-locale path uniqueness. Column order matches the
+    // resolution lookup pattern: WHERE collection_id = ? AND locale = ? AND path = ?.
+    unique('idx_document_paths_collection_locale_path').on(
+      table.collection_id,
+      table.locale,
+      table.path
+    ),
+    // Reverse lookup by document.
+    index('idx_document_paths_document_id').on(table.document_id),
+  ]
+)
+
+// Document → advertised content locales. One row per (logical document,
+// advertised locale) — the editorial "advertise these locales" set an editor
+// curates per document. The deliberate counterpart to the derived,
+// version-grained `byline_document_version_locales` ledger: this is intent
+// ("I want these advertised"), the ledger is fact ("this version is complete
+// in these"). Document-grain and sticky across versions — editorial intent
+// carries forward across edits and survives restore. Surfaced on reads as
+// `availableLocales`; the public advertised set is the intersection with the
+// ledger's `_availableVersionLocales`. Replaced wholesale on write (the lifecycle
+// deletes then re-inserts the set), never appended. See docs/07-internationalization/index.md.
+export const documentAvailableLocales = mysqlTable(
+  'byline_document_available_locales',
+  {
+    document_id: uuidChar('document_id').notNull(),
+    locale: varchar('locale', { length: 10 }).notNull(),
+    collection_id: uuidChar('collection_id').notNull(),
+    ...timestamps,
+  },
+  (table) => [
+    foreignKey({
+      name: 'fk_document_available_locales_document_id',
+      columns: [table.document_id],
+      foreignColumns: [documents.id],
+    }).onDelete('cascade'),
+    foreignKey({
+      name: 'fk_document_available_locales_collection_id',
+      columns: [table.collection_id],
+      foreignColumns: [collections.id],
+    }).onDelete('cascade'),
+    // One row per (logical document, advertised locale).
+    primaryKey({ columns: [table.document_id, table.locale] }),
+    // Reverse lookup by document for the read projection.
+    index('idx_document_available_locales_document_id').on(table.document_id),
+  ]
+)
+
+// Document version → available content locales. One row per (version, locale)
+// for every locale the version's content is *complete* in — path-coverage
+// against the default content locale: a locale is recorded only when it covers
+// every localized field path the default locale has. A version with no
+// localized content at all gets a single `'all'` sentinel row (it renders
+// identically in any locale). Computed status-blind at write time and frozen
+// on the immutable version, so restore / point-in-time reads stay consistent.
+// Drives `localeFallback: 'strict'` reads via an indexed EXISTS gate without
+// scanning the store_* tables. See docs/07-internationalization/index.md.
+export const documentVersionLocales = mysqlTable(
+  'byline_document_version_locales',
+  {
+    document_version_id: uuidChar('document_version_id').notNull(),
+    locale: varchar('locale', { length: 10 }).notNull(),
+  },
+  (table) => [
+    foreignKey({
+      name: 'fk_document_version_locales_document_version_id',
+      columns: [table.document_version_id],
+      foreignColumns: [documentVersions.id],
+    }).onDelete('cascade'),
+    primaryKey({ columns: [table.document_version_id, table.locale] }),
+  ]
+)
+
+// Document Tree — single-parent ordered adjacency. See docs/04-collections/04-document-trees.md.
+//
+// A document-grain, unversioned hierarchy primitive for `tree: true`
+// collections (self-referential, single collection). Rows reference the logical
+// `document_id`, not the version `id`. Unlike most edge tables the FKs are
+// load-bearing here:
+//   - child  → cascade : when the document is deleted, its membership row
+//                        disappears (the node leaves the tree).
+//   - parent → set null: when a parent document is deleted, its children's
+//                        parent pointer clears — they promote to root.
+export const documentRelationships = mysqlTable(
+  'byline_document_relationships',
+  {
+    child_document_id: uuidChar('child_document_id').notNull(),
+    // Nullable = root node. `set null` promotes orphans to root on parent delete.
+    parent_document_id: uuidChar('parent_document_id'),
+    // Per-parent sibling order (each parent is its own keyspace). ascii_bin
+    // so DB ordering matches the JS fractional-index algorithm, exactly like
+    // `byline_documents.order_key`.
+    order_key: varcharByteSorted('order_key', { length: 128 }).notNull(),
+    ...timestamps,
+  },
+  (table) => [
+    foreignKey({
+      name: 'fk_document_relationships_child_document_id',
+      columns: [table.child_document_id],
+      foreignColumns: [documents.id],
+    }).onDelete('cascade'),
+    foreignKey({
+      name: 'fk_document_relationships_parent_document_id',
+      columns: [table.parent_document_id],
+      foreignColumns: [documents.id],
+    }).onDelete('set null'),
+    // Single-parent invariant: each document appears in at most one row.
+    unique('uq_document_relationships_child').on(table.child_document_id),
+    // Per-parent sibling read, in order — drives the authoring tree and the
+    // read-side flatten.
+    index('idx_document_relationships_parent_order').on(table.parent_document_id, table.order_key),
+  ]
+)
+
+// Current Documents View — latest version of each logical document via
+// `ROW_NUMBER() OVER (PARTITION BY document_id ORDER BY id DESC)`.
+//
+// MySQL forbade subqueries in a view's FROM clause until 8.0.14 — the same
+// release that added LATERAL — which is the real reason this adapter's
+// engine floor is 8.0.14 (see `src/lib/boot-check.ts`). Ported here with
+// the same CTE-backed shape as the Postgres view.
+//
+// `path` is intentionally NOT projected here. Path resolution is locale-
+// aware and lives in the storage adapter's read functions, which join
+// `byline_document_paths` with the requested locale + default-locale
+// fallback. See docs/04-collections/05-document-paths.md.
+export const currentDocumentsView = mysqlView('byline_current_documents').as((qb) => {
+  const sq = qb.$with('sq').as(
+    qb
+      .select({
+        id: documentVersions.id,
+        document_id: documentVersions.document_id,
+        collection_id: documentVersions.collection_id,
+        collection_version: documentVersions.collection_version,
+        event_type: documentVersions.event_type,
+        status: documentVersions.status,
+        is_deleted: documentVersions.is_deleted,
+        created_at: documentVersions.created_at,
+        updated_at: documentVersions.updated_at,
+        created_by: documentVersions.created_by,
+        change_summary: documentVersions.change_summary,
+        rn: sql<number>`row_number() OVER (PARTITION BY ${documentVersions.document_id} ORDER BY ${documentVersions.id} DESC)`.as(
+          'rn'
+        ),
+      })
+      .from(documentVersions)
+      .where(eq(documentVersions.is_deleted, false))
+  )
+  // `order_key` is sourced from `byline_documents` (the logical-document
+  // row, not the version row). Joining it through the view keeps
+  // `d.order_key` addressable in findDocuments' ORDER BY without an
+  // ad-hoc join per query. Always nullable; null sorts last for
+  // collections that haven't opted in to `orderable: true`.
+  return qb
+    .with(sq)
+    .select({
+      id: sq.id,
+      document_id: sq.document_id,
+      collection_id: sq.collection_id,
+      collection_version: sq.collection_version,
+      event_type: sq.event_type,
+      status: sq.status,
+      is_deleted: sq.is_deleted,
+      created_at: sq.created_at,
+      updated_at: sq.updated_at,
+      created_by: sq.created_by,
+      change_summary: sq.change_summary,
+      order_key: documents.order_key,
+      // The document's content-locale anchor, projected here so locale-aware
+      // read paths (`buildLocaleChain` / `pathProjection` / field-fallback)
+      // re-base onto the per-document source rather than the mutable global
+      // default — a primary-key join, already present for `order_key`.
+      // See docs/07-internationalization/index.md.
+      source_locale: documents.source_locale,
+    })
+    .from(sq)
+    .innerJoin(documents, eq(documents.id, sq.document_id))
+    .where(eq(sq.rn, 1))
+})
+
+// Current Published Documents View - gets the latest version of each logical
+// document whose status is 'published', regardless of whether a newer draft
+// version exists. Used by `readMode: 'published'` on reads so public
+// consumers keep seeing the last published content while editors work on
+// drafts. Row-wise shape is identical to `current_documents`.
+export const currentPublishedDocumentsView = mysqlView('byline_current_published_documents').as(
+  (qb) => {
+    const sq = qb.$with('sq').as(
+      qb
+        .select({
+          id: documentVersions.id,
+          document_id: documentVersions.document_id,
+          collection_id: documentVersions.collection_id,
+          collection_version: documentVersions.collection_version,
+          event_type: documentVersions.event_type,
+          status: documentVersions.status,
+          is_deleted: documentVersions.is_deleted,
+          created_at: documentVersions.created_at,
+          updated_at: documentVersions.updated_at,
+          created_by: documentVersions.created_by,
+          change_summary: documentVersions.change_summary,
+          rn: sql<number>`row_number() OVER (PARTITION BY ${documentVersions.document_id} ORDER BY ${documentVersions.id} DESC)`.as(
+            'rn'
+          ),
+        })
+        .from(documentVersions)
+        .where(
+          sql`${documentVersions.is_deleted} = false AND ${documentVersions.status} = 'published'`
+        )
+    )
+    return qb
+      .with(sq)
+      .select({
+        id: sq.id,
+        document_id: sq.document_id,
+        collection_id: sq.collection_id,
+        collection_version: sq.collection_version,
+        event_type: sq.event_type,
+        status: sq.status,
+        is_deleted: sq.is_deleted,
+        created_at: sq.created_at,
+        updated_at: sq.updated_at,
+        created_by: sq.created_by,
+        change_summary: sq.change_summary,
+        order_key: documents.order_key,
+        // See `currentDocumentsView` — the per-document content-locale anchor,
+        // carried for locale-aware reads. PK join, already present.
+        source_locale: documents.source_locale,
+      })
+      .from(sq)
+      .innerJoin(documents, eq(documents.id, sq.document_id))
+      .where(eq(sq.rn, 1))
+  }
+)
+
+// Base field values structure
+const baseStoreColumns = {
+  id: uuidChar('id').primaryKey(),
+  document_version_id: uuidChar('document_version_id').notNull(), // References the version ID
+  collection_id: uuidChar('collection_id').notNull(), // For cross-collection queries
+  // Kept at 500, matching the Postgres schema's `field_path` bound exactly
+  // (`packages/db-postgres/src/database/schema/index.ts`) — an earlier
+  // version of this file widened it to 512, but that was a mistake: it
+  // both broke parity with pg for no reason and left `parent_path` (below,
+  // a prefix of `field_path`) too narrow to hold a maximal `field_path`
+  // value, which would raise `ER_DATA_TOO_LONG` under strict mode on
+  // MySQL — a state unreachable on the pg adapter. The store tables'
+  // tightest unique key — (document_version_id, field_path, locale) — is
+  // 2076 bytes under InnoDB's 3072-byte DYNAMIC index-key cap: 36
+  // (char(36) ascii) + 2000 (varchar(500) utf8mb4) + 40 (varchar(10)
+  // utf8mb4). `idx_text_path_value` (field_path + a 191-char prefix of
+  // `value`) is the tightest *non-unique* index on this table at 2764
+  // bytes. See `schema-pins.test.node.ts`, which pins both.
+  field_path: varchar('field_path', { length: 500 }).notNull(),
+  field_name: varchar('field_name', { length: 255 }).notNull(),
+  locale: varchar('locale', { length: 10 }).notNull().default('default'),
+  parent_path: varchar('parent_path', { length: 500 }),
+  ...timestamps,
+}
+
+// 1. TEXT FIELDS TABLE
+export const textStore = mysqlTable(
+  'byline_store_text',
+  {
+    ...baseStoreColumns,
+
+    value: text('value').notNull(),
+    word_count: int('word_count'), // Pre-computed for analytics
+  },
+  (table) => [
+    foreignKey({
+      name: 'fk_store_text_document_version_id',
+      columns: [table.document_version_id],
+      foreignColumns: [documentVersions.id],
+    }).onDelete('cascade'),
+    foreignKey({
+      name: 'fk_store_text_collection_id',
+      columns: [table.collection_id],
+      foreignColumns: [collections.id],
+    }).onDelete('cascade'),
+    // Optimized indexes for text operations. MySQL requires an explicit
+    // key-length prefix to index a TEXT column (error 1170 otherwise) —
+    // 191 is the conventional MySQL prefix length (the largest that stays
+    // under the historical 767-byte REDUNDANT/COMPACT index-key limit at
+    // 4 bytes/char for utf8mb4: 767 / 4 ≈ 191), kept here even though this
+    // schema's DYNAMIC row format has more headroom, for portability.
+    index('idx_text_value').on(sql`${table.value}(191)`),
+    // Dropped: Postgres's GIN index over `to_tsvector('english', value)`
+    // has no MySQL equivalent through this schema layer (MySQL's own
+    // full-text index type is not exposed by drizzle-kit's mysql-core index
+    // builder, which only supports 'btree' | 'hash'). Not load-bearing —
+    // no query code references this index name — and Byline's actual
+    // full-text search is a separate, pluggable `SearchProvider` seam
+    // (`@byline/core`), not built on this table's indexes. See
+    // docs/05-reading-and-delivery/07-search.md.
+    index('idx_text_locale_value').on(table.locale, sql`${table.value}(191)`),
+    index('idx_text_path_value').on(table.field_path, sql`${table.value}(191)`),
+    // Unique constraints for unique fields
+    unique('unique_text_field').on(table.document_version_id, table.field_path, table.locale),
+  ]
+)
+
+// 2. NUMERIC FIELDS TABLE
+export const numericStore = mysqlTable(
+  'byline_store_numeric',
+  {
+    ...baseStoreColumns,
+
+    // Store the original number type for reconstruction
+    number_type: varchar('number_type', { length: 20 }).notNull(), // 'integer', 'decimal', 'float'
+
+    value_integer: int('value_integer'),
+    value_decimal: decimal('value_decimal', { precision: 10, scale: 2 }),
+    // Postgres `real` (single-precision float) → MySQL `FLOAT` (also
+    // single-precision). MySQL's `REAL` is a configurable alias for
+    // `DOUBLE` unless the server runs with `REAL_AS_FLOAT`, so `float()` is
+    // the unambiguous match rather than the `real()` name.
+    value_float: float('value_float'),
+  },
+  (table) => [
+    foreignKey({
+      name: 'fk_store_numeric_document_version_id',
+      columns: [table.document_version_id],
+      foreignColumns: [documentVersions.id],
+    }).onDelete('cascade'),
+    foreignKey({
+      name: 'fk_store_numeric_collection_id',
+      columns: [table.collection_id],
+      foreignColumns: [collections.id],
+    }).onDelete('cascade'),
+    // Optimized indexes for numeric operations
+    index('idx_numeric_integer').on(table.value_integer),
+    index('idx_numeric_decimal').on(table.value_decimal),
+    index('idx_numeric_float').on(table.value_float),
+
+    // Range indexes for common queries
+    index('idx_numeric_integer_range').on(table.field_path, table.value_integer),
+    index('idx_numeric_decimal_range').on(table.field_path, table.value_decimal),
+
+    unique('unique_numeric_field').on(table.document_version_id, table.field_path, table.locale),
+  ]
+)
+
+// 3. BOOLEAN FIELDS TABLE
+export const booleanStore = mysqlTable(
+  'byline_store_boolean',
+  {
+    ...baseStoreColumns,
+
+    value: boolean('value').notNull(),
+  },
+  (table) => [
+    foreignKey({
+      name: 'fk_store_boolean_document_version_id',
+      columns: [table.document_version_id],
+      foreignColumns: [documentVersions.id],
+    }).onDelete('cascade'),
+    foreignKey({
+      name: 'fk_store_boolean_collection_id',
+      columns: [table.collection_id],
+      foreignColumns: [collections.id],
+    }).onDelete('cascade'),
+    // Simple but effective indexes for boolean queries
+    index('idx_boolean_value').on(table.value),
+    index('idx_boolean_path_value').on(table.field_path, table.value),
+    index('idx_boolean_collection_value').on(table.collection_id, table.field_path, table.value),
+    unique('unique_boolean_field').on(table.document_version_id, table.field_path, table.locale),
+  ]
+)
+
+// 4. DATE/TIME FIELDS TABLE
+export const datetimeStore = mysqlTable(
+  'byline_store_datetime',
+  {
+    ...baseStoreColumns,
+
+    // Store the original date type for reconstruction
+    date_type: varchar('date_type', { length: 20 }).notNull(), // 'date', 'time', 'timestamptz'
+
+    value_date: date('value_date'),
+    value_time: time('value_time'),
+    // Postgres `timestamptz` → `datetime(3)` (spec §2). UTC by convention —
+    // see `common.ts`'s `auditTimestamp` doc comment.
+    value_timestamp_tz: datetime('value_timestamp_tz', { fsp: 3 }),
+  },
+  (table) => [
+    foreignKey({
+      name: 'fk_store_datetime_document_version_id',
+      columns: [table.document_version_id],
+      foreignColumns: [documentVersions.id],
+    }).onDelete('cascade'),
+    foreignKey({
+      name: 'fk_store_datetime_collection_id',
+      columns: [table.collection_id],
+      foreignColumns: [collections.id],
+    }).onDelete('cascade'),
+    // Optimized for date range queries
+    index('idx_datetime_date').on(table.value_date),
+    index('idx_datetime_timestamp_tz').on(table.value_timestamp_tz),
+    // Common date query patterns
+    index('idx_datetime_path_date').on(table.field_path, table.value_timestamp_tz),
+    index('idx_datetime_collection_date').on(table.collection_id, table.value_timestamp_tz),
+    unique('unique_datetime_field').on(table.document_version_id, table.field_path, table.locale),
+  ]
+)
+
+// 5. RELATION FIELDS TABLE
+export const relationStore = mysqlTable(
+  'byline_store_relation',
+  {
+    ...baseStoreColumns,
+
+    target_document_id: uuidChar('target_document_id').notNull(),
+
+    target_collection_id: uuidChar('target_collection_id').notNull(),
+
+    // Relationship metadata
+    relationship_type: varchar('relationship_type', { length: 50 }).default('reference'), // 'reference', 'embed', 'weak'
+    cascade_delete: boolean('cascade_delete').default(false),
+  },
+  (table) => [
+    foreignKey({
+      name: 'fk_store_relation_document_version_id',
+      columns: [table.document_version_id],
+      foreignColumns: [documentVersions.id],
+    }).onDelete('cascade'),
+    foreignKey({
+      name: 'fk_store_relation_collection_id',
+      columns: [table.collection_id],
+      foreignColumns: [collections.id],
+    }).onDelete('cascade'),
+    // No onDelete — matches the Postgres schema's `.references(() =>
+    // documents.id)` / `.references(() => collections.id)` without an
+    // onDelete option, which defaults to NO ACTION on both dialects.
+    foreignKey({
+      name: 'fk_store_relation_target_document_id',
+      columns: [table.target_document_id],
+      foreignColumns: [documents.id],
+    }),
+    foreignKey({
+      name: 'fk_store_relation_target_collection_id',
+      columns: [table.target_collection_id],
+      foreignColumns: [collections.id],
+    }),
+    // Critical indexes for relationship queries
+    index('idx_relation_target_document').on(table.target_document_id),
+    index('idx_relation_target_collection').on(table.target_collection_id),
+    index('idx_relation_type').on(table.relationship_type),
+
+    // Reverse relationship lookup
+    index('idx_relation_reverse').on(table.target_document_id, table.field_path),
+
+    // Cross-collection relationship queries
+    index('idx_relation_collection_to_collection').on(
+      table.collection_id,
+      table.target_collection_id
+    ),
+
+    unique('unique_relation_field').on(table.document_version_id, table.field_path, table.locale),
+  ]
+)
+
+// Generic meta store for document nodes (blocks, array items, fields, etc.)
+// This allows attaching durable IDs and arbitrary metadata to any node
+// in a document tree, keyed by document version and path.
+export const metaStore = mysqlTable(
+  'byline_store_meta',
+  {
+    id: uuidChar('id').primaryKey(),
+    document_version_id: uuidChar('document_version_id').notNull(),
+    collection_id: uuidChar('collection_id').notNull(),
+
+    // Node classification and linkage back into the reconstructed tree.
+    // Bounded (Postgres uses unbounded `text`) because MySQL cannot index
+    // an unbounded TEXT/BLOB column without an explicit key-length prefix,
+    // and both columns below participate in `unique_meta_node`. 50/512
+    // keep the tightest key on this table — 36 (id, ascii) + 200 (type,
+    // utf8mb4) + 2048 (path, utf8mb4) = 2284 bytes — comfortably under the
+    // 3072-byte InnoDB cap; see `schema-pins.test.node.ts`.
+    type: varchar('type', { length: 50 }).notNull(),
+    path: varchar('path', { length: 512 }).notNull(),
+
+    // Durable identifier for this item within a document version. This is the
+    // ID exposed to the dashboard/API for blocks, array items, etc.
+    item_id: varchar('item_id', { length: 255 }).notNull(),
+
+    // Optional opaque metadata payload for this node. Common attributes like
+    // label, icon, collapsed state, etc. can be stored here.
+    meta: json('meta'),
+
+    ...timestamps,
+  },
+  (table) => [
+    foreignKey({
+      name: 'fk_store_meta_document_version_id',
+      columns: [table.document_version_id],
+      foreignColumns: [documentVersions.id],
+    }).onDelete('cascade'),
+    foreignKey({
+      name: 'fk_store_meta_collection_id',
+      columns: [table.collection_id],
+      foreignColumns: [collections.id],
+    }).onDelete('cascade'),
+    // Fast lookup by document and node type/path when enriching reconstructed
+    // trees with meta information.
+    index('idx_meta_document_type_path').on(table.document_version_id, table.type, table.path),
+    // Resolve durable IDs (e.g. for array.move by item_id) back to a node path.
+    index('idx_meta_item_id').on(table.item_id),
+    // Support queries scoped by collection and type (e.g. all blocks in a collection).
+    index('idx_meta_collection_type').on(table.collection_id, table.type),
+    // Ensure only a single meta row exists for a given node in a document version.
+    unique('unique_meta_node').on(table.document_version_id, table.type, table.path),
+  ]
+)
+
+// 6. FILE FIELDS TABLE (Your composite type example)
+export const fileStore = mysqlTable(
+  'byline_store_file',
+  {
+    ...baseStoreColumns,
+
+    // File identity
+    file_id: uuidChar('file_id').notNull(), // Reference to file storage system
+    filename: varchar('filename', { length: 255 }).notNull(),
+    original_filename: varchar('original_filename', { length: 255 }).notNull(),
+
+    // File metadata
+    mime_type: varchar('mime_type', { length: 100 }).notNull(),
+    file_size: bigint('file_size', { mode: 'number' }).notNull(), // Size in bytes
+    file_hash: varchar('file_hash', { length: 64 }), // SHA-256 hash for deduplication
+
+    // Storage information
+    storage_provider: varchar('storage_provider', { length: 50 }).notNull(), // 'local', 's3', 'gcs', etc.
+    storage_path: text('storage_path').notNull(),
+    storage_url: text('storage_url'), // CDN or direct URL
+
+    // Image-specific metadata (when applicable)
+    image_width: int('image_width'),
+    image_height: int('image_height'),
+    image_format: varchar('image_format', { length: 20 }),
+
+    // File processing status
+    processing_status: varchar('processing_status', { length: 20 }).default('pending'), // 'pending', 'processing', 'completed', 'failed'
+    thumbnail_generated: boolean('thumbnail_generated').default(false),
+
+    // Image variants (Sharp-generated derivatives). Persisted as JSON so
+    // the read path can return a `<picture>` / `srcset`-ready array
+    // without a sidecar table. Shape: FileStoreVariant[] —
+    // { name, storage_path, storage_url?, width?, height?, format? }.
+    variants: json('variants'),
+  },
+  (table) => [
+    foreignKey({
+      name: 'fk_store_file_document_version_id',
+      columns: [table.document_version_id],
+      foreignColumns: [documentVersions.id],
+    }).onDelete('cascade'),
+    foreignKey({
+      name: 'fk_store_file_collection_id',
+      columns: [table.collection_id],
+      foreignColumns: [collections.id],
+    }).onDelete('cascade'),
+    // File-specific indexes
+    index('idx_file_file_id').on(table.file_id),
+    index('idx_file_mime_type').on(table.mime_type),
+    index('idx_file_size').on(table.file_size),
+    index('idx_file_hash').on(table.file_hash),
+
+    // Image queries
+    index('idx_file_image_dimensions').on(table.image_width, table.image_height),
+
+    // Storage queries
+    index('idx_file_storage_provider').on(table.storage_provider),
+    index('idx_file_processing_status').on(table.processing_status),
+
+    unique('unique_file_field').on(table.document_version_id, table.field_path, table.locale),
+  ]
+)
+
+// 7. JSON/STRUCTURED DATA FIELDS TABLE
+export const jsonStore = mysqlTable(
+  'byline_store_json',
+  {
+    ...baseStoreColumns,
+
+    value: json('value').notNull(),
+    // JSON metadata for optimization
+    json_schema: varchar('json_schema', { length: 100 }), // Schema identifier for validation
+    // Postgres `text[]` (array of top-level keys) → MySQL `json`, storing a
+    // JSON array of strings. MySQL has no native array column type.
+    object_keys: json('object_keys'),
+  },
+  (table) => [
+    foreignKey({
+      name: 'fk_store_json_document_version_id',
+      columns: [table.document_version_id],
+      foreignColumns: [documentVersions.id],
+    }).onDelete('cascade'),
+    foreignKey({
+      name: 'fk_store_json_collection_id',
+      columns: [table.collection_id],
+      foreignColumns: [collections.id],
+    }).onDelete('cascade'),
+    // Dropped: `idx_json_value_gin` (Postgres GIN over the whole `value`
+    // jsonb blob, for containment queries) and `idx_json_keys` (GIN over
+    // the `object_keys` array) have no MySQL equivalent through this schema
+    // layer — MySQL cannot index a JSON column directly; doing so requires
+    // a generated/virtual column over a specific JSON path expression,
+    // which is a different (narrower) indexing strategy than "index the
+    // whole document," not a straight port. Neither index name is
+    // referenced by any query code today.
+    index('idx_json_schema').on(table.json_schema),
+
+    unique('unique_json_field').on(table.document_version_id, table.field_path, table.locale),
+  ]
+)
+
+// ---------------------------------------------------------------------------
+// Counter groups registry
+// ---------------------------------------------------------------------------
+//
+// One row per counter `group` discovered in collection field definitions.
+// On Postgres the actual ID allocator is a SEQUENCE object (named in
+// `sequence_name`), reconciled at boot by `IDbAdapter.ensureCounterGroup`.
+// MySQL has no native user-defined SEQUENCE object (unlike Postgres, or
+// MariaDB's own extension) — the concrete allocation mechanism this column
+// backs on MySQL is a Task 11 decision, not this schema-only task's. The
+// registry table itself only records that the group exists and which
+// allocator object backs it; it is not used in the hot allocation path.
+//
+// Why a separate table rather than reading allocator objects from
+// `information_schema`: the mapping from `group_name` → allocator identity
+// belongs in the application's schema, not in MySQL metadata, so backups
+// and adapter logic have a stable name to anchor against.
+//
+// `group_name` is bounded (Postgres uses unbounded `text`) because it is
+// this table's primary key, and MySQL cannot index — including as a
+// PRIMARY KEY — an unbounded TEXT/BLOB column without an explicit
+// key-length prefix. 255 matches `byline_collections.path`'s bound, the
+// closest sibling "short identifier" column in this schema.
+export const counterGroups = mysqlTable('byline_counter_groups', {
+  group_name: varchar('group_name', { length: 255 }).primaryKey(),
+  sequence_name: text('sequence_name').notNull(),
+  ...createdAt,
+})
+
+// RELATIONS
+// =========
+
+export const collectionsRelations = relations(collections, ({ many }) => ({
+  documents: many(documentVersions),
+  text_values: many(textStore),
+  numeric_values: many(numericStore),
+  boolean_values: many(booleanStore),
+  datetime_values: many(datetimeStore),
+  relation_values: many(relationStore, { relationName: 'source_collection' }),
+  file_values: many(fileStore),
+  json_values: many(jsonStore),
+}))
+
+export const documentsRelations = relations(documentVersions, ({ one, many }) => ({
+  collection: one(collections, {
+    fields: [documentVersions.collection_id],
+    references: [collections.id],
+  }),
+  // Relations for field values
+  text_values: many(textStore),
+  numeric_values: many(numericStore),
+  boolean_values: many(booleanStore),
+  datetime_values: many(datetimeStore),
+  relation_values: many(relationStore),
+  file_values: many(fileStore),
+  json_values: many(jsonStore),
+}))
+
+export const documentRelationshipsRelations = relations(documentRelationships, ({ one }) => ({
+  parent: one(documents, {
+    fields: [documentRelationships.parent_document_id],
+    references: [documents.id],
+    relationName: 'tree_parent',
+  }),
+  child: one(documents, {
+    fields: [documentRelationships.child_document_id],
+    references: [documents.id],
+    relationName: 'tree_child',
+  }),
+}))
+
+// Document-tree edges on the logical document. The tree read path itself is a
+// recursive CTE (see docs/04-collections/04-document-trees.md), not the Drizzle query builder —
+// these relations exist for completeness / ad-hoc joins.
+export const documentTreeRelations = relations(documents, ({ many }) => ({
+  // The membership edge where this document is the child — its placement in the
+  // tree. 0..1 by the unique(child_document_id) constraint; modelled as `many`
+  // per Drizzle's inverse-side convention (the FK lives on the edge table).
+  tree_parent_edge: many(documentRelationships, { relationName: 'tree_child' }),
+  // Edges where this document is the parent — its ordered children.
+  tree_child_edges: many(documentRelationships, { relationName: 'tree_parent' }),
+}))
+
+// Field value relations
+export const textStoreRelations = relations(textStore, ({ one }) => ({
+  document: one(documentVersions, {
+    fields: [textStore.document_version_id],
+    references: [documentVersions.id],
+  }),
+  collection: one(collections, {
+    fields: [textStore.collection_id],
+    references: [collections.id],
+  }),
+}))
+
+export const numericStoreRelations = relations(numericStore, ({ one }) => ({
+  document: one(documentVersions, {
+    fields: [numericStore.document_version_id],
+    references: [documentVersions.id],
+  }),
+  collection: one(collections, {
+    fields: [numericStore.collection_id],
+    references: [collections.id],
+  }),
+}))
+
+export const booleanStoreRelations = relations(booleanStore, ({ one }) => ({
+  document: one(documentVersions, {
+    fields: [booleanStore.document_version_id],
+    references: [documentVersions.id],
+  }),
+  collection: one(collections, {
+    fields: [booleanStore.collection_id],
+    references: [collections.id],
+  }),
+}))
+
+export const datetimeStoreRelations = relations(datetimeStore, ({ one }) => ({
+  document: one(documentVersions, {
+    fields: [datetimeStore.document_version_id],
+    references: [documentVersions.id],
+  }),
+  collection: one(collections, {
+    fields: [datetimeStore.collection_id],
+    references: [collections.id],
+  }),
+}))
+
+export const relationStoreRelations = relations(relationStore, ({ one }) => ({
+  document: one(documentVersions, {
+    fields: [relationStore.document_version_id],
+    references: [documentVersions.id],
+  }),
+  collection: one(collections, {
+    fields: [relationStore.collection_id],
+    references: [collections.id],
+    relationName: 'source_collection',
+  }),
+  // This relation is now based on the logical document_id.
+  // Note: This will relate to *all* versions of the document.
+  // You will typically query against the `currentDocumentsView` to get the latest version.
+  target_document: one(documentVersions, {
+    fields: [relationStore.target_document_id],
+    references: [documentVersions.document_id],
+  }),
+  target_collection: one(collections, {
+    fields: [relationStore.target_collection_id],
+    references: [collections.id],
+  }),
+}))
+
+export const fileStoreRelations = relations(fileStore, ({ one }) => ({
+  document: one(documentVersions, {
+    fields: [fileStore.document_version_id],
+    references: [documentVersions.id],
+  }),
+  collection: one(collections, {
+    fields: [fileStore.collection_id],
+    references: [collections.id],
+  }),
+}))
+
+export const jsonStoreRelations = relations(jsonStore, ({ one }) => ({
+  document: one(documentVersions, {
+    fields: [jsonStore.document_version_id],
+    references: [documentVersions.id],
+  }),
+  collection: one(collections, {
+    fields: [jsonStore.collection_id],
+    references: [collections.id],
+  }),
+}))
+
+// ---------------------------------------------------------------------------
+// Audit log — byline_audit_log
+// ---------------------------------------------------------------------------
+
+// Document-grain audit log. Records the changes the immutable version stream
+// does NOT capture an actor for: non-versioned system-field writes (path,
+// availableLocales), in-place status transitions, and deletions — plus, later,
+// admin-module events. One generic table (nullable `document_id`, namespaced
+// `action`) so the system-wide activity report and future admin-realm auditing
+// fit without a second migration. Append-only and deliberately **FK-free**: an
+// audit row is an immutable historical fact that must outlive the document,
+// collection, or actor it references — a `document.deleted` row cannot be
+// allowed to cascade-delete itself. See docs/06-auth-and-security/02-auditability.md — Workstream 2.
+export const auditLog = mysqlTable(
+  'byline_audit_log',
+  {
+    id: uuidChar('id').primaryKey(), // UUIDv7 — time-ordered, so id ordering ≈ time ordering
+    document_id: uuidChar('document_id'), // NULL for admin-realm (non-document) events; no FK
+    collection_id: uuidChar('collection_id'), // no FK — outlives the collection
+    actor_id: uuidChar('actor_id'), // NULL = system / internal tooling / non-UUID synthetic actor
+    actor_realm: varchar('actor_realm', { length: 16 }).notNull(), // 'admin' | 'user' | 'system'
+    action: varchar('action', { length: 64 }).notNull(), // namespaced, e.g. 'document.path.changed'
+    field: varchar('field', { length: 128 }), // the changed field where meaningful (e.g. 'path'), else NULL
+    before: json('before'),
+    after: json('after'),
+    occurred_at: datetime('occurred_at', { fsp: 3 }).notNull().default(sql`CURRENT_TIMESTAMP(3)`),
+  },
+  (table) => [
+    // Per-document history, time-ordered (id is UUIDv7).
+    index('idx_audit_log_document_id').on(table.document_id, table.id),
+    // Per-actor activity — the system-wide report's actor filter.
+    index('idx_audit_log_actor_id').on(table.actor_id, table.id),
+    // Action-type filter for the activity report.
+    index('idx_audit_log_action').on(table.action, table.id),
+  ]
+)
+
+// ---------------------------------------------------------------------------
+// Auth schema — byline_admin_users, byline_admin_roles, etc.
+// See ./auth.ts for definitions and rationale.
+// ---------------------------------------------------------------------------
+
+export {
+  adminPermissions,
+  adminPermissionsRelations,
+  adminRefreshTokens,
+  adminRefreshTokensRelations,
+  adminRoleAdminUser,
+  adminRoleAdminUserRelations,
+  adminRoles,
+  adminRolesRelations,
+  adminUserPreferences,
+  adminUsers,
+  adminUsersRelations,
+} from './auth.js'

--- a/packages/db-mysql/src/database/schema/schema-pins.test.node.ts
+++ b/packages/db-mysql/src/database/schema/schema-pins.test.node.ts
@@ -1,0 +1,414 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ *
+ * Schema pins — driven entirely off the Drizzle schema objects in
+ * `./index.ts` / `./auth.ts`, not a live database. These pin the
+ * dialect-critical properties spelled out in the Task 8 controller
+ * amendments (§F):
+ *
+ *   1. Every index's worst-case byte width — unique keys, primary keys,
+ *      *and* plain secondary indexes — stays under InnoDB's 3072-byte
+ *      `DYNAMIC` row-format index-key cap. Non-unique indexes are included
+ *      deliberately: the binding constraint on some tables (e.g.
+ *      `idx_text_path_value`) is a secondary index, not the table's
+ *      tightest unique key, so checking unique keys alone would miss it.
+ *   2. Every id / FK column and every `order_key` column resolves to the
+ *      `ascii_bin` collation (byte-wise, case-sensitive comparison —
+ *      what makes id equality case-sensitive and `order_key`'s DB sort
+ *      match JS string sort on the `generateKeyBetween` alphabet).
+ *   3. Every timestamp column is `datetime(3)` — millisecond precision.
+ *   4. The `byline_document_paths` per-collection path-uniqueness index
+ *      keeps the exact name `idx_document_paths_collection_locale_path`,
+ *      because `packages/core/src/services/document-lifecycle/internals.ts`
+ *      substring-matches this name against the adapter's `classifyError`
+ *      constraint report to detect path collisions.
+ *
+ * Computed generically over the schema so a future column widening (or a
+ * new `_id` column that forgets `uuidChar`) trips this test rather than
+ * surfacing later as a mysterious production failure.
+ */
+
+import { is, SQL } from 'drizzle-orm'
+import { type AnyMySqlColumn, getTableConfig, MySqlTable } from 'drizzle-orm/mysql-core'
+import { describe, expect, it } from 'vitest'
+
+import * as authSchema from './auth.js'
+import * as coreSchema from './index.js'
+
+// InnoDB's DYNAMIC row format (the default since MySQL 5.7 with
+// innodb_large_prefix on, which is the default from 8.0 on) caps a single
+// index key at 3072 bytes.
+const INNODB_INDEX_KEY_BYTE_CAP = 3072
+
+// Column names that end in `_id` (or are literally `id`) but are NOT
+// uuid-shaped FK/PK columns, so they are exempt from the `uuidChar`
+// (ascii_bin, char(36)) pin. Kept as an explicit, reviewable allowlist —
+// mirrors the pg schema's `metaStore.item_id`, which is deliberately a
+// generic `varchar(255)` identifier, not a `uuid` column, because it is
+// merely "exposed to the dashboard/API" rather than referencing another
+// table's primary key.
+const ID_COLUMN_UUID_EXEMPTIONS = new Set(['item_id'])
+
+function allTables(): MySqlTable[] {
+  const tables: MySqlTable[] = []
+  for (const value of [...Object.values(coreSchema), ...Object.values(authSchema)]) {
+    if (is(value, MySqlTable)) {
+      tables.push(value)
+    }
+  }
+  return tables
+}
+
+/**
+ * `ascii` counts 1 byte per character; anything else (the database's
+ * `utf8mb4` default charset) counts the InnoDB worst case of 4 bytes per
+ * character. Shared by both the whole-column and the prefixed-expression
+ * sizing below.
+ */
+function bytesPerChar(sqlType: string): number {
+  return /character set ascii/i.test(sqlType) ? 1 : 4
+}
+
+/**
+ * Bytes of fractional-seconds storage MySQL adds to a `TIME`/`DATETIME`/
+ * `TIMESTAMP` base width for a given `fsp` (0-6): 0 for fsp 0, 1 byte for
+ * fsp 1-2, 2 bytes for fsp 3-4, 3 bytes for fsp 5-6. Byline uses fsp 3
+ * uniformly (see `common.ts`), which is 2 bytes.
+ */
+function fractionalSecondsBytes(fsp: number): number {
+  if (fsp === 0) return 0
+  if (fsp <= 2) return 1
+  if (fsp <= 4) return 2
+  return 3
+}
+
+/**
+ * InnoDB's packed-`DECIMAL` storage: 9 decimal digits pack into 4 bytes,
+ * with a partial-group table for the leftover 0-8 digits, applied
+ * separately to the integer and fractional digit counts.
+ */
+function decimalStorageBytes(precision: number, scale: number): number {
+  const partialGroupBytes = [0, 1, 1, 2, 2, 3, 3, 4, 4]
+  const digitBytes = (digits: number) => {
+    const fullGroups = Math.floor(digits / 9)
+    const leftover = digits % 9
+    return fullGroups * 4 + (partialGroupBytes[leftover] ?? 0)
+  }
+  return digitBytes(precision - scale) + digitBytes(scale)
+}
+
+/**
+ * Worst-case byte width of a single column, given its rendered MySQL type
+ * string. `char`/`varchar` size by declared length × charset width (e.g.
+ * `varchar(500) CHARACTER SET ascii COLLATE ascii_bin`, or plain
+ * `varchar(10)` for the database's default `utf8mb4` charset — see
+ * `bytesPerChar`). Every other column type this schema's indexes actually
+ * use (fixed-width numerics, dates, and instants) is sized by its known
+ * InnoDB on-disk storage width, because the 3072-byte index-key cap
+ * applies to the whole key, not just its string-typed columns — a wide
+ * secondary index that mixes an id column with a handful of `int`/
+ * `datetime` columns still has to fit.
+ */
+function columnByteWidth(columnName: string, sqlType: string): number {
+  const stringMatch = sqlType.match(/^(?:char|varchar)\((\d+)\)/i)
+  if (stringMatch?.[1]) {
+    return Number(stringMatch[1]) * bytesPerChar(sqlType)
+  }
+
+  const typeMatch = sqlType.match(/^([a-z]+)(?:\(([^)]*)\))?/i)
+  const typeName = typeMatch?.[1]?.toLowerCase()
+  const args = typeMatch?.[2]
+
+  switch (typeName) {
+    case 'boolean':
+    case 'tinyint':
+      return 1
+    case 'smallint':
+      return 2
+    case 'mediumint':
+      return 3
+    case 'int':
+      return 4
+    case 'bigint':
+      return 8
+    case 'float':
+      return 4
+    case 'double':
+      return 8
+    case 'decimal': {
+      const parts = (args ?? '').split(',').map(Number)
+      const precision = parts[0] ?? Number.NaN
+      const scale = parts[1] ?? Number.NaN
+      if (!Number.isFinite(precision) || !Number.isFinite(scale)) break
+      return decimalStorageBytes(precision, scale)
+    }
+    case 'date':
+      return 3
+    case 'time':
+      return 3 + fractionalSecondsBytes(args ? Number(args) : 0)
+    case 'datetime':
+      return 5 + fractionalSecondsBytes(args ? Number(args) : 0)
+    case 'timestamp':
+      return 4 + fractionalSecondsBytes(args ? Number(args) : 0)
+    default:
+      break
+  }
+
+  throw new Error(
+    `schema-pins: column '${columnName}' has SQL type '${sqlType}', which this byte-budget ` +
+      'computation does not know how to size. Widen the pin to understand the new type — ' +
+      'a column this schema-pin test cannot size is a column whose worst-case index-key ' +
+      'contribution nothing is checking.'
+  )
+}
+
+/**
+ * Worst-case byte width of one index column, which is either a plain
+ * `MySqlColumn` or a prefixed expression built via `sql\`${table.col}(N)\``
+ * (the shape `idx_text_value` / `idx_text_path_value` / etc. use to index
+ * into the `TEXT` `value` column — MySQL requires an explicit key-length
+ * prefix on any index over a `TEXT`/`BLOB` column). For a prefixed
+ * expression, drizzle's `SQL` wraps the underlying column and a trailing
+ * `StringChunk` literal holding the `(N)` prefix syntax; the prefix
+ * length — not the column's own (possibly unbounded) declared length —
+ * is what actually goes into the index key, so it is sized directly
+ * rather than by widening the "whole column" case artificially.
+ */
+function indexColumnByteWidth(
+  tableName: string,
+  keyName: string,
+  col: AnyMySqlColumn | SQL
+): number {
+  if (!is(col, SQL)) {
+    return columnByteWidth(col.name, col.getSQLType())
+  }
+
+  let underlyingColumn: AnyMySqlColumn | undefined
+  let prefixLength: number | undefined
+  for (const chunk of col.queryChunks) {
+    if (chunk && typeof chunk === 'object' && 'getSQLType' in chunk) {
+      underlyingColumn = chunk as AnyMySqlColumn
+      continue
+    }
+    if (chunk && typeof chunk === 'object' && 'value' in chunk) {
+      const text = (chunk as { value: unknown[] }).value.join('')
+      const m = text.match(/\((\d+)\)/)
+      if (m?.[1]) prefixLength = Number(m[1])
+    }
+  }
+
+  if (!underlyingColumn || prefixLength === undefined) {
+    throw new Error(
+      `schema-pins: index '${tableName}.${keyName}' contains a raw SQL expression this ` +
+        'byte-budget computation does not know how to size (expected a `${column}(N)` ' +
+        'key-length prefix). Widen the pin to understand the new expression shape.'
+    )
+  }
+
+  return prefixLength * bytesPerChar(underlyingColumn.getSQLType())
+}
+
+interface NamedKey {
+  tableName: string
+  keyName: string
+  columns: (AnyMySqlColumn | SQL)[]
+}
+
+/**
+ * Every index-shaped structure declared on the schema — unique
+ * constraints, column-level `.unique()` markers, primary keys (composite
+ * and single-column), *and* plain secondary `index(...)` declarations.
+ * InnoDB's 3072-byte `DYNAMIC` key cap applies to every index on a table,
+ * not just the unique ones — a wide-but-non-unique index (e.g.
+ * `idx_text_path_value` on `(field_path, value(191))`) can be the
+ * tightest key on a table even when every *unique* key has headroom to
+ * spare, so checking only `uniqueConstraints` would let exactly the kind
+ * of widening this pin exists to catch slip through unpinned.
+ */
+function allIndexLikeKeys(): NamedKey[] {
+  const keys: NamedKey[] = []
+  for (const table of allTables()) {
+    const cfg = getTableConfig(table)
+
+    for (const uc of cfg.uniqueConstraints) {
+      keys.push({
+        tableName: cfg.name,
+        keyName: uc.name ?? '(unnamed unique)',
+        columns: uc.columns,
+      })
+    }
+
+    for (const col of cfg.columns) {
+      if (col.isUnique) {
+        keys.push({
+          tableName: cfg.name,
+          keyName: col.uniqueName ?? `${cfg.name}_${col.name}_unique`,
+          columns: [col],
+        })
+      }
+    }
+
+    for (const pk of cfg.primaryKeys) {
+      keys.push({
+        tableName: cfg.name,
+        keyName: pk.getName() || `${cfg.name}_pkey`,
+        columns: pk.columns,
+      })
+    }
+
+    const singleColPk = cfg.columns.filter((c) => c.primary)
+    if (singleColPk.length > 0 && cfg.primaryKeys.length === 0) {
+      keys.push({
+        tableName: cfg.name,
+        keyName: `${cfg.name}_pkey`,
+        columns: singleColPk,
+      })
+    }
+
+    for (const idx of cfg.indexes) {
+      keys.push({
+        tableName: cfg.name,
+        keyName: idx.config.name,
+        columns: idx.config.columns,
+      })
+    }
+  }
+  return keys
+}
+
+describe('schema pins — index byte budget (spec §F.1)', () => {
+  const keys = allIndexLikeKeys()
+
+  it('finds indexes to check (schema is not empty)', () => {
+    expect(keys.length).toBeGreaterThan(0)
+  })
+
+  it.each(keys.map((k) => [`${k.tableName}.${k.keyName}`, k] as const))(
+    '%s stays within the 3072-byte InnoDB DYNAMIC index-key cap',
+    (_label, key) => {
+      const width = key.columns.reduce(
+        (sum, col) => sum + indexColumnByteWidth(key.tableName, key.keyName, col),
+        0
+      )
+      expect(width).toBeLessThanOrEqual(INNODB_INDEX_KEY_BYTE_CAP)
+    }
+  )
+
+  it('the tightest store-table unique key (document_version_id, field_path, locale) is exactly 2076 bytes', () => {
+    const textStoreKey = keys.find(
+      (k) => k.tableName === 'byline_store_text' && k.keyName === 'unique_text_field'
+    )
+    expect(textStoreKey).toBeDefined()
+    const width = (textStoreKey as NamedKey).columns.reduce(
+      (sum, col) => sum + indexColumnByteWidth('byline_store_text', 'unique_text_field', col),
+      0
+    )
+    expect(width).toBe(2076)
+  })
+
+  it('the tightest non-unique index on that table, idx_text_path_value (field_path + a value(191) prefix), is exactly 2764 bytes', () => {
+    const idx = keys.find(
+      (k) => k.tableName === 'byline_store_text' && k.keyName === 'idx_text_path_value'
+    )
+    expect(idx).toBeDefined()
+    const width = (idx as NamedKey).columns.reduce(
+      (sum, col) => sum + indexColumnByteWidth('byline_store_text', 'idx_text_path_value', col),
+      0
+    )
+    expect(width).toBe(2764)
+  })
+})
+
+describe('schema pins — ascii_bin collation (spec §F.2)', () => {
+  const idColumns: { tableName: string; column: AnyMySqlColumn }[] = []
+  const orderKeyColumns: { tableName: string; column: AnyMySqlColumn }[] = []
+
+  for (const table of allTables()) {
+    const cfg = getTableConfig(table)
+    for (const col of cfg.columns) {
+      if (col.name === 'order_key') {
+        orderKeyColumns.push({ tableName: cfg.name, column: col })
+        continue
+      }
+      const looksLikeIdColumn = col.name === 'id' || col.name.endsWith('_id')
+      if (looksLikeIdColumn && !ID_COLUMN_UUID_EXEMPTIONS.has(col.name)) {
+        idColumns.push({ tableName: cfg.name, column: col })
+      }
+    }
+  }
+
+  it('finds id columns to check (schema is not empty)', () => {
+    expect(idColumns.length).toBeGreaterThan(0)
+  })
+
+  it('finds order_key columns to check (schema is not empty)', () => {
+    expect(orderKeyColumns.length).toBeGreaterThan(0)
+  })
+
+  it.each(idColumns.map((c) => [`${c.tableName}.${c.column.name}`, c.column] as const))(
+    '%s is char(36) CHARACTER SET ascii COLLATE ascii_bin (uuidChar)',
+    (_label, column) => {
+      expect(column.getSQLType()).toBe('char(36) CHARACTER SET ascii COLLATE ascii_bin')
+    }
+  )
+
+  it.each(orderKeyColumns.map((c) => [`${c.tableName}.${c.column.name}`, c.column] as const))(
+    '%s is varchar(128) CHARACTER SET ascii COLLATE ascii_bin (varcharByteSorted)',
+    (_label, column) => {
+      expect(column.getSQLType()).toBe('varchar(128) CHARACTER SET ascii COLLATE ascii_bin')
+    }
+  )
+})
+
+describe('schema pins — timestamp precision (spec §F.3)', () => {
+  const datetimeColumns: { tableName: string; column: AnyMySqlColumn }[] = []
+
+  // Any temporal type that represents an instant (date + time-of-day) must
+  // be `datetime(3)`. `MySqlDateTime` is what `datetime()` produces —
+  // every timestamp column in this schema uses it — but a future column
+  // accidentally declared with mysql-core's `timestamp()` builder instead
+  // would produce `MySqlTimestamp` (rendered `timestamp(3)`, a distinct
+  // MySQL type this schema never intends to use). Filtering on
+  // `MySqlDateTime` alone would silently skip that column rather than
+  // failing it, so both instant-shaped types are checked here.
+  // `MySqlDate` / `MySqlTime` (the `date()` / `time()` builders used by
+  // `datetimeStore.value_date` / `value_time`) are deliberately excluded —
+  // those store a calendar date or a time-of-day alone, a different
+  // concept from a timestamped instant, and are not held to this pin.
+  const INSTANT_COLUMN_TYPES = new Set(['MySqlDateTime', 'MySqlTimestamp'])
+
+  for (const table of allTables()) {
+    const cfg = getTableConfig(table)
+    for (const col of cfg.columns) {
+      if (INSTANT_COLUMN_TYPES.has(col.columnType)) {
+        datetimeColumns.push({ tableName: cfg.name, column: col })
+      }
+    }
+  }
+
+  it('finds datetime columns to check (schema is not empty)', () => {
+    expect(datetimeColumns.length).toBeGreaterThan(0)
+  })
+
+  it.each(datetimeColumns.map((c) => [`${c.tableName}.${c.column.name}`, c.column] as const))(
+    '%s is datetime(3) — millisecond precision',
+    (_label, column) => {
+      expect(column.getSQLType()).toBe('datetime(3)')
+    }
+  )
+})
+
+describe('schema pins — document-paths unique index name (spec §E)', () => {
+  it('byline_document_paths carries a unique key literally named idx_document_paths_collection_locale_path', () => {
+    const cfg = getTableConfig(coreSchema.documentPaths)
+    const pathKey = cfg.uniqueConstraints.find(
+      (uc) => uc.name === 'idx_document_paths_collection_locale_path'
+    )
+    expect(pathKey).toBeDefined()
+    expect(pathKey?.columns.map((c) => c.name)).toEqual(['collection_id', 'locale', 'path'])
+  })
+})

--- a/packages/db-mysql/src/database/schema/schema-pins.test.node.ts
+++ b/packages/db-mysql/src/database/schema/schema-pins.test.node.ts
@@ -20,12 +20,20 @@
  *      `ascii_bin` collation (byte-wise, case-sensitive comparison —
  *      what makes id equality case-sensitive and `order_key`'s DB sort
  *      match JS string sort on the `generateKeyBetween` alphabet).
- *   3. Every timestamp column is `datetime(3)` — millisecond precision.
+ *   3. Every timestamp (instant) column is `datetime(3)` — millisecond
+ *      precision — and every bare time-of-day column is `time(3)`, the
+ *      same millisecond precision, so a fractional time value round-trips
+ *      instead of silently truncating to whole seconds.
  *   4. The `byline_document_paths` per-collection path-uniqueness index
  *      keeps the exact name `idx_document_paths_collection_locale_path`,
  *      because `packages/core/src/services/document-lifecycle/internals.ts`
  *      substring-matches this name against the adapter's `classifyError`
  *      constraint report to detect path collisions.
+ *   5. `byline_document_paths.path` carries the `utf8mb4_bin` collation
+ *      (project-owner ruling) so path uniqueness is case- and
+ *      accent-sensitive on MySQL exactly like it already is on Postgres —
+ *      see `varcharCaseSensitive` in `./common.ts` for the Thai /
+ *      Devanagari / Hebrew combining-mark evidence behind the ruling.
  *
  * Computed generically over the schema so a future column widening (or a
  * new `_id` column that forgets `uuidChar`) trips this test rather than
@@ -43,15 +51,6 @@ import * as coreSchema from './index.js'
 // innodb_large_prefix on, which is the default from 8.0 on) caps a single
 // index key at 3072 bytes.
 const INNODB_INDEX_KEY_BYTE_CAP = 3072
-
-// Column names that end in `_id` (or are literally `id`) but are NOT
-// uuid-shaped FK/PK columns, so they are exempt from the `uuidChar`
-// (ascii_bin, char(36)) pin. Kept as an explicit, reviewable allowlist —
-// mirrors the pg schema's `metaStore.item_id`, which is deliberately a
-// generic `varchar(255)` identifier, not a `uuid` column, because it is
-// merely "exposed to the dashboard/API" rather than referencing another
-// table's primary key.
-const ID_COLUMN_UUID_EXEMPTIONS = new Set(['item_id'])
 
 function allTables(): MySqlTable[] {
   const tables: MySqlTable[] = []
@@ -324,7 +323,7 @@ describe('schema pins — index byte budget (spec §F.1)', () => {
 })
 
 describe('schema pins — ascii_bin collation (spec §F.2)', () => {
-  const idColumns: { tableName: string; column: AnyMySqlColumn }[] = []
+  const char36Columns: { tableName: string; column: AnyMySqlColumn }[] = []
   const orderKeyColumns: { tableName: string; column: AnyMySqlColumn }[] = []
 
   for (const table of allTables()) {
@@ -334,22 +333,29 @@ describe('schema pins — ascii_bin collation (spec §F.2)', () => {
         orderKeyColumns.push({ tableName: cfg.name, column: col })
         continue
       }
-      const looksLikeIdColumn = col.name === 'id' || col.name.endsWith('_id')
-      if (looksLikeIdColumn && !ID_COLUMN_UUID_EXEMPTIONS.has(col.name)) {
-        idColumns.push({ tableName: cfg.name, column: col })
+      // Asserted on the rendered *type* (any `char(36)` column) rather
+      // than the column *name* (`id` / `*_id`) — a name-pattern rule
+      // missed `documentVersions.created_by`, which is a `uuidChar`
+      // column that doesn't end in `_id`. Matching on type instead means
+      // every 36-char fixed-width column in the schema is held to this
+      // pin regardless of what it's called, and a column that renders as
+      // `char(36)` but isn't the `uuidChar` (ascii_bin) flavor fails the
+      // assertion below rather than escaping the check entirely.
+      if (/^char\(36\)/i.test(col.getSQLType())) {
+        char36Columns.push({ tableName: cfg.name, column: col })
       }
     }
   }
 
-  it('finds id columns to check (schema is not empty)', () => {
-    expect(idColumns.length).toBeGreaterThan(0)
+  it('finds char(36) columns to check (schema is not empty)', () => {
+    expect(char36Columns.length).toBeGreaterThan(0)
   })
 
   it('finds order_key columns to check (schema is not empty)', () => {
     expect(orderKeyColumns.length).toBeGreaterThan(0)
   })
 
-  it.each(idColumns.map((c) => [`${c.tableName}.${c.column.name}`, c.column] as const))(
+  it.each(char36Columns.map((c) => [`${c.tableName}.${c.column.name}`, c.column] as const))(
     '%s is char(36) CHARACTER SET ascii COLLATE ascii_bin (uuidChar)',
     (_label, column) => {
       expect(column.getSQLType()).toBe('char(36) CHARACTER SET ascii COLLATE ascii_bin')
@@ -365,7 +371,8 @@ describe('schema pins — ascii_bin collation (spec §F.2)', () => {
 })
 
 describe('schema pins — timestamp precision (spec §F.3)', () => {
-  const datetimeColumns: { tableName: string; column: AnyMySqlColumn }[] = []
+  const instantColumns: { tableName: string; column: AnyMySqlColumn }[] = []
+  const timeColumns: { tableName: string; column: AnyMySqlColumn }[] = []
 
   // Any temporal type that represents an instant (date + time-of-day) must
   // be `datetime(3)`. `MySqlDateTime` is what `datetime()` produces —
@@ -375,29 +382,53 @@ describe('schema pins — timestamp precision (spec §F.3)', () => {
   // MySQL type this schema never intends to use). Filtering on
   // `MySqlDateTime` alone would silently skip that column rather than
   // failing it, so both instant-shaped types are checked here.
-  // `MySqlDate` / `MySqlTime` (the `date()` / `time()` builders used by
-  // `datetimeStore.value_date` / `value_time`) are deliberately excluded —
-  // those store a calendar date or a time-of-day alone, a different
-  // concept from a timestamped instant, and are not held to this pin.
   const INSTANT_COLUMN_TYPES = new Set(['MySqlDateTime', 'MySqlTimestamp'])
 
   for (const table of allTables()) {
     const cfg = getTableConfig(table)
     for (const col of cfg.columns) {
       if (INSTANT_COLUMN_TYPES.has(col.columnType)) {
-        datetimeColumns.push({ tableName: cfg.name, column: col })
+        instantColumns.push({ tableName: cfg.name, column: col })
+      }
+      if (col.columnType === 'MySqlTime') {
+        timeColumns.push({ tableName: cfg.name, column: col })
       }
     }
   }
 
   it('finds datetime columns to check (schema is not empty)', () => {
-    expect(datetimeColumns.length).toBeGreaterThan(0)
+    expect(instantColumns.length).toBeGreaterThan(0)
   })
 
-  it.each(datetimeColumns.map((c) => [`${c.tableName}.${c.column.name}`, c.column] as const))(
+  it.each(instantColumns.map((c) => [`${c.tableName}.${c.column.name}`, c.column] as const))(
     '%s is datetime(3) — millisecond precision',
     (_label, column) => {
       expect(column.getSQLType()).toBe('datetime(3)')
+    }
+  )
+
+  // `MySqlDate` (the `date()` builder, used by `datetimeStore.value_date`)
+  // is the one temporal type genuinely outside this pin's scope — a
+  // calendar date has no time-of-day component to lose precision on, so
+  // there is nothing for an fsp pin to assert.
+  //
+  // `MySqlTime` used to get the same pass, on the theory that a bare
+  // time-of-day was a different concept from a timestamped instant. That
+  // reasoning was wrong: `time` is a real Byline field type
+  // (`packages/core/src/storage/field-store-map.ts`), and an unspecified
+  // `fsp` defaults to whole-second precision on MySQL — silently
+  // truncating a fractional time value that round-trips fine on Postgres,
+  // whose `time` column (also declared with no explicit precision on that
+  // side) defaults to microsecond precision. The exclusion is now a
+  // positive assertion instead.
+  it('finds time columns to check (schema is not empty)', () => {
+    expect(timeColumns.length).toBeGreaterThan(0)
+  })
+
+  it.each(timeColumns.map((c) => [`${c.tableName}.${c.column.name}`, c.column] as const))(
+    '%s is time(3) — millisecond precision',
+    (_label, column) => {
+      expect(column.getSQLType()).toBe('time(3)')
     }
   )
 })
@@ -410,5 +441,24 @@ describe('schema pins — document-paths unique index name (spec §E)', () => {
     )
     expect(pathKey).toBeDefined()
     expect(pathKey?.columns.map((c) => c.name)).toEqual(['collection_id', 'locale', 'path'])
+  })
+})
+
+describe('schema pins — document-paths case-sensitive collation (project-owner ruling)', () => {
+  // `path` must resolve to `utf8mb4_bin` — not the database's default
+  // `utf8mb4_0900_ai_ci` — so path uniqueness is case- AND
+  // accent-sensitive on MySQL exactly like it already is on Postgres
+  // (whose default collation folds neither). Verified against a live
+  // server: MySQL's default collation also collapses non-Latin combining
+  // marks Byline's slugifier deliberately preserves (Thai tone marks,
+  // Devanagari anusvara, Hebrew niqqud — see
+  // `packages/core/src/utils/slugify.ts`), so two documents intended as
+  // distinct would silently collide as one path on MySQL only. See
+  // `varcharCaseSensitive` in `./common.ts` for the full ruling.
+  it('byline_document_paths.path is varchar(255) COLLATE utf8mb4_bin', () => {
+    const cfg = getTableConfig(coreSchema.documentPaths)
+    const pathColumn = cfg.columns.find((c) => c.name === 'path')
+    expect(pathColumn).toBeDefined()
+    expect(pathColumn?.getSQLType()).toBe('varchar(255) COLLATE utf8mb4_bin')
   })
 })

--- a/packages/db-mysql/src/index.ts
+++ b/packages/db-mysql/src/index.ts
@@ -1,0 +1,233 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import type { CollectionDefinition, IDbAdapter } from '@byline/core'
+import { drizzle, type MySql2Database } from 'drizzle-orm/mysql2'
+import type { PoolConnection as CallbackPoolConnection } from 'mysql2'
+import mysql from 'mysql2/promise'
+
+import { assertMySqlVersion } from './lib/boot-check.js'
+import { DBManagerImpl, TXManagerImpl } from './lib/db-manager.js'
+
+/**
+ * Public return type of `mysqlAdapter`. Extends `IDbAdapter` with concrete
+ * Drizzle + mysql2 handles so integrations that need the raw database (the
+ * session provider, housekeeping scripts, migration tooling) don't have
+ * to construct a second connection pool.
+ *
+ * Consumers that only need the adapter contract can still annotate as
+ * `IDbAdapter` and ignore the extra properties. Mirrors `PgAdapter`
+ * (`packages/db-postgres/src/index.ts`).
+ */
+export interface MySqlAdapter extends IDbAdapter {
+  /**
+   * The underlying Drizzle instance.
+   *
+   * TODO(Task 8): parameterize with `typeof schema` once
+   * `src/database/schema/index.ts` lands, mirroring `PgAdapter['drizzle']`
+   * (`NodePgDatabase<typeof schema>`).
+   */
+  drizzle: MySql2Database<Record<string, never>>
+  /** The mysql2 connection pool — exposed for housekeeping and teardown. */
+  pool: mysql.Pool
+}
+
+/**
+ * Build a stub matching one `IDbAdapter` command/query member's exact call
+ * signature. Every real implementation lands task by task (9: storage
+ * commands, 10: storage queries, 11: counters/audit) — the adapter this
+ * factory returns is deliberately non-functional until then. Throwing keeps
+ * that honest at the call site: `MySqlAdapter` satisfies `IDbAdapter`
+ * structurally today, but invoking any operation before its task lands
+ * fails loudly instead of silently doing nothing.
+ */
+function notImplemented<T>(member: string, task: number): T {
+  return (() => {
+    throw new Error(`@byline/db-mysql: ${member} is not implemented yet (Task ${task})`)
+  }) as unknown as T
+}
+
+export const mysqlAdapter = ({
+  connectionString,
+  // biome-ignore lint/correctness/noUnusedFunctionParameters: threaded through the signature now for parity with pgAdapter; wired into the storage query builders in Task 10.
+  collections,
+  // biome-ignore lint/correctness/noUnusedFunctionParameters: threaded through the signature now for parity with pgAdapter; wired into the storage command/query builders starting Task 9.
+  defaultContentLocale,
+  connectionLimit = 20,
+}: {
+  connectionString: string
+  collections: readonly CollectionDefinition[]
+  /**
+   * The installation's default content locale, sourced from
+   * `ServerConfig.i18n.content.defaultLocale`. Used by the storage layer as
+   * the **fallback** anchor only: new documents are stamped with it as their
+   * `source_locale`, and it is the floor for row-less lookups (findByPath) and
+   * for documents whose `source_locale` is not yet backfilled. Per-document
+   * reads and writes otherwise re-base onto each document's own `source_locale`
+   * (carried on the current-documents views), so changing this value does not
+   * re-interpret existing data. See docs/07-internationalization/index.md.
+   */
+  defaultContentLocale: string
+  /**
+   * Maximum number of connections in the mysql2 pool. Defaults to 20. Tune
+   * via `BYLINE_DB_MYSQL_CONNECTION_LIMIT` in the host app.
+   */
+  connectionLimit?: number
+}): MySqlAdapter => {
+  const pool = mysql.createPool({
+    uri: connectionString,
+    connectionLimit,
+    // Every DATETIME(3) column is UTC by convention (spec §2). 'Z' stops
+    // mysql2 from reinterpreting stored UTC values against the server's or
+    // session's local timezone on the way in and out.
+    timezone: 'Z',
+    // Keep DECIMAL columns as strings instead of coercing to JS `number`,
+    // which loses precision on money/decimal values. The storage layer
+    // (Task 9) treats decimal store values as strings end to end, matching
+    // the pg adapter's `numeric` handling.
+    decimalNumbers: false,
+  })
+
+  // TODO(Task 8): pass the real schema once `src/database/schema/index.ts`
+  // lands. `drizzle-orm/mysql2` requires `mode` whenever `schema` is
+  // supplied — even an empty placeholder — so `'default'` stands in until
+  // then.
+  const db: MySql2Database<Record<string, never>> = drizzle(pool, {
+    schema: {},
+    mode: 'default',
+  })
+
+  // Request-scoped transaction propagation (docs/03-architecture/03-transactions.md), mirroring
+  // the pg adapter. Exported via ./lib/db-manager.js for Tasks 9-12: command
+  // builders land on the DBManager so each `this.db` access resolves to the
+  // ambient transaction when a `withTransaction` boundary is open, else the
+  // pool.
+  const dbManager = new DBManagerImpl({ dbPool: db })
+  // biome-ignore lint/correctness/noUnusedVariables: constructed now so Tasks 9-12 wire withTransaction to it; unused until then (see the withTransaction stub below).
+  const txManager = new TXManagerImpl({ db: dbManager })
+
+  // Boot check: run lazily on the pool's first physical connection rather
+  // than eagerly here, because `mysqlAdapter` is synchronous (mirroring
+  // `pgAdapter`) and cannot await a round trip before returning. mysql2
+  // pools open no connections at construction time — the `'connection'`
+  // event fires the first time a query actually needs one, which in
+  // practice is during `initBylineCore()`'s own boot sequence. A too-old
+  // server or MariaDB is a configuration error, not a recoverable runtime
+  // condition, so a failed check is rethrown on the next tick to surface as
+  // a loud, fail-fast crash instead of a silently swallowed rejection.
+  //
+  // The `mysql2/promise` typings claim this event hands back a
+  // promise-wrapped `PoolConnection`, but at runtime it is the underlying
+  // callback-style connection (confirmed against a live server) — calling
+  // `.query()` on it directly returns an `EventEmitter`, not a `Promise`.
+  // `.promise()` is the callback API's own escape hatch back to the
+  // promise wrapper; see https://sidorares.github.io/node-mysql2/docs/documentation/promise-wrapper.
+  let versionCheckStarted = false
+  pool.on('connection', (connection) => {
+    if (versionCheckStarted) return
+    versionCheckStarted = true
+    const rawConnection = connection as unknown as CallbackPoolConnection
+    const promiseConnection = rawConnection.promise()
+    assertMySqlVersion(async (sql) => {
+      const [rows] = await promiseConnection.query(sql)
+      return rows as Array<{ v: string }>
+    }).catch((err) => {
+      process.nextTick(() => {
+        throw err
+      })
+    })
+  })
+
+  return {
+    commands: {
+      collections: {
+        create: notImplemented('commands.collections.create', 9),
+        update: notImplemented('commands.collections.update', 9),
+        delete: notImplemented('commands.collections.delete', 9),
+      },
+      documents: {
+        createDocumentVersion: notImplemented('commands.documents.createDocumentVersion', 9),
+        updateDocumentPath: notImplemented('commands.documents.updateDocumentPath', 9),
+        setDocumentAvailableLocales: notImplemented(
+          'commands.documents.setDocumentAvailableLocales',
+          9
+        ),
+        setDocumentStatus: notImplemented('commands.documents.setDocumentStatus', 9),
+        archivePublishedVersions: notImplemented('commands.documents.archivePublishedVersions', 9),
+        softDeleteDocument: notImplemented('commands.documents.softDeleteDocument', 9),
+        deleteDocumentLocale: notImplemented('commands.documents.deleteDocumentLocale', 9),
+        setOrderKey: notImplemented('commands.documents.setOrderKey', 9),
+        placeTreeNode: notImplemented('commands.documents.placeTreeNode', 9),
+        removeFromTree: notImplemented('commands.documents.removeFromTree', 9),
+        promoteChildrenAndRemoveFromTree: notImplemented(
+          'commands.documents.promoteChildrenAndRemoveFromTree',
+          9
+        ),
+      },
+      counters: {
+        ensureCounterGroup: notImplemented('commands.counters.ensureCounterGroup', 11),
+        nextCounterValue: notImplemented('commands.counters.nextCounterValue', 11),
+        nextScopedCounterValue: notImplemented('commands.counters.nextScopedCounterValue', 11),
+      },
+      audit: {
+        append: notImplemented('commands.audit.append', 11),
+      },
+    },
+    queries: {
+      collections: {
+        getAllCollections: notImplemented('queries.collections.getAllCollections', 10),
+        getCollectionByPath: notImplemented('queries.collections.getCollectionByPath', 10),
+        getCollectionById: notImplemented('queries.collections.getCollectionById', 10),
+      },
+      documents: {
+        getDocumentSystemFieldsForUpdate: notImplemented(
+          'queries.documents.getDocumentSystemFieldsForUpdate',
+          10
+        ),
+        getDocumentById: notImplemented('queries.documents.getDocumentById', 10),
+        getCurrentVersionMetadata: notImplemented(
+          'queries.documents.getCurrentVersionMetadata',
+          10
+        ),
+        getCurrentPath: notImplemented('queries.documents.getCurrentPath', 10),
+        getDocumentByPath: notImplemented('queries.documents.getDocumentByPath', 10),
+        getDocumentByVersion: notImplemented('queries.documents.getDocumentByVersion', 10),
+        getDocumentsByVersionIds: notImplemented('queries.documents.getDocumentsByVersionIds', 10),
+        getDocumentsByDocumentIds: notImplemented(
+          'queries.documents.getDocumentsByDocumentIds',
+          10
+        ),
+        getDocumentHistory: notImplemented('queries.documents.getDocumentHistory', 10),
+        getPublishedVersion: notImplemented('queries.documents.getPublishedVersion', 10),
+        getPublishedDocumentIds: notImplemented('queries.documents.getPublishedDocumentIds', 10),
+        getDocumentCountsByStatus: notImplemented(
+          'queries.documents.getDocumentCountsByStatus',
+          10
+        ),
+        findDocuments: notImplemented('queries.documents.findDocuments', 10),
+        getLastOrderKey: notImplemented('queries.documents.getLastOrderKey', 10),
+        getNeighborOrderKeys: notImplemented('queries.documents.getNeighborOrderKeys', 10),
+        getCanonicalDocumentOrder: notImplemented(
+          'queries.documents.getCanonicalDocumentOrder',
+          10
+        ),
+        getTreeAncestors: notImplemented('queries.documents.getTreeAncestors', 10),
+        getTreeChildren: notImplemented('queries.documents.getTreeChildren', 10),
+        getTreeParent: notImplemented('queries.documents.getTreeParent', 10),
+        getTreeSubtree: notImplemented('queries.documents.getTreeSubtree', 10),
+      },
+      audit: {
+        getDocumentAuditLog: notImplemented('queries.audit.getDocumentAuditLog', 11),
+        findAuditLog: notImplemented('queries.audit.findAuditLog', 11),
+      },
+    },
+    withTransaction: notImplemented('withTransaction', 9),
+    drizzle: db,
+    pool,
+  }
+}

--- a/packages/db-mysql/src/index.ts
+++ b/packages/db-mysql/src/index.ts
@@ -11,6 +11,7 @@ import { drizzle, type MySql2Database } from 'drizzle-orm/mysql2'
 import type { PoolConnection as CallbackPoolConnection } from 'mysql2'
 import mysql from 'mysql2/promise'
 
+import * as schema from './database/schema/index.js'
 import { assertMySqlVersion } from './lib/boot-check.js'
 import { DBManagerImpl, TXManagerImpl } from './lib/db-manager.js'
 
@@ -25,14 +26,8 @@ import { DBManagerImpl, TXManagerImpl } from './lib/db-manager.js'
  * (`packages/db-postgres/src/index.ts`).
  */
 export interface MySqlAdapter extends IDbAdapter {
-  /**
-   * The underlying Drizzle instance.
-   *
-   * TODO(Task 8): parameterize with `typeof schema` once
-   * `src/database/schema/index.ts` lands, mirroring `PgAdapter['drizzle']`
-   * (`NodePgDatabase<typeof schema>`).
-   */
-  drizzle: MySql2Database<Record<string, never>>
+  /** The underlying Drizzle instance, typed against the full schema. */
+  drizzle: MySql2Database<typeof schema>
   /** The mysql2 connection pool — exposed for housekeeping and teardown. */
   pool: mysql.Pool
 }
@@ -93,12 +88,11 @@ export const mysqlAdapter = ({
     decimalNumbers: false,
   })
 
-  // TODO(Task 8): pass the real schema once `src/database/schema/index.ts`
-  // lands. `drizzle-orm/mysql2` requires `mode` whenever `schema` is
-  // supplied — even an empty placeholder — so `'default'` stands in until
-  // then.
-  const db: MySql2Database<Record<string, never>> = drizzle(pool, {
-    schema: {},
+  // `drizzle-orm/mysql2` requires `mode` whenever `schema` is supplied.
+  // 'default' matches the pg adapter's un-prefixed-key mode (as opposed to
+  // 'planetscale', which changes how relational queries build).
+  const db: MySql2Database<typeof schema> = drizzle(pool, {
+    schema,
     mode: 'default',
   })
 

--- a/packages/db-mysql/src/lib/boot-check.test.node.ts
+++ b/packages/db-mysql/src/lib/boot-check.test.node.ts
@@ -1,0 +1,60 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import { assertMySqlVersion } from './boot-check.js'
+
+const queryReturning = (v: string) => async () => [{ v }]
+
+describe('assertMySqlVersion', () => {
+  describe('accepts supported MySQL server versions', () => {
+    it.each([
+      ['8.0.14', '8.0.14 — the exact floor'],
+      ['8.4.0', '8.4.0'],
+      ['9.7.1', "9.7.1 — this repo's dev container"],
+      ['8.0.35-0ubuntu0.22.04.1', 'a distro-suffixed release string'],
+    ])('%s (%s)', async (version) => {
+      await expect(assertMySqlVersion(queryReturning(version))).resolves.toBeUndefined()
+    })
+  })
+
+  describe('rejects unsupported servers', () => {
+    it.each([
+      ['8.0.13', 'one patch below the floor'],
+      ['8.0.0', 'the 8.0 GA release, below the floor'],
+      ['5.7.44', 'MySQL 5.7'],
+      ['11.4.2-MariaDB', 'a MariaDB version string'],
+      ['5.5.5-10.11.2-MariaDB', 'the MariaDB replication-handshake version shape'],
+    ])('%s (%s)', async (version) => {
+      await expect(assertMySqlVersion(queryReturning(version))).rejects.toThrow(
+        /MariaDB is not supported/
+      )
+    })
+
+    it('names MariaDB explicitly, not just a failed numeric comparison', async () => {
+      await expect(assertMySqlVersion(queryReturning('11.4.2-MariaDB'))).rejects.toThrow(/MariaDB/)
+      await expect(assertMySqlVersion(queryReturning('5.5.5-10.11.2-MariaDB'))).rejects.toThrow(
+        /MariaDB/
+      )
+    })
+  })
+
+  describe('malformed results', () => {
+    it('throws a clear error (not a destructuring TypeError) when the query returns no rows', async () => {
+      await expect(assertMySqlVersion(async () => [])).rejects.toThrow(/@byline\/db-mysql/)
+      await expect(assertMySqlVersion(async () => [])).rejects.not.toThrow(TypeError)
+    })
+
+    it('throws a clear error when the query returns a row without a usable version string', async () => {
+      await expect(
+        assertMySqlVersion(async () => [{ v: undefined as unknown as string }])
+      ).rejects.toThrow(/@byline\/db-mysql/)
+    })
+  })
+})

--- a/packages/db-mysql/src/lib/boot-check.ts
+++ b/packages/db-mysql/src/lib/boot-check.ts
@@ -1,0 +1,57 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ *
+ * Boot-time engine check for the MySQL adapter. `mysqlAdapter` runs this
+ * lazily against the first connection the pool hands out (see
+ * `src/index.ts`) so a too-old server or a MariaDB instance fails fast at
+ * `initBylineCore()` boot rather than surfacing as an obscure SQL error the
+ * first time the storage layer emits a LATERAL join (Task 10+).
+ */
+
+const MIN = { major: 8, minor: 0, patch: 14 }
+
+const unsupportedEngineError = (reported: string): Error =>
+  new Error(
+    `@byline/db-mysql requires MySQL ${MIN.major}.${MIN.minor}.${MIN.patch}+ (LATERAL joins); server reports ${reported}. MariaDB is not supported.`
+  )
+
+/**
+ * Assert the connected server is MySQL (not MariaDB) at or above the
+ * supported floor. `query` is injected so this is unit-testable without a
+ * live server — the adapter passes a thin wrapper around the pool's
+ * `SELECT VERSION()` round trip.
+ */
+export async function assertMySqlVersion(
+  query: (sql: string) => Promise<Array<{ v: string }>>
+): Promise<void> {
+  const rows = await query('SELECT VERSION() AS v')
+  const v = rows?.[0]?.v
+
+  if (typeof v !== 'string' || v.length === 0) {
+    throw new Error(
+      "@byline/db-mysql: could not determine the MySQL server version — 'SELECT VERSION()' returned no usable result."
+    )
+  }
+
+  // MariaDB reports version strings that satisfy the numeric floor below
+  // (it commonly claims a 10.x/11.x series, sometimes fronted by the
+  // legacy `5.5.5-` replication-handshake prefix), so it must be rejected
+  // explicitly before the numeric comparison, not merely by chance.
+  if (/mariadb/i.test(v)) {
+    throw unsupportedEngineError(v)
+  }
+
+  const m = v.match(/^(\d+)\.(\d+)\.(\d+)/)
+  const [major = 0, minor = 0, patch = 0] = m ? m.slice(1).map(Number) : []
+  const ok =
+    major > MIN.major ||
+    (major === MIN.major && (minor > MIN.minor || (minor === MIN.minor && patch >= MIN.patch)))
+
+  if (!ok) {
+    throw unsupportedEngineError(v)
+  }
+}

--- a/packages/db-mysql/src/lib/db-manager.ts
+++ b/packages/db-mysql/src/lib/db-manager.ts
@@ -21,11 +21,9 @@ import { AsyncLocalStorage } from 'node:async_hooks'
 
 import type { MySql2Database } from 'drizzle-orm/mysql2'
 
-// TODO(Task 8): parameterize with `typeof schema` once
-// `src/database/schema/index.ts` lands, mirroring the pg adapter's
-// `MySql2Database<typeof schema>`. The schema module does not exist yet —
-// Task 7 is package skeleton only.
-export type DBExecutor = MySql2Database<Record<string, never>>
+import type * as schema from '../database/schema/index.js'
+
+export type DBExecutor = MySql2Database<typeof schema>
 
 const transactionALS = new AsyncLocalStorage<DBExecutor>()
 

--- a/packages/db-mysql/src/lib/db-manager.ts
+++ b/packages/db-mysql/src/lib/db-manager.ts
@@ -1,0 +1,89 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ *
+ * Request-scoped transaction propagation via AsyncLocalStorage.
+ *
+ * Mirrors the Postgres adapter's `db-manager.ts` — the same ALS mechanism
+ * Byline's logger already uses (`packages/core/src/lib/logger.ts`,
+ * `withLogContext`). The full design — the service-owned `withTransaction`
+ * boundary, the DB↔DB vs DB↔external distinction, the incremental-adoption
+ * caveat, and the serverless db-contract-seam decisions — lives in
+ * `docs/03-architecture/03-transactions.md`. This machinery is deliberately adapter-internal:
+ * transactions are driver-specific, so `@byline/core` only declares the
+ * `withTransaction` capability on `IDbAdapter`, never the implementation.
+ */
+
+import { AsyncLocalStorage } from 'node:async_hooks'
+
+import type { MySql2Database } from 'drizzle-orm/mysql2'
+
+// TODO(Task 8): parameterize with `typeof schema` once
+// `src/database/schema/index.ts` lands, mirroring the pg adapter's
+// `MySql2Database<typeof schema>`. The schema module does not exist yet —
+// Task 7 is package skeleton only.
+export type DBExecutor = MySql2Database<Record<string, never>>
+
+const transactionALS = new AsyncLocalStorage<DBExecutor>()
+
+export interface DBManager {
+  /**
+   * The current executor: the ambient transaction when a `withTransaction`
+   * boundary is open in this async context, otherwise the pool.
+   */
+  get(): DBExecutor
+}
+
+export class DBManagerImpl implements DBManager {
+  private readonly dbPool: DBExecutor
+
+  constructor(deps: { dbPool: DBExecutor }) {
+    this.dbPool = deps.dbPool
+  }
+
+  get(): DBExecutor {
+    return transactionALS.getStore() ?? this.dbPool
+  }
+}
+
+export interface TXManager {
+  /**
+   * Run `fn` inside a single database transaction. Every `DBManager.get()`
+   * call made during `fn` (transitively, across `await`s) returns that
+   * transaction, so the commands `fn` invokes commit or roll back together.
+   *
+   * Nesting: when already inside a `withTransaction`, the inner call opens a
+   * SAVEPOINT (Drizzle nested transaction) — an inner throw rolls back to the
+   * savepoint, an outer throw rolls back everything.
+   */
+  withTransaction<T>(fn: () => Promise<T>): Promise<T>
+}
+
+export class TXManagerImpl implements TXManager {
+  private readonly db: DBManager
+
+  constructor(deps: { db: DBManager }) {
+    this.db = deps.db
+  }
+
+  withTransaction<T>(fn: () => Promise<T>): Promise<T> {
+    return this.db.get().transaction(
+      (tx) =>
+        // `tx` is Drizzle's MySqlTransaction; it carries the full
+        // query-builder surface every command uses. The cast bridges the
+        // structural gap to MySql2Database the same way the pg adapter
+        // bridges to NodePgDatabase. See docs/03-architecture/03-transactions.md.
+        transactionALS.run(tx as unknown as DBExecutor, fn),
+      {
+        // Spec decision: pin the isolation level to match the pg adapter's
+        // assumptions (Postgres's default is READ COMMITTED; MySQL/InnoDB
+        // defaults to REPEATABLE READ). Canonical adapters must behave
+        // identically for the shared db-conformance suite.
+        isolationLevel: 'read committed',
+      }
+    )
+  }
+}

--- a/packages/db-mysql/tsconfig.json
+++ b/packages/db-mysql/tsconfig.json
@@ -1,0 +1,36 @@
+{
+  "compilerOptions": {
+    /* Base Options: */
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "target": "es2024",
+    "allowJs": true,
+    "resolveJsonModule": true,
+    "moduleDetection": "force",
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+
+    /* Strictness */
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noFallthroughCasesInSwitch": true,
+
+    /* If transpiling with TypeScript: */
+    "module": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "sourceMap": false,
+    "declaration": true,
+    "declarationMap": false,
+    "lib": ["es2024"], // No DOM or browser libraries
+
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}

--- a/packages/db-mysql/vitest.config.ts
+++ b/packages/db-mysql/vitest.config.ts
@@ -1,0 +1,40 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig(({ mode }) => {
+  // Unit:        vitest run --mode=node          → *.test.node.ts
+  // Integration: vitest run --mode=integration   → **/*.test.ts under src/**/tests/
+  //              plus tests/**/*.test.ts — the conformance entry that will
+  //              run the shared @byline/db-conformance storage suite once
+  //              the storage/query modules land (Tasks 8-12).
+  const isIntegration = mode === 'integration'
+  const testFiles = isIntegration
+    ? ['src/**/tests/**/*.test.ts', 'tests/**/*.test.ts']
+    : ['**/*.test.node.ts']
+
+  return {
+    test: {
+      environment: 'node',
+      include: testFiles,
+      reporter: 'verbose',
+      globals: true,
+      // Mirrors db-postgres: live-DB integration tests can take a while
+      // (migrations, argon2id hashing in the admin suite). Keep the
+      // global timeout generous.
+      testTimeout: 30_000,
+      hookTimeout: 60_000,
+      ...(isIntegration
+        ? {
+            // Same shape as db-postgres: migrate once via globalSetup,
+            // truncate per file via setupFiles, and force serial file
+            // execution so per-file TRUNCATEs don't wipe each other's
+            // seeded fixtures mid-run.
+            globalSetup: ['./tests/_global-setup.ts'],
+            setupFiles: ['./tests/_per-file-setup.ts'],
+            fileParallelism: false,
+            maxWorkers: 1,
+            isolate: false,
+          }
+        : {}),
+    },
+  }
+})

--- a/packages/db-mysql/vitest.config.ts
+++ b/packages/db-mysql/vitest.config.ts
@@ -33,6 +33,17 @@ export default defineConfig(({ mode }) => {
             fileParallelism: false,
             maxWorkers: 1,
             isolate: false,
+            // TODO(Task 13): remove once the conformance entry lands.
+            // There is no `tests/` directory yet (`globalSetup` /
+            // `setupFiles` above point at files that don't exist until
+            // Task 13 lands the shared @byline/db-conformance suite
+            // entry), so `vitest run --mode=integration` currently
+            // matches zero test files and exits 1 with "No test files
+            // found" — which turns `pnpm test:integration` (and CI, which
+            // runs it at the repo root) red for a condition that isn't a
+            // failure, just "nothing to run yet." `passWithNoTests`
+            // makes an empty run exit 0 instead.
+            passWithNoTests: true,
           }
         : {}),
     },

--- a/packages/db-postgres/.env.example
+++ b/packages/db-postgres/.env.example
@@ -6,7 +6,16 @@
 # database, copy .env.test.example to .env.test instead and
 # run `pnpm db:init:test`.
 #
-# Single source of truth — common.sh parses this URL to derive
-# user / password / host / port / database. Must use the
-# postgres:// or postgresql:// scheme.
+# Single source of truth. The primary consumer is `pgAdapter`
+# (packages/db-postgres/src/index.ts), which hands this string straight
+# to node-postgres — node-postgres parses URLs natively, including this
+# one. `common.sh` also parses it, but only because the `psql` /
+# `createuser` tooling takes discrete flags rather than a URL; that
+# parsing exists to serve the shell scripts, not the other way round.
+# Must use the postgres:// or postgresql:// scheme. Special characters
+# in the user or password must be percent-encoded (`@` as `%40`, `#` as
+# `%23`, `/` as `%2F`, …) — node-postgres and common.sh's urldecode()
+# both percent-decode the userinfo the same way, so an unencoded
+# reserved character would parse differently (or fail to parse) on one
+# side or the other.
 BYLINE_DB_POSTGRES_CONNECTION_STRING=postgres://byline:byline@127.0.0.1:5432/byline_dev

--- a/packages/db-postgres/.env.test.example
+++ b/packages/db-postgres/.env.test.example
@@ -2,4 +2,8 @@
 # The DB name MUST end in `_test` — db_init.sh refuses to operate
 # on anything else (see check_db_suffix in common.sh) and the test
 # bootstrap calls assertTestDatabase() with the same guard.
+# Special characters in the user or password must be percent-encoded
+# (`@` as `%40`, `#` as `%23`, `/` as `%2F`, …) — see .env.example for
+# why (node-postgres and common.sh's urldecode() both decode the
+# userinfo).
 BYLINE_DB_POSTGRES_CONNECTION_STRING=postgres://byline:byline@127.0.0.1:5432/byline_test

--- a/packages/db-postgres/src/database/common.sh
+++ b/packages/db-postgres/src/database/common.sh
@@ -69,9 +69,24 @@ check_conf_var() {
 # `printf %b`, which otherwise treats `\` as the start of its own escape
 # sequence and would mangle a password that legitimately contains one.
 #
+# Rejects a malformed percent-escape (a `%` not followed by exactly two
+# hex digits) instead of silently mis-decoding it — `printf %b` either
+# swallows a short/invalid escape into garbage bytes or prints its own
+# "missing hex digit" warning to stderr while still exiting 0, and either
+# way the caller would otherwise sail on with a corrupted value. A raw,
+# un-encoded `%` in a connection string violates RFC 3986, so this is
+# exactly the input node-postgres would independently reject with
+# `URIError: URI malformed` — failing here just fails at the same input
+# with a message that names the actual problem instead of a downstream
+# "password authentication failed."
+#
 ###~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~##
 urldecode() {
   local encoded="$1"
+  if [[ "${encoded}" =~ %([^0-9A-Fa-f]|[0-9A-Fa-f][^0-9A-Fa-f]|[0-9A-Fa-f]?$) ]]; then
+    echo "urldecode: malformed percent-escape in '${encoded}' -- every '%' must be followed by exactly two hex digits (e.g. '%40')" >&2
+    return 1
+  fi
   encoded="${encoded//\\/\\\\}"
   printf '%b' "${encoded//%/\\x}"
 }
@@ -124,8 +139,8 @@ parse_pg_url() {
     return
   fi
 
-  POSTGRES_USER="$(urldecode "${userinfo%%:*}")"
-  POSTGRES_PASSWORD="$(urldecode "${userinfo#*:}")"
+  POSTGRES_USER="$(urldecode "${userinfo%%:*}")" || { CONF_BAD=true; return; }
+  POSTGRES_PASSWORD="$(urldecode "${userinfo#*:}")" || { CONF_BAD=true; return; }
 
   local hostport="${hostpart%%/*}"
   local dbpath="${hostpart#*/}"
@@ -198,3 +213,17 @@ POSTGRES_PASSWORD_ESC=$(sed -e "s/[']/'&/g" <<< $POSTGRES_PASSWORD)
 # in the sql-escaped password from above.
 # https://stackoverflow.com/questions/407523/escape-a-string-for-a-sed-replace-pattern/2705678#2705678
 POSTGRES_PASSWORD_ESC=$(sed -e 's/[\/&]/\\&/g' <<< $POSTGRES_PASSWORD_ESC)
+
+# Escape the username for the same sed substitution in db_init.sh. Before
+# `urldecode` (above) existed, a raw `/`, `&`, or `\` in the username was
+# structurally impossible — it would have broken URL parsing before
+# `parse_pg_url` ever ran. Now a percent-encoded username (`%2F`, `%26`,
+# `%5C`) decodes into exactly those sed-special characters and reaches
+# db_init.sh's `s/${db_user}/.../ ` substitution unescaped, corrupting
+# the generated SQL (or, for `&`, silently substituting the whole
+# matched text instead of the literal username). Unlike the password,
+# the username never appears through this script as a SQL string literal
+# that also needs quote escaping — it only ever reaches sed as a
+# replacement value — so it gets this one escaping stage and not the
+# SQL-literal stage above.
+POSTGRES_USER_ESC=$(sed -e 's/[\/&]/\\&/g' <<< $POSTGRES_USER)

--- a/packages/db-postgres/src/database/common.sh
+++ b/packages/db-postgres/src/database/common.sh
@@ -43,6 +43,41 @@ check_conf_var() {
 
 ###~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~##
 #
+# FUNCTION: urldecode
+# Percent-decode a single URL component (RFC 3986 %XX escapes).
+#
+# `parse_pg_url` below extracts the user/password substrings from the
+# connection string by plain string manipulation — it does not decode
+# percent-escapes. But the running application hands the same connection
+# string to node-postgres, which parses it as a real URL and DOES
+# percent-decode the userinfo (username/password) component. Left
+# undecoded here, a password containing a character that had to be
+# percent-encoded in the URL (`@`, `#`, `/`, `%`, `'`, a literal `\`, …)
+# would make `db_init.sh` create the Postgres role with the literal
+# percent-escaped string as its password, while the running application
+# connects with the decoded password — "password authentication failed,"
+# with nothing about the error pointing at the real cause. See
+# `packages/db-mysql/src/database/common.sh`'s identical helper — mysql2
+# decodes the same way.
+#
+# Deliberately does NOT decode `+` to space: that is HTML form encoding
+# (`application/x-www-form-urlencoded`), which is a different convention
+# from URL-userinfo percent-encoding and is not what node-postgres or
+# mysql2 do when parsing a connection string.
+#
+# Escapes literal backslashes in the input *before* handing it to
+# `printf %b`, which otherwise treats `\` as the start of its own escape
+# sequence and would mangle a password that legitimately contains one.
+#
+###~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~##
+urldecode() {
+  local encoded="$1"
+  encoded="${encoded//\\/\\\\}"
+  printf '%b' "${encoded//%/\\x}"
+}
+
+###~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~##
+#
 # FUNCTION: parse_pg_url
 # Parse a Postgres connection URL into POSTGRES_USER, POSTGRES_PASSWORD,
 # POSTGRES_HOSTNAME, POSTGRES_PORT, POSTGRES_DATABASE. The single env var
@@ -53,6 +88,9 @@ check_conf_var() {
 #   postgres://user:password@host:port/database
 #
 # Strips `?...` query string. Defaults POSTGRES_PORT to 5432 if absent.
+# POSTGRES_USER and POSTGRES_PASSWORD are percent-decoded (see
+# `urldecode` above) so a password with URL-reserved characters resolves
+# to the same literal value node-postgres resolves it to.
 #
 ###~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~##
 parse_pg_url() {
@@ -86,8 +124,8 @@ parse_pg_url() {
     return
   fi
 
-  POSTGRES_USER="${userinfo%%:*}"
-  POSTGRES_PASSWORD="${userinfo#*:}"
+  POSTGRES_USER="$(urldecode "${userinfo%%:*}")"
+  POSTGRES_PASSWORD="$(urldecode "${userinfo#*:}")"
 
   local hostport="${hostpart%%/*}"
   local dbpath="${hostpart#*/}"

--- a/packages/db-postgres/src/database/db_init.sh
+++ b/packages/db-postgres/src/database/db_init.sh
@@ -32,6 +32,6 @@ source common.sh
 
 echo "Initializing DB '${POSTGRES_DATABASE}' (enter postgres root password below)"
 sed -e "s/\${db_name}/${POSTGRES_DATABASE}/" \
-    -e "s/\${db_user}/${POSTGRES_USER}/" \
+    -e "s/\${db_user}/${POSTGRES_USER_ESC}/" \
     -e "s/\${db_pass}/${POSTGRES_PASSWORD_ESC}/" db-reset.sql.template \
   | psql -h 127.0.0.1 -U postgres -q

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,7 +113,7 @@ importers:
         version: 1.0.0
       nitro:
         specifier: npm:nitro-nightly@3.0.260522-beta
-        version: nitro-nightly@3.0.260522-beta(chokidar@5.0.0)(dotenv@17.4.2)(drizzle-orm@0.45.2(@types/pg@8.20.0)(pg@8.22.0))(jiti@2.7.0)(lru-cache@11.5.2)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.7)(sass@1.101.0)(stylus@0.62.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: nitro-nightly@3.0.260522-beta(chokidar@5.0.0)(dotenv@17.4.2)(drizzle-orm@0.45.2(@types/pg@8.20.0)(mysql2@3.23.1(@types/node@26.1.1))(pg@8.22.0))(jiti@2.7.0)(lru-cache@11.5.2)(mysql2@3.23.1(@types/node@26.1.1))(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.7)(sass@1.101.0)(stylus@0.62.0)(tsx@4.23.1)(yaml@2.9.0))
       prism-react-renderer:
         specifier: ^2.4.1
         version: 2.4.1(react@19.2.7)
@@ -472,7 +472,7 @@ importers:
         version: 9.0.0
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@types/pg@8.20.0)(pg@8.22.0)
+        version: 0.45.2(@types/pg@8.20.0)(mysql2@3.23.1(@types/node@26.1.1))(pg@8.22.0)
       execa:
         specifier: ^10.0.0
         version: 10.0.0
@@ -670,6 +670,55 @@ importers:
         specifier: ^4.1.10
         version: 4.1.10(@types/node@26.1.1)(happy-dom@20.10.6)(jsdom@29.1.1)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.7)(sass@1.101.0)(stylus@0.62.0)(tsx@4.23.1)(yaml@2.9.0))
 
+  packages/db-mysql:
+    dependencies:
+      '@byline/core':
+        specifier: workspace:*
+        version: link:../core
+      drizzle-orm:
+        specifier: ^0.45.2
+        version: 0.45.2(@types/pg@8.20.0)(mysql2@3.23.1(@types/node@26.1.1))(pg@8.22.0)
+      mysql2:
+        specifier: ^3.23.1
+        version: 3.23.1(@types/node@26.1.1)
+      npm-run-all:
+        specifier: ^4.1.5
+        version: 4.1.5
+    devDependencies:
+      '@biomejs/biome':
+        specifier: 2.5.4
+        version: 2.5.4
+      '@byline/db-conformance':
+        specifier: workspace:*
+        version: link:../db-conformance
+      '@types/node':
+        specifier: ^26.1.1
+        version: 26.1.1
+      chokidar:
+        specifier: ^5.0.0
+        version: 5.0.0
+      chokidar-cli:
+        specifier: ^3.0.0
+        version: 3.0.0
+      dotenv:
+        specifier: ^17.4.2
+        version: 17.4.2
+      drizzle-kit:
+        specifier: ^0.31.10
+        version: 0.31.10
+      tsc-alias:
+        specifier: ^1.9.1
+        version: 1.9.1
+      tsx:
+        specifier: ^4.23.1
+        version: 4.23.1
+      typescript:
+        specifier: ^7.0.2
+        version: 7.0.2
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@26.1.1)(happy-dom@20.10.6)(jsdom@29.1.1)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.7)(sass@1.101.0)(stylus@0.62.0)(tsx@4.23.1)(yaml@2.9.0))
+
   packages/db-postgres:
     dependencies:
       '@byline/admin':
@@ -680,7 +729,7 @@ importers:
         version: link:../core
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@types/pg@8.20.0)(pg@8.22.0)
+        version: 0.45.2(@types/pg@8.20.0)(mysql2@3.23.1(@types/node@26.1.1))(pg@8.22.0)
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
@@ -4287,6 +4336,10 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
+  aws-ssl-profiles@1.1.2:
+    resolution: {integrity: sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==}
+    engines: {node: '>= 6.0.0'}
+
   babel-dead-code-elimination@1.0.12:
     resolution: {integrity: sha512-GERT7L2TiYcYDtYk1IpD+ASAYXjKbLTDPhBtYj7X1NuRMDTMtAx9kyBenub1Ev41lo91OHCKdmP+egTDmfQ7Ig==}
 
@@ -4615,6 +4668,10 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
+
+  denque@2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -5038,6 +5095,9 @@ packages:
     resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
     engines: {node: '>=18'}
 
+  generate-function@2.3.1:
+    resolution: {integrity: sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==}
+
   generator-function@2.0.1:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
     engines: {node: '>= 0.4'}
@@ -5382,6 +5442,9 @@ packages:
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  is-property@1.0.2:
+    resolution: {integrity: sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==}
 
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
@@ -5760,6 +5823,10 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lru.min@1.1.4:
+    resolution: {integrity: sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==}
+    engines: {bun: '>=1.0.0', deno: '>=1.30.0', node: '>=8.0.0'}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -5962,6 +6029,16 @@ packages:
   mylas@2.1.14:
     resolution: {integrity: sha512-BzQguy9W9NJgoVn2mRWzbFrFWWztGCcng2QI9+41frfk+Athwgx3qhqhvStz7ExeUUu7Kzw427sNzHpEZNINog==}
     engines: {node: '>=16.0.0'}
+
+  mysql2@3.23.1:
+    resolution: {integrity: sha512-tTuRnC7qCet2IOfSNMYZ5SwXuBnfvBPAcIA28P0gtruXyZlU1LMxA6uha32kYypoFgyYklMqhLWwt4laYwXR/Q==}
+    engines: {node: '>= 8.0'}
+    peerDependencies:
+      '@types/node': '>= 8'
+
+  named-placeholders@1.1.6:
+    resolution: {integrity: sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==}
+    engines: {node: '>=8.0.0'}
 
   nanoid@3.3.16:
     resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
@@ -6838,6 +6915,10 @@ packages:
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
+  sql-escaper@1.5.1:
+    resolution: {integrity: sha512-4toX5E1fQbBrpfXidaHnF0669nkAdETeIPTs2SUjxxD7RRIs9ICG4gtpmfc68JCEKehsdwLFqBu9VlQqZ1P1gg==}
+    engines: {bun: '>=1.0.0', deno: '>=2.0.0', node: '>=12.0.0'}
 
   srvx@0.11.22:
     resolution: {integrity: sha512-LqZxxBDMKuMAZzFzJnDCkFOrs9MZQZr0LvHiO/SuSZVdQaXD7xQ5UWTUxheJrQPve1qk9MG2B/yttUvJxw8egQ==}
@@ -10363,6 +10444,8 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
+  aws-ssl-profiles@1.1.2: {}
+
   babel-dead-code-elimination@1.0.12:
     dependencies:
       '@babel/core': 7.29.7
@@ -10638,9 +10721,10 @@ snapshots:
 
   date-fns@4.4.0: {}
 
-  db0@0.3.4(drizzle-orm@0.45.2(@types/pg@8.20.0)(pg@8.22.0)):
+  db0@0.3.4(drizzle-orm@0.45.2(@types/pg@8.20.0)(mysql2@3.23.1(@types/node@26.1.1))(pg@8.22.0))(mysql2@3.23.1(@types/node@26.1.1)):
     optionalDependencies:
-      drizzle-orm: 0.45.2(@types/pg@8.20.0)(pg@8.22.0)
+      drizzle-orm: 0.45.2(@types/pg@8.20.0)(mysql2@3.23.1(@types/node@26.1.1))(pg@8.22.0)
+      mysql2: 3.23.1(@types/node@26.1.1)
 
   debug@4.4.3:
     dependencies:
@@ -10677,6 +10761,8 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
+  denque@2.1.0: {}
+
   dequal@2.0.3: {}
 
   detect-indent@6.1.0: {}
@@ -10708,9 +10794,10 @@ snapshots:
       esbuild: 0.25.12
       tsx: 4.23.1
 
-  drizzle-orm@0.45.2(@types/pg@8.20.0)(pg@8.22.0):
+  drizzle-orm@0.45.2(@types/pg@8.20.0)(mysql2@3.23.1(@types/node@26.1.1))(pg@8.22.0):
     optionalDependencies:
       '@types/pg': 8.20.0
+      mysql2: 3.23.1(@types/node@26.1.1)
       pg: 8.22.0
 
   dunder-proto@1.0.1:
@@ -11116,6 +11203,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  generate-function@2.3.1:
+    dependencies:
+      is-property: 1.0.2
+
   generator-function@2.0.1: {}
 
   gensync@1.0.0-beta.2: {}
@@ -11473,6 +11564,8 @@ snapshots:
 
   is-potential-custom-element-name@1.0.1: {}
 
+  is-property@1.0.2: {}
+
   is-regex@1.2.1:
     dependencies:
       call-bound: 1.0.4
@@ -11823,6 +11916,8 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lru.min@1.1.4: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -12178,6 +12273,22 @@ snapshots:
 
   mylas@2.1.14: {}
 
+  mysql2@3.23.1(@types/node@26.1.1):
+    dependencies:
+      '@types/node': 26.1.1
+      aws-ssl-profiles: 1.1.2
+      denque: 2.1.0
+      generate-function: 2.3.1
+      iconv-lite: 0.7.3
+      long: 5.3.2
+      lru.min: 1.1.4
+      named-placeholders: 1.1.6
+      sql-escaper: 1.5.1
+
+  named-placeholders@1.1.6:
+    dependencies:
+      lru.min: 1.1.4
+
   nanoid@3.3.16: {}
 
   needle@3.5.0:
@@ -12192,11 +12303,11 @@ snapshots:
 
   nice-try@1.0.5: {}
 
-  nitro-nightly@3.0.260522-beta(chokidar@5.0.0)(dotenv@17.4.2)(drizzle-orm@0.45.2(@types/pg@8.20.0)(pg@8.22.0))(jiti@2.7.0)(lru-cache@11.5.2)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.7)(sass@1.101.0)(stylus@0.62.0)(tsx@4.23.1)(yaml@2.9.0)):
+  nitro-nightly@3.0.260522-beta(chokidar@5.0.0)(dotenv@17.4.2)(drizzle-orm@0.45.2(@types/pg@8.20.0)(mysql2@3.23.1(@types/node@26.1.1))(pg@8.22.0))(jiti@2.7.0)(lru-cache@11.5.2)(mysql2@3.23.1(@types/node@26.1.1))(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.7)(sass@1.101.0)(stylus@0.62.0)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
       consola: 3.4.2
       crossws: 0.4.10(srvx@0.11.22)
-      db0: 0.3.4(drizzle-orm@0.45.2(@types/pg@8.20.0)(pg@8.22.0))
+      db0: 0.3.4(drizzle-orm@0.45.2(@types/pg@8.20.0)(mysql2@3.23.1(@types/node@26.1.1))(pg@8.22.0))(mysql2@3.23.1(@types/node@26.1.1))
       env-runner: 0.1.16
       h3: 2.0.1-rc.25(crossws@0.4.10(srvx@0.11.22))
       hookable: 6.1.1
@@ -12207,7 +12318,7 @@ snapshots:
       rolldown: 1.2.0
       srvx: 0.11.22
       unenv: 2.0.0-rc.24
-      unstorage: 2.0.0-alpha.7(chokidar@5.0.0)(db0@0.3.4(drizzle-orm@0.45.2(@types/pg@8.20.0)(pg@8.22.0)))(lru-cache@11.5.2)(ofetch@2.0.0-alpha.3)
+      unstorage: 2.0.0-alpha.7(chokidar@5.0.0)(db0@0.3.4(drizzle-orm@0.45.2(@types/pg@8.20.0)(mysql2@3.23.1(@types/node@26.1.1))(pg@8.22.0))(mysql2@3.23.1(@types/node@26.1.1)))(lru-cache@11.5.2)(ofetch@2.0.0-alpha.3)
     optionalDependencies:
       dotenv: 17.4.2
       jiti: 2.7.0
@@ -13151,6 +13262,8 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
+  sql-escaper@1.5.1: {}
+
   srvx@0.11.22: {}
 
   stackback@0.0.2: {}
@@ -13495,10 +13608,10 @@ snapshots:
       rolldown: 1.2.0
       vite: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.7)(sass@1.101.0)(stylus@0.62.0)(tsx@4.23.1)(yaml@2.9.0)
 
-  unstorage@2.0.0-alpha.7(chokidar@5.0.0)(db0@0.3.4(drizzle-orm@0.45.2(@types/pg@8.20.0)(pg@8.22.0)))(lru-cache@11.5.2)(ofetch@2.0.0-alpha.3):
+  unstorage@2.0.0-alpha.7(chokidar@5.0.0)(db0@0.3.4(drizzle-orm@0.45.2(@types/pg@8.20.0)(mysql2@3.23.1(@types/node@26.1.1))(pg@8.22.0))(mysql2@3.23.1(@types/node@26.1.1)))(lru-cache@11.5.2)(ofetch@2.0.0-alpha.3):
     optionalDependencies:
       chokidar: 5.0.0
-      db0: 0.3.4(drizzle-orm@0.45.2(@types/pg@8.20.0)(pg@8.22.0))
+      db0: 0.3.4(drizzle-orm@0.45.2(@types/pg@8.20.0)(mysql2@3.23.1(@types/node@26.1.1))(pg@8.22.0))(mysql2@3.23.1(@types/node@26.1.1))
       lru-cache: 11.5.2
       ofetch: 2.0.0-alpha.3
 


### PR DESCRIPTION
Phase 2, PR 1 of 3 for the MySQL adapter program. Tasks 6–8 of
[`specs/2026-07-24-db-mysql-adapter-plan.md`](https://github.com/Byline-CMS/bylinecms.dev/blob/develop/specs/2026-07-24-db-mysql-adapter-plan.md).

Part of #42. Builds on Phase 1 (#41, released in v4.7.0) and the `classifyError` seam (#45/#46).

## What's here

| Task | |
|---|---|
| 6 | MySQL database provisioning — `common.sh` URL parser, `db_init.sh` / `db_init_test.sh`, `db-reset.sql.template`, `.env` conventions, root `db:init:test:mysql` |
| 7 | Package skeleton — mysql2 pool, `assertMySqlVersion` (8.0.14+ floor, MariaDB rejected), `DBManagerImpl`/`TXManagerImpl` pinned to READ COMMITTED, stub adapter |
| 8 | Schema — 23 tables, 33 named FKs, both `ROW_NUMBER()` current-document views, admin/auth tables, migration stream, `sql/README.md`, schema pins |

The adapter is **deliberately non-functional**: every `commands.*` / `queries.*` member throws, naming the task that implements it (9 storage commands, 10 queries, 11 counters/audit). Tasks 9–12 land in PR 2, Tasks 13–15 in PR 3.

## Two changes that reach beyond the new package

**1. `@byline/db-postgres` `db_init.sh` — behaviour change, changeset included.**

Neither adapter's `common.sh` percent-decoded the connection-string userinfo, but both drivers do. A password written `pa%40ss` had `db_init.sh` create the role with the literal `pa%40ss` while the adapter connected as `pa@ss`. Fixed in both adapters; malformed `%` escapes are now rejected with a clear message rather than passed through.

Guard: `packages/db-postgres` `test:integration` re-run at **173/173**, matching the Phase 1 baseline.

**2. `utf8mb4_bin` pinned on `byline_document_paths.path`.**

MySQL's default `utf8mb4_0900_ai_ci` would have made the path unique key case- and accent-insensitive, so `/About` and `/about` collide on MySQL but not Postgres. Testing against MySQL 9.7.1 showed `ai_ci` also collapses combining marks Byline's slugifier deliberately preserves — `กา` = `ก่า` (Thai), `कान` = `कानं` (Devanagari), `שלום` = `שָׁלוֹם` (Hebrew), against `slugify.ts:101` which folds Latin diacritics but keeps non-Latin marks.

Pinning `utf8mb4_bin` keeps both adapters identical today. Store value columns keep `ai_ci` — the accent-insensitive `LIKE` divergence was elected deliberately in the design spec.

The broader question this exposed — that manual path overrides skip the slugifier entirely, so `/About` and `/about` are two documents on **both** adapters — is filed as #48.

## Deviations from the plan

- **`field_path` is `varchar(500)`, not the plan's 512.** The plan described the Postgres column as `text`; it is `varchar(500)`. At 512 the sibling `parent_path` — which holds a *prefix* of `field_path` — stayed at 500, making `ER_DATA_TOO_LONG` reachable on MySQL only.
- **All 33 foreign keys explicitly named** `fk_<table>_<column>`. Drizzle-kit's auto-names exceed MySQL's 64-character identifier cap where Postgres silently truncates (one auto-named to 79 chars).
- **Three Postgres-only indexes dropped** — `idx_text_fulltext`, `idx_json_value_gin`, `idx_json_keys`. Verified unreferenced by any query the adapter emits; the `query` path is a leading-wildcard `ILIKE`, which cannot use a GIN tsvector index. MySQL FULLTEXT is a Task 15 follow-up.
- **Env var is `BYLINE_DB_MYSQL_CONNECTION_STRING`**, mirroring the Postgres convention rather than the plan's `BYLINE_MYSQL_DATABASE_URL`.
- **`mysql/docker-compose.yml` left as committed in `d46656fa`**, mirroring the `postgres/` helper's conventions rather than the plan's pinned-image/healthcheck text. The engine floor is enforced by the boot check; CI pins `mysql:8.0` in Task 14.

## Verification

- Schema pins **258/258**, output pristine
- From-scratch `db_init.sh` + `drizzle:migrate` clean; `information_schema` cross-checks match the pins
- `pnpm typecheck`, `pnpm lint`, `pnpm knip` clean workspace-wide
- `pnpm test:integration` from the repo root exits 0 — db-postgres 173/173, client 142/142

## Notes for review

- The schema pins are the safety instrument here: they compute worst-case InnoDB index key widths from the column definitions, so a future column widening trips a test rather than a failed migration. The binding constraint is the non-unique `idx_text_path_value` at 2764 bytes against the 3072-byte cap — not any unique key.
- `packages/db-mysql/README.md`, the docs updates and the `@byline/db-mysql` changeset are deliberately Task 15.