### PR TITLE
feat(db-mysql): storage commands, queries, counters, audit and admin repositories

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -11,6 +11,7 @@
       "@byline/client",
       "@byline/core",
       "@byline/db-postgres",
+      "@byline/db-mysql",
       "@byline/generated-types",
       "@byline/host-tanstack-start",
       "@byline/i18n",

--- a/packages/db-conformance/src/classify-error-contract.ts
+++ b/packages/db-conformance/src/classify-error-contract.ts
@@ -1,0 +1,79 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import { type DbErrorClassification, DbErrorCodes } from '@byline/core'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * One adapter's contribution to the shared `classifyError` contract matrix
+ * (carry-forward from the #45 review). Each canonical adapter (db-postgres,
+ * db-mysql) wires this from its own `.test.node.ts` file, passing its own
+ * `classifyError` and a realistic driver error representing the *same*
+ * logical failure: a duplicate-key collision on the
+ * `idx_document_paths_collection_locale_path` unique index/constraint
+ * (each adapter's `src/database/schema/index.ts`). Running every adapter's case
+ * through one shared assertion set is what keeps the two classifiers from
+ * silently drifting apart — the whole point of the `classifyError` seam is
+ * that core never learns driver anatomy, which only holds if every adapter
+ * reports the same shape for the same failure.
+ */
+export interface ClassifyErrorContractCase {
+  /** Short label for the `describe` block, e.g. 'postgres' / 'mysql'. */
+  adapterName: string
+  classifyError: (err: unknown) => DbErrorClassification
+  /**
+   * A realistic driver error for a duplicate-key collision on
+   * `idx_document_paths_collection_locale_path`, with no `cause` chain —
+   * the raw driver error shape as it would surface directly.
+   */
+  uniqueViolationError: unknown
+  /**
+   * The same failure, nested inside a Drizzle-style `cause` chain
+   * (`DrizzleQueryError` wrapping the driver error) — the shape
+   * `classifyError` actually receives in production.
+   */
+  nestedUniqueViolationError: unknown
+  /** A realistic but unrelated driver error (e.g. a foreign-key violation). */
+  unrelatedError: unknown
+}
+
+/**
+ * Run the shared `classifyError` contract against every case supplied.
+ * No database required — every input is a synthetic driver-error fixture.
+ */
+export function runClassifyErrorContract(cases: ClassifyErrorContractCase[]): void {
+  describe.each(cases)(
+    'classifyError contract ($adapterName)',
+    ({ classifyError, uniqueViolationError, nestedUniqueViolationError, unrelatedError }) => {
+      it('classifies a unique violation with the bare index name', () => {
+        expect(classifyError(uniqueViolationError)).toEqual({
+          code: DbErrorCodes.UNIQUE_VIOLATION,
+          constraint: 'idx_document_paths_collection_locale_path',
+        })
+      })
+
+      it('classifies a unique violation nested inside a Drizzle-style cause chain', () => {
+        expect(classifyError(nestedUniqueViolationError)).toEqual({
+          code: DbErrorCodes.UNIQUE_VIOLATION,
+          constraint: 'idx_document_paths_collection_locale_path',
+        })
+      })
+
+      it('classifies an unrelated error as UNKNOWN', () => {
+        expect(classifyError(unrelatedError)).toEqual({ code: DbErrorCodes.UNKNOWN })
+      })
+
+      it('does not throw on a non-Error value', () => {
+        expect(() => classifyError(null)).not.toThrow()
+        expect(() => classifyError('boom')).not.toThrow()
+        expect(classifyError(null)).toEqual({ code: DbErrorCodes.UNKNOWN })
+        expect(classifyError('boom')).toEqual({ code: DbErrorCodes.UNKNOWN })
+      })
+    }
+  )
+}

--- a/packages/db-conformance/src/index.ts
+++ b/packages/db-conformance/src/index.ts
@@ -25,6 +25,36 @@ import { systemFieldsDirectWriteSuite } from './suites/system-fields-direct-writ
 import { transactionsSuite } from './suites/transactions.js'
 import { versioningSuite } from './suites/versioning.js'
 
+export {
+  type ClassifyErrorContractCase,
+  runClassifyErrorContract,
+} from './classify-error-contract.js'
+/**
+ * Named per-suite exports, additive alongside `runAdapterConformanceSuite`
+ * below. An adapter mid-port (see `packages/db-mysql/tests/conformance.integration.test.ts`)
+ * registers only the suites its current task has turned green, one `import`
+ * per suite, instead of the full `runAdapterConformanceSuite` — which would
+ * otherwise pull in every suite (including ones the adapter can't pass yet)
+ * and turn `pnpm test:integration` red for the whole of the port. Once an
+ * adapter passes every suite, its entry file switches to
+ * `runAdapterConformanceSuite(hooks)` and drops these individual imports —
+ * see the `db-postgres` conformance entry for the target shape.
+ */
+export { adminStoreSuite } from './suites/admin-store.js'
+export { auditSuite } from './suites/audit.js'
+export { countersSuite } from './suites/counters.js'
+export { deleteLocaleSuite } from './suites/delete-locale.js'
+export { documentAvailableLocalesSuite } from './suites/document-available-locales.js'
+export { documentPathsSuite } from './suites/document-paths.js'
+export { documentTreeSuite } from './suites/document-tree.js'
+export { documentTreeAuditSuite } from './suites/document-tree-audit.js'
+export { fieldTypesSuite } from './suites/field-types.js'
+export { localeFallbackSuite } from './suites/locale-fallback.js'
+export { restoreSuite } from './suites/restore.js'
+export { systemFieldsDirectWriteSuite } from './suites/system-fields-direct-write.js'
+export { transactionsSuite } from './suites/transactions.js'
+export { versioningSuite } from './suites/versioning.js'
+
 /**
  * The seam a database adapter implements to run the shared behavioural
  * conformance suite against its own test database. `@byline/db-postgres`

--- a/packages/db-conformance/src/suites/audit.ts
+++ b/packages/db-conformance/src/suites/audit.ts
@@ -164,7 +164,45 @@ const PagesConfig: CollectionDefinition = {
  * sequence, the resulting `occurred_at` ordering is exactly as deterministic
  * as the original fixed-date one — only the *mechanism* for asserting "these
  * rows precede those rows" changed, not the assertions themselves.
+ *
+ * **Clock-resolution requirement (binding on every canonical adapter):** the
+ * boundary between the version-stream writes and the audit-log appends must
+ * be unambiguous regardless of the DB column's own timestamp precision. A
+ * fixed epsilon pad around a captured timestamp is not sufficient to
+ * guarantee that on its own, for two independent reasons found live on this
+ * program (`@byline/db-mysql` Task 11):
+ *
+ *   1. Column precision: on a millisecond-granular clock (MySQL's
+ *      `DATETIME(3)`), two statements issued back-to-back on a fast local
+ *      connection can land in the same tick and receive an identical
+ *      timestamp, so a 1ms pad can be entirely consumed. Fixed by moving
+ *      every instant column in `@byline/db-mysql` to `DATETIME(6)`
+ *      (microsecond, matching pg's own precision) — see that adapter's
+ *      `common.ts`.
+ *   2. **Independent of column precision:** `IAuditQueries.findAuditLog`'s
+ *      `from`/`to` parameters are typed `Date` (`@byline/core`), and a JS
+ *      `Date` cannot represent sub-millisecond time no matter how precise
+ *      the column it was read from is. `versionsEnd`, derived from a `Date`,
+ *      is therefore always effectively millisecond-resolution once it
+ *      becomes a query parameter again — confirmed live: even after moving
+ *      to `DATETIME(6)`, this fixture still failed under real concurrent
+ *      load (`pnpm test:integration` run at the repo root, alongside many
+ *      other packages' tasks) with two different failure shapes across two
+ *      consecutive runs, because the real wall-clock gap between the last
+ *      version write and the first audit append can still land under 1ms.
+ *      Column precision closes reason 1; it cannot close reason 2.
+ *
+ * The fix for both is the same: a real, awaited delay (`sleep`, below)
+ * between the version-stream phase and the audit-append phase, long enough
+ * to dwarf a millisecond — not a larger epsilon pad, which only moves the
+ * same race to a different, still-finite window and does nothing about
+ * reason 2 regardless of size.
  */
+const AUDIT_PHASE_SEPARATION_MS = 20
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
 function activityFeedSuite(hooks: ConformanceHooks): void {
   let adapter: IDbAdapter
   let colA: string
@@ -198,13 +236,19 @@ function activityFeedSuite(hooks: ConformanceHooks): void {
       // client-side `new Date()` read, which would race against the audit
       // appends below (the whole fixture can complete within a single
       // millisecond on a fast local connection, and JS's clock resolution is
-      // only 1ms). `created_at` is a TIMESTAMPTZ(6) (microsecond) column
-      // defaulted by Postgres itself (`common.ts`'s `auditTimestamp`); once
-      // it round-trips through `.returning()` into a JS `Date`, its
-      // microsecond component is truncated, so the row's own `created_at`
-      // can compare *earlier* than the true value stored for that same row.
-      // Padding by 1ms in each direction absorbs exactly that truncation
-      // without needing microsecond-safe (re-)serialization.
+      // only 1ms).
+      //
+      // The 1ms pad below is an **inclusion-only** tolerance, not an
+      // exclusion mechanism: `created_at` on Postgres is a TIMESTAMPTZ(6)
+      // (microsecond) column, and once it round-trips through `.returning()`
+      // into a JS `Date`, its microsecond component is truncated, so the
+      // row's own `created_at` can *read back* earlier than the true stored
+      // value. Without the pad, that truncation could wrongly exclude
+      // `updateA` itself from an inclusive `<=` bound. It does nothing to
+      // guarantee separation from the audit rows appended afterwards — see
+      // the module docblock's clock-resolution requirement, and the
+      // `AUDIT_PHASE_SEPARATION_MS` sleep below, which is what actually
+      // guarantees that separation on every dialect.
       const createA = await adapter.commands.documents.createDocumentVersion({
         collectionId: colA,
         collectionVersion: 1,
@@ -242,6 +286,14 @@ function activityFeedSuite(hooks: ConformanceHooks): void {
         createdBy: actor1,
       })
       versionsEnd = new Date(updateA.document.created_at.getTime() + 1)
+
+      // Guarantee real wall-clock separation between the version-stream
+      // phase and the audit-log phase before appending — see the module
+      // docblock's clock-resolution requirement. This is what makes "the
+      // audit rows land strictly after versionsEnd" actually true on every
+      // dialect and under real concurrent load, rather than a fixed epsilon
+      // pad that a fast (or merely lucky) round trip can consume entirely.
+      await sleep(AUDIT_PHASE_SEPARATION_MS)
 
       // Audit log: a status change on docA (actor1) and a system deletion of docB.
       await adapter.commands.audit.append({

--- a/packages/db-mysql/package.json
+++ b/packages/db-mysql/package.json
@@ -65,7 +65,8 @@
     "@byline/core": "workspace:*",
     "drizzle-orm": "^0.45.2",
     "mysql2": "^3.23.1",
-    "npm-run-all": "^4.1.5"
+    "npm-run-all": "^4.1.5",
+    "uuid": "^14.0.1"
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.4",

--- a/packages/db-mysql/package.json
+++ b/packages/db-mysql/package.json
@@ -62,6 +62,7 @@
     "dist"
   ],
   "dependencies": {
+    "@byline/admin": "workspace:*",
     "@byline/core": "workspace:*",
     "drizzle-orm": "^0.45.2",
     "mysql2": "^3.23.1",

--- a/packages/db-mysql/src/database/migrations/0001_burly_slyde.sql
+++ b/packages/db-mysql/src/database/migrations/0001_burly_slyde.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `byline_counter_groups` ADD `current_value` bigint DEFAULT 0 NOT NULL;

--- a/packages/db-mysql/src/database/migrations/0002_furry_silverclaw.sql
+++ b/packages/db-mysql/src/database/migrations/0002_furry_silverclaw.sql
@@ -1,0 +1,47 @@
+ALTER TABLE `byline_admin_permissions` MODIFY COLUMN `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6);--> statement-breakpoint
+ALTER TABLE `byline_admin_permissions` MODIFY COLUMN `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6);--> statement-breakpoint
+ALTER TABLE `byline_admin_refresh_tokens` MODIFY COLUMN `issued_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6);--> statement-breakpoint
+ALTER TABLE `byline_admin_refresh_tokens` MODIFY COLUMN `expires_at` datetime(6) NOT NULL;--> statement-breakpoint
+ALTER TABLE `byline_admin_refresh_tokens` MODIFY COLUMN `revoked_at` datetime(6);--> statement-breakpoint
+ALTER TABLE `byline_admin_refresh_tokens` MODIFY COLUMN `last_used_at` datetime(6);--> statement-breakpoint
+ALTER TABLE `byline_admin_refresh_tokens` MODIFY COLUMN `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6);--> statement-breakpoint
+ALTER TABLE `byline_admin_refresh_tokens` MODIFY COLUMN `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6);--> statement-breakpoint
+ALTER TABLE `byline_admin_role_admin_user` MODIFY COLUMN `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6);--> statement-breakpoint
+ALTER TABLE `byline_admin_roles` MODIFY COLUMN `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6);--> statement-breakpoint
+ALTER TABLE `byline_admin_roles` MODIFY COLUMN `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6);--> statement-breakpoint
+ALTER TABLE `byline_admin_user_preferences` MODIFY COLUMN `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6);--> statement-breakpoint
+ALTER TABLE `byline_admin_user_preferences` MODIFY COLUMN `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6);--> statement-breakpoint
+ALTER TABLE `byline_admin_users` MODIFY COLUMN `last_login` datetime(6);--> statement-breakpoint
+ALTER TABLE `byline_admin_users` MODIFY COLUMN `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6);--> statement-breakpoint
+ALTER TABLE `byline_admin_users` MODIFY COLUMN `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6);--> statement-breakpoint
+ALTER TABLE `byline_audit_log` MODIFY COLUMN `occurred_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6);--> statement-breakpoint
+ALTER TABLE `byline_store_boolean` MODIFY COLUMN `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6);--> statement-breakpoint
+ALTER TABLE `byline_store_boolean` MODIFY COLUMN `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6);--> statement-breakpoint
+ALTER TABLE `byline_collections` MODIFY COLUMN `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6);--> statement-breakpoint
+ALTER TABLE `byline_collections` MODIFY COLUMN `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6);--> statement-breakpoint
+ALTER TABLE `byline_counter_groups` MODIFY COLUMN `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6);--> statement-breakpoint
+ALTER TABLE `byline_store_datetime` MODIFY COLUMN `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6);--> statement-breakpoint
+ALTER TABLE `byline_store_datetime` MODIFY COLUMN `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6);--> statement-breakpoint
+ALTER TABLE `byline_store_datetime` MODIFY COLUMN `value_timestamp_tz` datetime(6);--> statement-breakpoint
+ALTER TABLE `byline_document_available_locales` MODIFY COLUMN `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6);--> statement-breakpoint
+ALTER TABLE `byline_document_available_locales` MODIFY COLUMN `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6);--> statement-breakpoint
+ALTER TABLE `byline_document_paths` MODIFY COLUMN `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6);--> statement-breakpoint
+ALTER TABLE `byline_document_paths` MODIFY COLUMN `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6);--> statement-breakpoint
+ALTER TABLE `byline_document_relationships` MODIFY COLUMN `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6);--> statement-breakpoint
+ALTER TABLE `byline_document_relationships` MODIFY COLUMN `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6);--> statement-breakpoint
+ALTER TABLE `byline_document_versions` MODIFY COLUMN `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6);--> statement-breakpoint
+ALTER TABLE `byline_document_versions` MODIFY COLUMN `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6);--> statement-breakpoint
+ALTER TABLE `byline_documents` MODIFY COLUMN `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6);--> statement-breakpoint
+ALTER TABLE `byline_documents` MODIFY COLUMN `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6);--> statement-breakpoint
+ALTER TABLE `byline_store_file` MODIFY COLUMN `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6);--> statement-breakpoint
+ALTER TABLE `byline_store_file` MODIFY COLUMN `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6);--> statement-breakpoint
+ALTER TABLE `byline_store_json` MODIFY COLUMN `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6);--> statement-breakpoint
+ALTER TABLE `byline_store_json` MODIFY COLUMN `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6);--> statement-breakpoint
+ALTER TABLE `byline_store_meta` MODIFY COLUMN `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6);--> statement-breakpoint
+ALTER TABLE `byline_store_meta` MODIFY COLUMN `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6);--> statement-breakpoint
+ALTER TABLE `byline_store_numeric` MODIFY COLUMN `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6);--> statement-breakpoint
+ALTER TABLE `byline_store_numeric` MODIFY COLUMN `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6);--> statement-breakpoint
+ALTER TABLE `byline_store_relation` MODIFY COLUMN `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6);--> statement-breakpoint
+ALTER TABLE `byline_store_relation` MODIFY COLUMN `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6);--> statement-breakpoint
+ALTER TABLE `byline_store_text` MODIFY COLUMN `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6);--> statement-breakpoint
+ALTER TABLE `byline_store_text` MODIFY COLUMN `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6);

--- a/packages/db-mysql/src/database/migrations/meta/0001_snapshot.json
+++ b/packages/db-mysql/src/database/migrations/meta/0001_snapshot.json
@@ -1,0 +1,3190 @@
+{
+  "version": "5",
+  "dialect": "mysql",
+  "id": "9be23d30-e5db-49fb-b6e9-c880b8ab3313",
+  "prevId": "54b6ad03-c719-4832-a3f2-32cc0fd2794d",
+  "tables": {
+    "byline_admin_permissions": {
+      "name": "byline_admin_permissions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "vid": {
+          "name": "vid",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "admin_role_id": {
+          "name": "admin_role_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ability": {
+          "name": "ability",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "idx_byline_admin_permissions_role": {
+          "name": "idx_byline_admin_permissions_role",
+          "columns": [
+            "admin_role_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "fk_admin_permissions_admin_role_id": {
+          "name": "fk_admin_permissions_admin_role_id",
+          "tableFrom": "byline_admin_permissions",
+          "tableTo": "byline_admin_roles",
+          "columnsFrom": [
+            "admin_role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "byline_admin_permissions_id": {
+          "name": "byline_admin_permissions_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "uq_byline_admin_permissions_role_ability": {
+          "name": "uq_byline_admin_permissions_role_ability",
+          "columns": [
+            "admin_role_id",
+            "ability"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "byline_admin_refresh_tokens": {
+      "name": "byline_admin_refresh_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rotated_to_id": {
+          "name": "rotated_to_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "idx_byline_admin_refresh_tokens_user": {
+          "name": "idx_byline_admin_refresh_tokens_user",
+          "columns": [
+            "admin_user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_byline_admin_refresh_tokens_token_hash": {
+          "name": "idx_byline_admin_refresh_tokens_token_hash",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "fk_admin_refresh_tokens_admin_user_id": {
+          "name": "fk_admin_refresh_tokens_admin_user_id",
+          "tableFrom": "byline_admin_refresh_tokens",
+          "tableTo": "byline_admin_users",
+          "columnsFrom": [
+            "admin_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "byline_admin_refresh_tokens_id": {
+          "name": "byline_admin_refresh_tokens_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "byline_admin_refresh_tokens_token_hash_unique": {
+          "name": "byline_admin_refresh_tokens_token_hash_unique",
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "byline_admin_role_admin_user": {
+      "name": "byline_admin_role_admin_user",
+      "columns": {
+        "admin_role_id": {
+          "name": "admin_role_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "idx_byline_admin_role_admin_user_user": {
+          "name": "idx_byline_admin_role_admin_user_user",
+          "columns": [
+            "admin_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "fk_admin_role_admin_user_admin_role_id": {
+          "name": "fk_admin_role_admin_user_admin_role_id",
+          "tableFrom": "byline_admin_role_admin_user",
+          "tableTo": "byline_admin_roles",
+          "columnsFrom": [
+            "admin_role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_admin_role_admin_user_admin_user_id": {
+          "name": "fk_admin_role_admin_user_admin_user_id",
+          "tableFrom": "byline_admin_role_admin_user",
+          "tableTo": "byline_admin_users",
+          "columnsFrom": [
+            "admin_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "byline_admin_role_admin_user_admin_role_id_admin_user_id_pk": {
+          "name": "byline_admin_role_admin_user_admin_role_id_admin_user_id_pk",
+          "columns": [
+            "admin_role_id",
+            "admin_user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "byline_admin_roles": {
+      "name": "byline_admin_roles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "vid": {
+          "name": "vid",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "machine_name": {
+          "name": "machine_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "idx_byline_admin_roles_machine_name": {
+          "name": "idx_byline_admin_roles_machine_name",
+          "columns": [
+            "machine_name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "byline_admin_roles_id": {
+          "name": "byline_admin_roles_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "byline_admin_roles_machine_name_unique": {
+          "name": "byline_admin_roles_machine_name_unique",
+          "columns": [
+            "machine_name"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "byline_admin_user_preferences": {
+      "name": "byline_admin_user_preferences",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fk_admin_user_preferences_user_id": {
+          "name": "fk_admin_user_preferences_user_id",
+          "tableFrom": "byline_admin_user_preferences",
+          "tableTo": "byline_admin_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "byline_admin_user_preferences_user_id_scope_pk": {
+          "name": "byline_admin_user_preferences_user_id_scope_pk",
+          "columns": [
+            "user_id",
+            "scope"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "byline_admin_users": {
+      "name": "byline_admin_users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "vid": {
+          "name": "vid",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "given_name": {
+          "name": "given_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "family_name": {
+          "name": "family_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(254)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remember_me": {
+          "name": "remember_me",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "last_login": {
+          "name": "last_login",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_login_ip": {
+          "name": "last_login_ip",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failed_login_attempts": {
+          "name": "failed_login_attempts",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_super_admin": {
+          "name": "is_super_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_email_verified": {
+          "name": "is_email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "preferred_locale": {
+          "name": "preferred_locale",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "idx_byline_admin_users_email": {
+          "name": "idx_byline_admin_users_email",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "byline_admin_users_id": {
+          "name": "byline_admin_users_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "byline_admin_users_username_unique": {
+          "name": "byline_admin_users_username_unique",
+          "columns": [
+            "username"
+          ]
+        },
+        "byline_admin_users_email_unique": {
+          "name": "byline_admin_users_email_unique",
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "byline_audit_log": {
+      "name": "byline_audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_realm": {
+          "name": "actor_realm",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field": {
+          "name": "field",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "before": {
+          "name": "before",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "after": {
+          "name": "after",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "idx_audit_log_document_id": {
+          "name": "idx_audit_log_document_id",
+          "columns": [
+            "document_id",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "idx_audit_log_actor_id": {
+          "name": "idx_audit_log_actor_id",
+          "columns": [
+            "actor_id",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "idx_audit_log_action": {
+          "name": "idx_audit_log_action",
+          "columns": [
+            "action",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "byline_audit_log_id": {
+          "name": "byline_audit_log_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "byline_store_boolean": {
+      "name": "byline_store_boolean",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_version_id": {
+          "name": "document_version_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_path": {
+          "name": "field_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_name": {
+          "name": "field_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "parent_path": {
+          "name": "parent_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "value": {
+          "name": "value",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_boolean_value": {
+          "name": "idx_boolean_value",
+          "columns": [
+            "value"
+          ],
+          "isUnique": false
+        },
+        "idx_boolean_path_value": {
+          "name": "idx_boolean_path_value",
+          "columns": [
+            "field_path",
+            "value"
+          ],
+          "isUnique": false
+        },
+        "idx_boolean_collection_value": {
+          "name": "idx_boolean_collection_value",
+          "columns": [
+            "collection_id",
+            "field_path",
+            "value"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "fk_store_boolean_document_version_id": {
+          "name": "fk_store_boolean_document_version_id",
+          "tableFrom": "byline_store_boolean",
+          "tableTo": "byline_document_versions",
+          "columnsFrom": [
+            "document_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_store_boolean_collection_id": {
+          "name": "fk_store_boolean_collection_id",
+          "tableFrom": "byline_store_boolean",
+          "tableTo": "byline_collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "byline_store_boolean_id": {
+          "name": "byline_store_boolean_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_boolean_field": {
+          "name": "unique_boolean_field",
+          "columns": [
+            "document_version_id",
+            "field_path",
+            "locale"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "byline_collections": {
+      "name": "byline_collections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "singular": {
+          "name": "singular",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plural": {
+          "name": "plural",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "schema_hash": {
+          "name": "schema_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "byline_collections_id": {
+          "name": "byline_collections_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "byline_collections_path_unique": {
+          "name": "byline_collections_path_unique",
+          "columns": [
+            "path"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "byline_counter_groups": {
+      "name": "byline_counter_groups",
+      "columns": {
+        "group_name": {
+          "name": "group_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence_name": {
+          "name": "sequence_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_value": {
+          "name": "current_value",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "byline_counter_groups_group_name": {
+          "name": "byline_counter_groups_group_name",
+          "columns": [
+            "group_name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "byline_store_datetime": {
+      "name": "byline_store_datetime",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_version_id": {
+          "name": "document_version_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_path": {
+          "name": "field_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_name": {
+          "name": "field_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "parent_path": {
+          "name": "parent_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "date_type": {
+          "name": "date_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value_date": {
+          "name": "value_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "value_time": {
+          "name": "value_time",
+          "type": "time(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "value_timestamp_tz": {
+          "name": "value_timestamp_tz",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_datetime_date": {
+          "name": "idx_datetime_date",
+          "columns": [
+            "value_date"
+          ],
+          "isUnique": false
+        },
+        "idx_datetime_timestamp_tz": {
+          "name": "idx_datetime_timestamp_tz",
+          "columns": [
+            "value_timestamp_tz"
+          ],
+          "isUnique": false
+        },
+        "idx_datetime_path_date": {
+          "name": "idx_datetime_path_date",
+          "columns": [
+            "field_path",
+            "value_timestamp_tz"
+          ],
+          "isUnique": false
+        },
+        "idx_datetime_collection_date": {
+          "name": "idx_datetime_collection_date",
+          "columns": [
+            "collection_id",
+            "value_timestamp_tz"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "fk_store_datetime_document_version_id": {
+          "name": "fk_store_datetime_document_version_id",
+          "tableFrom": "byline_store_datetime",
+          "tableTo": "byline_document_versions",
+          "columnsFrom": [
+            "document_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_store_datetime_collection_id": {
+          "name": "fk_store_datetime_collection_id",
+          "tableFrom": "byline_store_datetime",
+          "tableTo": "byline_collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "byline_store_datetime_id": {
+          "name": "byline_store_datetime_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_datetime_field": {
+          "name": "unique_datetime_field",
+          "columns": [
+            "document_version_id",
+            "field_path",
+            "locale"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "byline_document_available_locales": {
+      "name": "byline_document_available_locales",
+      "columns": {
+        "document_id": {
+          "name": "document_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "idx_document_available_locales_document_id": {
+          "name": "idx_document_available_locales_document_id",
+          "columns": [
+            "document_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "fk_document_available_locales_document_id": {
+          "name": "fk_document_available_locales_document_id",
+          "tableFrom": "byline_document_available_locales",
+          "tableTo": "byline_documents",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_document_available_locales_collection_id": {
+          "name": "fk_document_available_locales_collection_id",
+          "tableFrom": "byline_document_available_locales",
+          "tableTo": "byline_collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "byline_document_available_locales_document_id_locale_pk": {
+          "name": "byline_document_available_locales_document_id_locale_pk",
+          "columns": [
+            "document_id",
+            "locale"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "byline_document_paths": {
+      "name": "byline_document_paths",
+      "columns": {
+        "document_id": {
+          "name": "document_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(255) COLLATE utf8mb4_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "idx_document_paths_document_id": {
+          "name": "idx_document_paths_document_id",
+          "columns": [
+            "document_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "fk_document_paths_document_id": {
+          "name": "fk_document_paths_document_id",
+          "tableFrom": "byline_document_paths",
+          "tableTo": "byline_documents",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_document_paths_collection_id": {
+          "name": "fk_document_paths_collection_id",
+          "tableFrom": "byline_document_paths",
+          "tableTo": "byline_collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_document_paths_document_locale": {
+          "name": "unique_document_paths_document_locale",
+          "columns": [
+            "document_id",
+            "locale"
+          ]
+        },
+        "idx_document_paths_collection_locale_path": {
+          "name": "idx_document_paths_collection_locale_path",
+          "columns": [
+            "collection_id",
+            "locale",
+            "path"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "byline_document_relationships": {
+      "name": "byline_document_relationships",
+      "columns": {
+        "child_document_id": {
+          "name": "child_document_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_document_id": {
+          "name": "parent_document_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "varchar(128) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "idx_document_relationships_parent_order": {
+          "name": "idx_document_relationships_parent_order",
+          "columns": [
+            "parent_document_id",
+            "order_key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "fk_document_relationships_child_document_id": {
+          "name": "fk_document_relationships_child_document_id",
+          "tableFrom": "byline_document_relationships",
+          "tableTo": "byline_documents",
+          "columnsFrom": [
+            "child_document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_document_relationships_parent_document_id": {
+          "name": "fk_document_relationships_parent_document_id",
+          "tableFrom": "byline_document_relationships",
+          "tableTo": "byline_documents",
+          "columnsFrom": [
+            "parent_document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_document_relationships_child": {
+          "name": "uq_document_relationships_child",
+          "columns": [
+            "child_document_id"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "byline_document_version_locales": {
+      "name": "byline_document_version_locales",
+      "columns": {
+        "document_version_id": {
+          "name": "document_version_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fk_document_version_locales_document_version_id": {
+          "name": "fk_document_version_locales_document_version_id",
+          "tableFrom": "byline_document_version_locales",
+          "tableTo": "byline_document_versions",
+          "columnsFrom": [
+            "document_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "byline_document_version_locales_document_version_id_locale_pk": {
+          "name": "byline_document_version_locales_document_version_id_locale_pk",
+          "columns": [
+            "document_version_id",
+            "locale"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "byline_document_versions": {
+      "name": "byline_document_versions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection_version": {
+          "name": "collection_version",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "doc": {
+          "name": "doc",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'create'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "change_summary": {
+          "name": "change_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_documents_document_id": {
+          "name": "idx_documents_document_id",
+          "columns": [
+            "document_id"
+          ],
+          "isUnique": false
+        },
+        "idx_documents_collection_document_deleted": {
+          "name": "idx_documents_collection_document_deleted",
+          "columns": [
+            "collection_id",
+            "document_id",
+            "is_deleted"
+          ],
+          "isUnique": false
+        },
+        "idx_documents_current_view": {
+          "name": "idx_documents_current_view",
+          "columns": [
+            "collection_id",
+            "document_id",
+            "is_deleted",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "idx_documents_event_type": {
+          "name": "idx_documents_event_type",
+          "columns": [
+            "event_type"
+          ],
+          "isUnique": false
+        },
+        "idx_documents_created_at": {
+          "name": "idx_documents_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_documents_document_collection": {
+          "name": "idx_documents_document_collection",
+          "columns": [
+            "document_id",
+            "collection_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "fk_document_versions_document_id": {
+          "name": "fk_document_versions_document_id",
+          "tableFrom": "byline_document_versions",
+          "tableTo": "byline_documents",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_document_versions_collection_id": {
+          "name": "fk_document_versions_collection_id",
+          "tableFrom": "byline_document_versions",
+          "tableTo": "byline_collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "byline_document_versions_id": {
+          "name": "byline_document_versions_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "byline_documents": {
+      "name": "byline_documents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "varchar(128) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_locale": {
+          "name": "source_locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "idx_documents_collection": {
+          "name": "idx_documents_collection",
+          "columns": [
+            "collection_id"
+          ],
+          "isUnique": false
+        },
+        "idx_documents_collection_order": {
+          "name": "idx_documents_collection_order",
+          "columns": [
+            "collection_id",
+            "order_key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "fk_documents_collection_id": {
+          "name": "fk_documents_collection_id",
+          "tableFrom": "byline_documents",
+          "tableTo": "byline_collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "byline_documents_id": {
+          "name": "byline_documents_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "byline_store_file": {
+      "name": "byline_store_file",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_version_id": {
+          "name": "document_version_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_path": {
+          "name": "field_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_name": {
+          "name": "field_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "parent_path": {
+          "name": "parent_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_filename": {
+          "name": "original_filename",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "storage_provider": {
+          "name": "storage_provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "storage_url": {
+          "name": "storage_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_width": {
+          "name": "image_width",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_height": {
+          "name": "image_height",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_format": {
+          "name": "image_format",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "processing_status": {
+          "name": "processing_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "thumbnail_generated": {
+          "name": "thumbnail_generated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "variants": {
+          "name": "variants",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_file_file_id": {
+          "name": "idx_file_file_id",
+          "columns": [
+            "file_id"
+          ],
+          "isUnique": false
+        },
+        "idx_file_mime_type": {
+          "name": "idx_file_mime_type",
+          "columns": [
+            "mime_type"
+          ],
+          "isUnique": false
+        },
+        "idx_file_size": {
+          "name": "idx_file_size",
+          "columns": [
+            "file_size"
+          ],
+          "isUnique": false
+        },
+        "idx_file_hash": {
+          "name": "idx_file_hash",
+          "columns": [
+            "file_hash"
+          ],
+          "isUnique": false
+        },
+        "idx_file_image_dimensions": {
+          "name": "idx_file_image_dimensions",
+          "columns": [
+            "image_width",
+            "image_height"
+          ],
+          "isUnique": false
+        },
+        "idx_file_storage_provider": {
+          "name": "idx_file_storage_provider",
+          "columns": [
+            "storage_provider"
+          ],
+          "isUnique": false
+        },
+        "idx_file_processing_status": {
+          "name": "idx_file_processing_status",
+          "columns": [
+            "processing_status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "fk_store_file_document_version_id": {
+          "name": "fk_store_file_document_version_id",
+          "tableFrom": "byline_store_file",
+          "tableTo": "byline_document_versions",
+          "columnsFrom": [
+            "document_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_store_file_collection_id": {
+          "name": "fk_store_file_collection_id",
+          "tableFrom": "byline_store_file",
+          "tableTo": "byline_collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "byline_store_file_id": {
+          "name": "byline_store_file_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_file_field": {
+          "name": "unique_file_field",
+          "columns": [
+            "document_version_id",
+            "field_path",
+            "locale"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "byline_store_json": {
+      "name": "byline_store_json",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_version_id": {
+          "name": "document_version_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_path": {
+          "name": "field_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_name": {
+          "name": "field_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "parent_path": {
+          "name": "parent_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "value": {
+          "name": "value",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "json_schema": {
+          "name": "json_schema",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "object_keys": {
+          "name": "object_keys",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_json_schema": {
+          "name": "idx_json_schema",
+          "columns": [
+            "json_schema"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "fk_store_json_document_version_id": {
+          "name": "fk_store_json_document_version_id",
+          "tableFrom": "byline_store_json",
+          "tableTo": "byline_document_versions",
+          "columnsFrom": [
+            "document_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_store_json_collection_id": {
+          "name": "fk_store_json_collection_id",
+          "tableFrom": "byline_store_json",
+          "tableTo": "byline_collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "byline_store_json_id": {
+          "name": "byline_store_json_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_json_field": {
+          "name": "unique_json_field",
+          "columns": [
+            "document_version_id",
+            "field_path",
+            "locale"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "byline_store_meta": {
+      "name": "byline_store_meta",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_version_id": {
+          "name": "document_version_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "idx_meta_document_type_path": {
+          "name": "idx_meta_document_type_path",
+          "columns": [
+            "document_version_id",
+            "type",
+            "path"
+          ],
+          "isUnique": false
+        },
+        "idx_meta_item_id": {
+          "name": "idx_meta_item_id",
+          "columns": [
+            "item_id"
+          ],
+          "isUnique": false
+        },
+        "idx_meta_collection_type": {
+          "name": "idx_meta_collection_type",
+          "columns": [
+            "collection_id",
+            "type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "fk_store_meta_document_version_id": {
+          "name": "fk_store_meta_document_version_id",
+          "tableFrom": "byline_store_meta",
+          "tableTo": "byline_document_versions",
+          "columnsFrom": [
+            "document_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_store_meta_collection_id": {
+          "name": "fk_store_meta_collection_id",
+          "tableFrom": "byline_store_meta",
+          "tableTo": "byline_collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "byline_store_meta_id": {
+          "name": "byline_store_meta_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_meta_node": {
+          "name": "unique_meta_node",
+          "columns": [
+            "document_version_id",
+            "type",
+            "path"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "byline_store_numeric": {
+      "name": "byline_store_numeric",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_version_id": {
+          "name": "document_version_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_path": {
+          "name": "field_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_name": {
+          "name": "field_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "parent_path": {
+          "name": "parent_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "number_type": {
+          "name": "number_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value_integer": {
+          "name": "value_integer",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "value_decimal": {
+          "name": "value_decimal",
+          "type": "decimal(10,2)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "value_float": {
+          "name": "value_float",
+          "type": "float",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_numeric_integer": {
+          "name": "idx_numeric_integer",
+          "columns": [
+            "value_integer"
+          ],
+          "isUnique": false
+        },
+        "idx_numeric_decimal": {
+          "name": "idx_numeric_decimal",
+          "columns": [
+            "value_decimal"
+          ],
+          "isUnique": false
+        },
+        "idx_numeric_float": {
+          "name": "idx_numeric_float",
+          "columns": [
+            "value_float"
+          ],
+          "isUnique": false
+        },
+        "idx_numeric_integer_range": {
+          "name": "idx_numeric_integer_range",
+          "columns": [
+            "field_path",
+            "value_integer"
+          ],
+          "isUnique": false
+        },
+        "idx_numeric_decimal_range": {
+          "name": "idx_numeric_decimal_range",
+          "columns": [
+            "field_path",
+            "value_decimal"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "fk_store_numeric_document_version_id": {
+          "name": "fk_store_numeric_document_version_id",
+          "tableFrom": "byline_store_numeric",
+          "tableTo": "byline_document_versions",
+          "columnsFrom": [
+            "document_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_store_numeric_collection_id": {
+          "name": "fk_store_numeric_collection_id",
+          "tableFrom": "byline_store_numeric",
+          "tableTo": "byline_collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "byline_store_numeric_id": {
+          "name": "byline_store_numeric_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_numeric_field": {
+          "name": "unique_numeric_field",
+          "columns": [
+            "document_version_id",
+            "field_path",
+            "locale"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "byline_store_relation": {
+      "name": "byline_store_relation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_version_id": {
+          "name": "document_version_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_path": {
+          "name": "field_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_name": {
+          "name": "field_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "parent_path": {
+          "name": "parent_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "target_document_id": {
+          "name": "target_document_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_collection_id": {
+          "name": "target_collection_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "relationship_type": {
+          "name": "relationship_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'reference'"
+        },
+        "cascade_delete": {
+          "name": "cascade_delete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "idx_relation_target_document": {
+          "name": "idx_relation_target_document",
+          "columns": [
+            "target_document_id"
+          ],
+          "isUnique": false
+        },
+        "idx_relation_target_collection": {
+          "name": "idx_relation_target_collection",
+          "columns": [
+            "target_collection_id"
+          ],
+          "isUnique": false
+        },
+        "idx_relation_type": {
+          "name": "idx_relation_type",
+          "columns": [
+            "relationship_type"
+          ],
+          "isUnique": false
+        },
+        "idx_relation_reverse": {
+          "name": "idx_relation_reverse",
+          "columns": [
+            "target_document_id",
+            "field_path"
+          ],
+          "isUnique": false
+        },
+        "idx_relation_collection_to_collection": {
+          "name": "idx_relation_collection_to_collection",
+          "columns": [
+            "collection_id",
+            "target_collection_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "fk_store_relation_document_version_id": {
+          "name": "fk_store_relation_document_version_id",
+          "tableFrom": "byline_store_relation",
+          "tableTo": "byline_document_versions",
+          "columnsFrom": [
+            "document_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_store_relation_collection_id": {
+          "name": "fk_store_relation_collection_id",
+          "tableFrom": "byline_store_relation",
+          "tableTo": "byline_collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_store_relation_target_document_id": {
+          "name": "fk_store_relation_target_document_id",
+          "tableFrom": "byline_store_relation",
+          "tableTo": "byline_documents",
+          "columnsFrom": [
+            "target_document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "fk_store_relation_target_collection_id": {
+          "name": "fk_store_relation_target_collection_id",
+          "tableFrom": "byline_store_relation",
+          "tableTo": "byline_collections",
+          "columnsFrom": [
+            "target_collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "byline_store_relation_id": {
+          "name": "byline_store_relation_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_relation_field": {
+          "name": "unique_relation_field",
+          "columns": [
+            "document_version_id",
+            "field_path",
+            "locale"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "byline_store_text": {
+      "name": "byline_store_text",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_version_id": {
+          "name": "document_version_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_path": {
+          "name": "field_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_name": {
+          "name": "field_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "parent_path": {
+          "name": "parent_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "word_count": {
+          "name": "word_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_text_value": {
+          "name": "idx_text_value",
+          "columns": [
+            "`value`(191)"
+          ],
+          "isUnique": false
+        },
+        "idx_text_locale_value": {
+          "name": "idx_text_locale_value",
+          "columns": [
+            "locale",
+            "`value`(191)"
+          ],
+          "isUnique": false
+        },
+        "idx_text_path_value": {
+          "name": "idx_text_path_value",
+          "columns": [
+            "field_path",
+            "`value`(191)"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "fk_store_text_document_version_id": {
+          "name": "fk_store_text_document_version_id",
+          "tableFrom": "byline_store_text",
+          "tableTo": "byline_document_versions",
+          "columnsFrom": [
+            "document_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_store_text_collection_id": {
+          "name": "fk_store_text_collection_id",
+          "tableFrom": "byline_store_text",
+          "tableTo": "byline_collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "byline_store_text_id": {
+          "name": "byline_store_text_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_text_field": {
+          "name": "unique_text_field",
+          "columns": [
+            "document_version_id",
+            "field_path",
+            "locale"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    }
+  },
+  "views": {
+    "byline_current_documents": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection_version": {
+          "name": "collection_version",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'create'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "change_summary": {
+          "name": "change_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "varchar(128) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_locale": {
+          "name": "source_locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "name": "byline_current_documents",
+      "isExisting": false,
+      "definition": "with `sq` as (select `id`, `document_id`, `collection_id`, `collection_version`, `event_type`, `status`, `is_deleted`, `created_at`, `updated_at`, `created_by`, `change_summary`, row_number() OVER (PARTITION BY `document_id` ORDER BY `id` DESC) as `rn` from `byline_document_versions` where `byline_document_versions`.`is_deleted` = false) select `sq`.`id`, `sq`.`document_id`, `sq`.`collection_id`, `sq`.`collection_version`, `sq`.`event_type`, `sq`.`status`, `sq`.`is_deleted`, `sq`.`created_at`, `sq`.`updated_at`, `sq`.`created_by`, `sq`.`change_summary`, `byline_documents`.`order_key`, `byline_documents`.`source_locale` from `sq` inner join `byline_documents` on `byline_documents`.`id` = `sq`.`document_id` where `rn` = 1",
+      "algorithm": "undefined",
+      "sqlSecurity": "definer"
+    },
+    "byline_current_published_documents": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection_version": {
+          "name": "collection_version",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'create'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3)"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "change_summary": {
+          "name": "change_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "varchar(128) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_locale": {
+          "name": "source_locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "name": "byline_current_published_documents",
+      "isExisting": false,
+      "definition": "with `sq` as (select `id`, `document_id`, `collection_id`, `collection_version`, `event_type`, `status`, `is_deleted`, `created_at`, `updated_at`, `created_by`, `change_summary`, row_number() OVER (PARTITION BY `document_id` ORDER BY `id` DESC) as `rn` from `byline_document_versions` where `byline_document_versions`.`is_deleted` = false AND `byline_document_versions`.`status` = 'published') select `sq`.`id`, `sq`.`document_id`, `sq`.`collection_id`, `sq`.`collection_version`, `sq`.`event_type`, `sq`.`status`, `sq`.`is_deleted`, `sq`.`created_at`, `sq`.`updated_at`, `sq`.`created_by`, `sq`.`change_summary`, `byline_documents`.`order_key`, `byline_documents`.`source_locale` from `sq` inner join `byline_documents` on `byline_documents`.`id` = `sq`.`document_id` where `rn` = 1",
+      "algorithm": "undefined",
+      "sqlSecurity": "definer"
+    }
+  },
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {
+      "idx_text_value": {
+        "columns": {
+          "`value`(191)": {
+            "isExpression": true
+          }
+        }
+      },
+      "idx_text_locale_value": {
+        "columns": {
+          "`value`(191)": {
+            "isExpression": true
+          }
+        }
+      },
+      "idx_text_path_value": {
+        "columns": {
+          "`value`(191)": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/db-mysql/src/database/migrations/meta/0002_snapshot.json
+++ b/packages/db-mysql/src/database/migrations/meta/0002_snapshot.json
@@ -1,0 +1,3190 @@
+{
+  "version": "5",
+  "dialect": "mysql",
+  "id": "d4043226-bfb5-4383-8bdb-06b5d6c92745",
+  "prevId": "9be23d30-e5db-49fb-b6e9-c880b8ab3313",
+  "tables": {
+    "byline_admin_permissions": {
+      "name": "byline_admin_permissions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "vid": {
+          "name": "vid",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "admin_role_id": {
+          "name": "admin_role_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ability": {
+          "name": "ability",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(6)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(6)"
+        }
+      },
+      "indexes": {
+        "idx_byline_admin_permissions_role": {
+          "name": "idx_byline_admin_permissions_role",
+          "columns": [
+            "admin_role_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "fk_admin_permissions_admin_role_id": {
+          "name": "fk_admin_permissions_admin_role_id",
+          "tableFrom": "byline_admin_permissions",
+          "tableTo": "byline_admin_roles",
+          "columnsFrom": [
+            "admin_role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "byline_admin_permissions_id": {
+          "name": "byline_admin_permissions_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "uq_byline_admin_permissions_role_ability": {
+          "name": "uq_byline_admin_permissions_role_ability",
+          "columns": [
+            "admin_role_id",
+            "ability"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "byline_admin_refresh_tokens": {
+      "name": "byline_admin_refresh_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "datetime(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(6)"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "datetime(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "datetime(6)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rotated_to_id": {
+          "name": "rotated_to_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "datetime(6)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(6)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(6)"
+        }
+      },
+      "indexes": {
+        "idx_byline_admin_refresh_tokens_user": {
+          "name": "idx_byline_admin_refresh_tokens_user",
+          "columns": [
+            "admin_user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_byline_admin_refresh_tokens_token_hash": {
+          "name": "idx_byline_admin_refresh_tokens_token_hash",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "fk_admin_refresh_tokens_admin_user_id": {
+          "name": "fk_admin_refresh_tokens_admin_user_id",
+          "tableFrom": "byline_admin_refresh_tokens",
+          "tableTo": "byline_admin_users",
+          "columnsFrom": [
+            "admin_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "byline_admin_refresh_tokens_id": {
+          "name": "byline_admin_refresh_tokens_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "byline_admin_refresh_tokens_token_hash_unique": {
+          "name": "byline_admin_refresh_tokens_token_hash_unique",
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "byline_admin_role_admin_user": {
+      "name": "byline_admin_role_admin_user",
+      "columns": {
+        "admin_role_id": {
+          "name": "admin_role_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(6)"
+        }
+      },
+      "indexes": {
+        "idx_byline_admin_role_admin_user_user": {
+          "name": "idx_byline_admin_role_admin_user_user",
+          "columns": [
+            "admin_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "fk_admin_role_admin_user_admin_role_id": {
+          "name": "fk_admin_role_admin_user_admin_role_id",
+          "tableFrom": "byline_admin_role_admin_user",
+          "tableTo": "byline_admin_roles",
+          "columnsFrom": [
+            "admin_role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_admin_role_admin_user_admin_user_id": {
+          "name": "fk_admin_role_admin_user_admin_user_id",
+          "tableFrom": "byline_admin_role_admin_user",
+          "tableTo": "byline_admin_users",
+          "columnsFrom": [
+            "admin_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "byline_admin_role_admin_user_admin_role_id_admin_user_id_pk": {
+          "name": "byline_admin_role_admin_user_admin_role_id_admin_user_id_pk",
+          "columns": [
+            "admin_role_id",
+            "admin_user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "byline_admin_roles": {
+      "name": "byline_admin_roles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "vid": {
+          "name": "vid",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "machine_name": {
+          "name": "machine_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(6)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(6)"
+        }
+      },
+      "indexes": {
+        "idx_byline_admin_roles_machine_name": {
+          "name": "idx_byline_admin_roles_machine_name",
+          "columns": [
+            "machine_name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "byline_admin_roles_id": {
+          "name": "byline_admin_roles_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "byline_admin_roles_machine_name_unique": {
+          "name": "byline_admin_roles_machine_name_unique",
+          "columns": [
+            "machine_name"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "byline_admin_user_preferences": {
+      "name": "byline_admin_user_preferences",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(6)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(6)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fk_admin_user_preferences_user_id": {
+          "name": "fk_admin_user_preferences_user_id",
+          "tableFrom": "byline_admin_user_preferences",
+          "tableTo": "byline_admin_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "byline_admin_user_preferences_user_id_scope_pk": {
+          "name": "byline_admin_user_preferences_user_id_scope_pk",
+          "columns": [
+            "user_id",
+            "scope"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "byline_admin_users": {
+      "name": "byline_admin_users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "vid": {
+          "name": "vid",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "given_name": {
+          "name": "given_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "family_name": {
+          "name": "family_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(254)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remember_me": {
+          "name": "remember_me",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "last_login": {
+          "name": "last_login",
+          "type": "datetime(6)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_login_ip": {
+          "name": "last_login_ip",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failed_login_attempts": {
+          "name": "failed_login_attempts",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_super_admin": {
+          "name": "is_super_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_email_verified": {
+          "name": "is_email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "preferred_locale": {
+          "name": "preferred_locale",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(6)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(6)"
+        }
+      },
+      "indexes": {
+        "idx_byline_admin_users_email": {
+          "name": "idx_byline_admin_users_email",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "byline_admin_users_id": {
+          "name": "byline_admin_users_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "byline_admin_users_username_unique": {
+          "name": "byline_admin_users_username_unique",
+          "columns": [
+            "username"
+          ]
+        },
+        "byline_admin_users_email_unique": {
+          "name": "byline_admin_users_email_unique",
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "byline_audit_log": {
+      "name": "byline_audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_realm": {
+          "name": "actor_realm",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field": {
+          "name": "field",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "before": {
+          "name": "before",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "after": {
+          "name": "after",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "datetime(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(6)"
+        }
+      },
+      "indexes": {
+        "idx_audit_log_document_id": {
+          "name": "idx_audit_log_document_id",
+          "columns": [
+            "document_id",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "idx_audit_log_actor_id": {
+          "name": "idx_audit_log_actor_id",
+          "columns": [
+            "actor_id",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "idx_audit_log_action": {
+          "name": "idx_audit_log_action",
+          "columns": [
+            "action",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "byline_audit_log_id": {
+          "name": "byline_audit_log_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "byline_store_boolean": {
+      "name": "byline_store_boolean",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_version_id": {
+          "name": "document_version_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_path": {
+          "name": "field_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_name": {
+          "name": "field_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "parent_path": {
+          "name": "parent_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(6)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(6)"
+        },
+        "value": {
+          "name": "value",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_boolean_value": {
+          "name": "idx_boolean_value",
+          "columns": [
+            "value"
+          ],
+          "isUnique": false
+        },
+        "idx_boolean_path_value": {
+          "name": "idx_boolean_path_value",
+          "columns": [
+            "field_path",
+            "value"
+          ],
+          "isUnique": false
+        },
+        "idx_boolean_collection_value": {
+          "name": "idx_boolean_collection_value",
+          "columns": [
+            "collection_id",
+            "field_path",
+            "value"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "fk_store_boolean_document_version_id": {
+          "name": "fk_store_boolean_document_version_id",
+          "tableFrom": "byline_store_boolean",
+          "tableTo": "byline_document_versions",
+          "columnsFrom": [
+            "document_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_store_boolean_collection_id": {
+          "name": "fk_store_boolean_collection_id",
+          "tableFrom": "byline_store_boolean",
+          "tableTo": "byline_collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "byline_store_boolean_id": {
+          "name": "byline_store_boolean_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_boolean_field": {
+          "name": "unique_boolean_field",
+          "columns": [
+            "document_version_id",
+            "field_path",
+            "locale"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "byline_collections": {
+      "name": "byline_collections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "singular": {
+          "name": "singular",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plural": {
+          "name": "plural",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "schema_hash": {
+          "name": "schema_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(6)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(6)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "byline_collections_id": {
+          "name": "byline_collections_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "byline_collections_path_unique": {
+          "name": "byline_collections_path_unique",
+          "columns": [
+            "path"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "byline_counter_groups": {
+      "name": "byline_counter_groups",
+      "columns": {
+        "group_name": {
+          "name": "group_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence_name": {
+          "name": "sequence_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_value": {
+          "name": "current_value",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(6)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "byline_counter_groups_group_name": {
+          "name": "byline_counter_groups_group_name",
+          "columns": [
+            "group_name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "byline_store_datetime": {
+      "name": "byline_store_datetime",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_version_id": {
+          "name": "document_version_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_path": {
+          "name": "field_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_name": {
+          "name": "field_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "parent_path": {
+          "name": "parent_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(6)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(6)"
+        },
+        "date_type": {
+          "name": "date_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value_date": {
+          "name": "value_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "value_time": {
+          "name": "value_time",
+          "type": "time(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "value_timestamp_tz": {
+          "name": "value_timestamp_tz",
+          "type": "datetime(6)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_datetime_date": {
+          "name": "idx_datetime_date",
+          "columns": [
+            "value_date"
+          ],
+          "isUnique": false
+        },
+        "idx_datetime_timestamp_tz": {
+          "name": "idx_datetime_timestamp_tz",
+          "columns": [
+            "value_timestamp_tz"
+          ],
+          "isUnique": false
+        },
+        "idx_datetime_path_date": {
+          "name": "idx_datetime_path_date",
+          "columns": [
+            "field_path",
+            "value_timestamp_tz"
+          ],
+          "isUnique": false
+        },
+        "idx_datetime_collection_date": {
+          "name": "idx_datetime_collection_date",
+          "columns": [
+            "collection_id",
+            "value_timestamp_tz"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "fk_store_datetime_document_version_id": {
+          "name": "fk_store_datetime_document_version_id",
+          "tableFrom": "byline_store_datetime",
+          "tableTo": "byline_document_versions",
+          "columnsFrom": [
+            "document_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_store_datetime_collection_id": {
+          "name": "fk_store_datetime_collection_id",
+          "tableFrom": "byline_store_datetime",
+          "tableTo": "byline_collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "byline_store_datetime_id": {
+          "name": "byline_store_datetime_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_datetime_field": {
+          "name": "unique_datetime_field",
+          "columns": [
+            "document_version_id",
+            "field_path",
+            "locale"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "byline_document_available_locales": {
+      "name": "byline_document_available_locales",
+      "columns": {
+        "document_id": {
+          "name": "document_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(6)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(6)"
+        }
+      },
+      "indexes": {
+        "idx_document_available_locales_document_id": {
+          "name": "idx_document_available_locales_document_id",
+          "columns": [
+            "document_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "fk_document_available_locales_document_id": {
+          "name": "fk_document_available_locales_document_id",
+          "tableFrom": "byline_document_available_locales",
+          "tableTo": "byline_documents",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_document_available_locales_collection_id": {
+          "name": "fk_document_available_locales_collection_id",
+          "tableFrom": "byline_document_available_locales",
+          "tableTo": "byline_collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "byline_document_available_locales_document_id_locale_pk": {
+          "name": "byline_document_available_locales_document_id_locale_pk",
+          "columns": [
+            "document_id",
+            "locale"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "byline_document_paths": {
+      "name": "byline_document_paths",
+      "columns": {
+        "document_id": {
+          "name": "document_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(255) COLLATE utf8mb4_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(6)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(6)"
+        }
+      },
+      "indexes": {
+        "idx_document_paths_document_id": {
+          "name": "idx_document_paths_document_id",
+          "columns": [
+            "document_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "fk_document_paths_document_id": {
+          "name": "fk_document_paths_document_id",
+          "tableFrom": "byline_document_paths",
+          "tableTo": "byline_documents",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_document_paths_collection_id": {
+          "name": "fk_document_paths_collection_id",
+          "tableFrom": "byline_document_paths",
+          "tableTo": "byline_collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_document_paths_document_locale": {
+          "name": "unique_document_paths_document_locale",
+          "columns": [
+            "document_id",
+            "locale"
+          ]
+        },
+        "idx_document_paths_collection_locale_path": {
+          "name": "idx_document_paths_collection_locale_path",
+          "columns": [
+            "collection_id",
+            "locale",
+            "path"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "byline_document_relationships": {
+      "name": "byline_document_relationships",
+      "columns": {
+        "child_document_id": {
+          "name": "child_document_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_document_id": {
+          "name": "parent_document_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "varchar(128) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(6)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(6)"
+        }
+      },
+      "indexes": {
+        "idx_document_relationships_parent_order": {
+          "name": "idx_document_relationships_parent_order",
+          "columns": [
+            "parent_document_id",
+            "order_key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "fk_document_relationships_child_document_id": {
+          "name": "fk_document_relationships_child_document_id",
+          "tableFrom": "byline_document_relationships",
+          "tableTo": "byline_documents",
+          "columnsFrom": [
+            "child_document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_document_relationships_parent_document_id": {
+          "name": "fk_document_relationships_parent_document_id",
+          "tableFrom": "byline_document_relationships",
+          "tableTo": "byline_documents",
+          "columnsFrom": [
+            "parent_document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_document_relationships_child": {
+          "name": "uq_document_relationships_child",
+          "columns": [
+            "child_document_id"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "byline_document_version_locales": {
+      "name": "byline_document_version_locales",
+      "columns": {
+        "document_version_id": {
+          "name": "document_version_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fk_document_version_locales_document_version_id": {
+          "name": "fk_document_version_locales_document_version_id",
+          "tableFrom": "byline_document_version_locales",
+          "tableTo": "byline_document_versions",
+          "columnsFrom": [
+            "document_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "byline_document_version_locales_document_version_id_locale_pk": {
+          "name": "byline_document_version_locales_document_version_id_locale_pk",
+          "columns": [
+            "document_version_id",
+            "locale"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "byline_document_versions": {
+      "name": "byline_document_versions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection_version": {
+          "name": "collection_version",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "doc": {
+          "name": "doc",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'create'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(6)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(6)"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "change_summary": {
+          "name": "change_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_documents_document_id": {
+          "name": "idx_documents_document_id",
+          "columns": [
+            "document_id"
+          ],
+          "isUnique": false
+        },
+        "idx_documents_collection_document_deleted": {
+          "name": "idx_documents_collection_document_deleted",
+          "columns": [
+            "collection_id",
+            "document_id",
+            "is_deleted"
+          ],
+          "isUnique": false
+        },
+        "idx_documents_current_view": {
+          "name": "idx_documents_current_view",
+          "columns": [
+            "collection_id",
+            "document_id",
+            "is_deleted",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "idx_documents_event_type": {
+          "name": "idx_documents_event_type",
+          "columns": [
+            "event_type"
+          ],
+          "isUnique": false
+        },
+        "idx_documents_created_at": {
+          "name": "idx_documents_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_documents_document_collection": {
+          "name": "idx_documents_document_collection",
+          "columns": [
+            "document_id",
+            "collection_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "fk_document_versions_document_id": {
+          "name": "fk_document_versions_document_id",
+          "tableFrom": "byline_document_versions",
+          "tableTo": "byline_documents",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_document_versions_collection_id": {
+          "name": "fk_document_versions_collection_id",
+          "tableFrom": "byline_document_versions",
+          "tableTo": "byline_collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "byline_document_versions_id": {
+          "name": "byline_document_versions_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "byline_documents": {
+      "name": "byline_documents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "varchar(128) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_locale": {
+          "name": "source_locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(6)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(6)"
+        }
+      },
+      "indexes": {
+        "idx_documents_collection": {
+          "name": "idx_documents_collection",
+          "columns": [
+            "collection_id"
+          ],
+          "isUnique": false
+        },
+        "idx_documents_collection_order": {
+          "name": "idx_documents_collection_order",
+          "columns": [
+            "collection_id",
+            "order_key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "fk_documents_collection_id": {
+          "name": "fk_documents_collection_id",
+          "tableFrom": "byline_documents",
+          "tableTo": "byline_collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "byline_documents_id": {
+          "name": "byline_documents_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "byline_store_file": {
+      "name": "byline_store_file",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_version_id": {
+          "name": "document_version_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_path": {
+          "name": "field_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_name": {
+          "name": "field_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "parent_path": {
+          "name": "parent_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(6)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(6)"
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_filename": {
+          "name": "original_filename",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "storage_provider": {
+          "name": "storage_provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "storage_url": {
+          "name": "storage_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_width": {
+          "name": "image_width",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_height": {
+          "name": "image_height",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_format": {
+          "name": "image_format",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "processing_status": {
+          "name": "processing_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "thumbnail_generated": {
+          "name": "thumbnail_generated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "variants": {
+          "name": "variants",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_file_file_id": {
+          "name": "idx_file_file_id",
+          "columns": [
+            "file_id"
+          ],
+          "isUnique": false
+        },
+        "idx_file_mime_type": {
+          "name": "idx_file_mime_type",
+          "columns": [
+            "mime_type"
+          ],
+          "isUnique": false
+        },
+        "idx_file_size": {
+          "name": "idx_file_size",
+          "columns": [
+            "file_size"
+          ],
+          "isUnique": false
+        },
+        "idx_file_hash": {
+          "name": "idx_file_hash",
+          "columns": [
+            "file_hash"
+          ],
+          "isUnique": false
+        },
+        "idx_file_image_dimensions": {
+          "name": "idx_file_image_dimensions",
+          "columns": [
+            "image_width",
+            "image_height"
+          ],
+          "isUnique": false
+        },
+        "idx_file_storage_provider": {
+          "name": "idx_file_storage_provider",
+          "columns": [
+            "storage_provider"
+          ],
+          "isUnique": false
+        },
+        "idx_file_processing_status": {
+          "name": "idx_file_processing_status",
+          "columns": [
+            "processing_status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "fk_store_file_document_version_id": {
+          "name": "fk_store_file_document_version_id",
+          "tableFrom": "byline_store_file",
+          "tableTo": "byline_document_versions",
+          "columnsFrom": [
+            "document_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_store_file_collection_id": {
+          "name": "fk_store_file_collection_id",
+          "tableFrom": "byline_store_file",
+          "tableTo": "byline_collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "byline_store_file_id": {
+          "name": "byline_store_file_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_file_field": {
+          "name": "unique_file_field",
+          "columns": [
+            "document_version_id",
+            "field_path",
+            "locale"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "byline_store_json": {
+      "name": "byline_store_json",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_version_id": {
+          "name": "document_version_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_path": {
+          "name": "field_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_name": {
+          "name": "field_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "parent_path": {
+          "name": "parent_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(6)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(6)"
+        },
+        "value": {
+          "name": "value",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "json_schema": {
+          "name": "json_schema",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "object_keys": {
+          "name": "object_keys",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_json_schema": {
+          "name": "idx_json_schema",
+          "columns": [
+            "json_schema"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "fk_store_json_document_version_id": {
+          "name": "fk_store_json_document_version_id",
+          "tableFrom": "byline_store_json",
+          "tableTo": "byline_document_versions",
+          "columnsFrom": [
+            "document_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_store_json_collection_id": {
+          "name": "fk_store_json_collection_id",
+          "tableFrom": "byline_store_json",
+          "tableTo": "byline_collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "byline_store_json_id": {
+          "name": "byline_store_json_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_json_field": {
+          "name": "unique_json_field",
+          "columns": [
+            "document_version_id",
+            "field_path",
+            "locale"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "byline_store_meta": {
+      "name": "byline_store_meta",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_version_id": {
+          "name": "document_version_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(6)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(6)"
+        }
+      },
+      "indexes": {
+        "idx_meta_document_type_path": {
+          "name": "idx_meta_document_type_path",
+          "columns": [
+            "document_version_id",
+            "type",
+            "path"
+          ],
+          "isUnique": false
+        },
+        "idx_meta_item_id": {
+          "name": "idx_meta_item_id",
+          "columns": [
+            "item_id"
+          ],
+          "isUnique": false
+        },
+        "idx_meta_collection_type": {
+          "name": "idx_meta_collection_type",
+          "columns": [
+            "collection_id",
+            "type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "fk_store_meta_document_version_id": {
+          "name": "fk_store_meta_document_version_id",
+          "tableFrom": "byline_store_meta",
+          "tableTo": "byline_document_versions",
+          "columnsFrom": [
+            "document_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_store_meta_collection_id": {
+          "name": "fk_store_meta_collection_id",
+          "tableFrom": "byline_store_meta",
+          "tableTo": "byline_collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "byline_store_meta_id": {
+          "name": "byline_store_meta_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_meta_node": {
+          "name": "unique_meta_node",
+          "columns": [
+            "document_version_id",
+            "type",
+            "path"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "byline_store_numeric": {
+      "name": "byline_store_numeric",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_version_id": {
+          "name": "document_version_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_path": {
+          "name": "field_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_name": {
+          "name": "field_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "parent_path": {
+          "name": "parent_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(6)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(6)"
+        },
+        "number_type": {
+          "name": "number_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value_integer": {
+          "name": "value_integer",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "value_decimal": {
+          "name": "value_decimal",
+          "type": "decimal(10,2)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "value_float": {
+          "name": "value_float",
+          "type": "float",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_numeric_integer": {
+          "name": "idx_numeric_integer",
+          "columns": [
+            "value_integer"
+          ],
+          "isUnique": false
+        },
+        "idx_numeric_decimal": {
+          "name": "idx_numeric_decimal",
+          "columns": [
+            "value_decimal"
+          ],
+          "isUnique": false
+        },
+        "idx_numeric_float": {
+          "name": "idx_numeric_float",
+          "columns": [
+            "value_float"
+          ],
+          "isUnique": false
+        },
+        "idx_numeric_integer_range": {
+          "name": "idx_numeric_integer_range",
+          "columns": [
+            "field_path",
+            "value_integer"
+          ],
+          "isUnique": false
+        },
+        "idx_numeric_decimal_range": {
+          "name": "idx_numeric_decimal_range",
+          "columns": [
+            "field_path",
+            "value_decimal"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "fk_store_numeric_document_version_id": {
+          "name": "fk_store_numeric_document_version_id",
+          "tableFrom": "byline_store_numeric",
+          "tableTo": "byline_document_versions",
+          "columnsFrom": [
+            "document_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_store_numeric_collection_id": {
+          "name": "fk_store_numeric_collection_id",
+          "tableFrom": "byline_store_numeric",
+          "tableTo": "byline_collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "byline_store_numeric_id": {
+          "name": "byline_store_numeric_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_numeric_field": {
+          "name": "unique_numeric_field",
+          "columns": [
+            "document_version_id",
+            "field_path",
+            "locale"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "byline_store_relation": {
+      "name": "byline_store_relation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_version_id": {
+          "name": "document_version_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_path": {
+          "name": "field_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_name": {
+          "name": "field_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "parent_path": {
+          "name": "parent_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(6)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(6)"
+        },
+        "target_document_id": {
+          "name": "target_document_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_collection_id": {
+          "name": "target_collection_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "relationship_type": {
+          "name": "relationship_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'reference'"
+        },
+        "cascade_delete": {
+          "name": "cascade_delete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "idx_relation_target_document": {
+          "name": "idx_relation_target_document",
+          "columns": [
+            "target_document_id"
+          ],
+          "isUnique": false
+        },
+        "idx_relation_target_collection": {
+          "name": "idx_relation_target_collection",
+          "columns": [
+            "target_collection_id"
+          ],
+          "isUnique": false
+        },
+        "idx_relation_type": {
+          "name": "idx_relation_type",
+          "columns": [
+            "relationship_type"
+          ],
+          "isUnique": false
+        },
+        "idx_relation_reverse": {
+          "name": "idx_relation_reverse",
+          "columns": [
+            "target_document_id",
+            "field_path"
+          ],
+          "isUnique": false
+        },
+        "idx_relation_collection_to_collection": {
+          "name": "idx_relation_collection_to_collection",
+          "columns": [
+            "collection_id",
+            "target_collection_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "fk_store_relation_document_version_id": {
+          "name": "fk_store_relation_document_version_id",
+          "tableFrom": "byline_store_relation",
+          "tableTo": "byline_document_versions",
+          "columnsFrom": [
+            "document_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_store_relation_collection_id": {
+          "name": "fk_store_relation_collection_id",
+          "tableFrom": "byline_store_relation",
+          "tableTo": "byline_collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_store_relation_target_document_id": {
+          "name": "fk_store_relation_target_document_id",
+          "tableFrom": "byline_store_relation",
+          "tableTo": "byline_documents",
+          "columnsFrom": [
+            "target_document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "fk_store_relation_target_collection_id": {
+          "name": "fk_store_relation_target_collection_id",
+          "tableFrom": "byline_store_relation",
+          "tableTo": "byline_collections",
+          "columnsFrom": [
+            "target_collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "byline_store_relation_id": {
+          "name": "byline_store_relation_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_relation_field": {
+          "name": "unique_relation_field",
+          "columns": [
+            "document_version_id",
+            "field_path",
+            "locale"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "byline_store_text": {
+      "name": "byline_store_text",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_version_id": {
+          "name": "document_version_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_path": {
+          "name": "field_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field_name": {
+          "name": "field_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "parent_path": {
+          "name": "parent_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(6)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(6)"
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "word_count": {
+          "name": "word_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_text_value": {
+          "name": "idx_text_value",
+          "columns": [
+            "`value`(191)"
+          ],
+          "isUnique": false
+        },
+        "idx_text_locale_value": {
+          "name": "idx_text_locale_value",
+          "columns": [
+            "locale",
+            "`value`(191)"
+          ],
+          "isUnique": false
+        },
+        "idx_text_path_value": {
+          "name": "idx_text_path_value",
+          "columns": [
+            "field_path",
+            "`value`(191)"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "fk_store_text_document_version_id": {
+          "name": "fk_store_text_document_version_id",
+          "tableFrom": "byline_store_text",
+          "tableTo": "byline_document_versions",
+          "columnsFrom": [
+            "document_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_store_text_collection_id": {
+          "name": "fk_store_text_collection_id",
+          "tableFrom": "byline_store_text",
+          "tableTo": "byline_collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "byline_store_text_id": {
+          "name": "byline_store_text_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_text_field": {
+          "name": "unique_text_field",
+          "columns": [
+            "document_version_id",
+            "field_path",
+            "locale"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    }
+  },
+  "views": {
+    "byline_current_documents": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection_version": {
+          "name": "collection_version",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'create'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(6)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(6)"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "change_summary": {
+          "name": "change_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "varchar(128) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_locale": {
+          "name": "source_locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "name": "byline_current_documents",
+      "isExisting": false,
+      "definition": "with `sq` as (select `id`, `document_id`, `collection_id`, `collection_version`, `event_type`, `status`, `is_deleted`, `created_at`, `updated_at`, `created_by`, `change_summary`, row_number() OVER (PARTITION BY `document_id` ORDER BY `id` DESC) as `rn` from `byline_document_versions` where `byline_document_versions`.`is_deleted` = false) select `sq`.`id`, `sq`.`document_id`, `sq`.`collection_id`, `sq`.`collection_version`, `sq`.`event_type`, `sq`.`status`, `sq`.`is_deleted`, `sq`.`created_at`, `sq`.`updated_at`, `sq`.`created_by`, `sq`.`change_summary`, `byline_documents`.`order_key`, `byline_documents`.`source_locale` from `sq` inner join `byline_documents` on `byline_documents`.`id` = `sq`.`document_id` where `rn` = 1",
+      "algorithm": "undefined",
+      "sqlSecurity": "definer"
+    },
+    "byline_current_published_documents": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection_version": {
+          "name": "collection_version",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'create'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(6)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(6)"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "char(36) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "change_summary": {
+          "name": "change_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "varchar(128) CHARACTER SET ascii COLLATE ascii_bin",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_locale": {
+          "name": "source_locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "name": "byline_current_published_documents",
+      "isExisting": false,
+      "definition": "with `sq` as (select `id`, `document_id`, `collection_id`, `collection_version`, `event_type`, `status`, `is_deleted`, `created_at`, `updated_at`, `created_by`, `change_summary`, row_number() OVER (PARTITION BY `document_id` ORDER BY `id` DESC) as `rn` from `byline_document_versions` where `byline_document_versions`.`is_deleted` = false AND `byline_document_versions`.`status` = 'published') select `sq`.`id`, `sq`.`document_id`, `sq`.`collection_id`, `sq`.`collection_version`, `sq`.`event_type`, `sq`.`status`, `sq`.`is_deleted`, `sq`.`created_at`, `sq`.`updated_at`, `sq`.`created_by`, `sq`.`change_summary`, `byline_documents`.`order_key`, `byline_documents`.`source_locale` from `sq` inner join `byline_documents` on `byline_documents`.`id` = `sq`.`document_id` where `rn` = 1",
+      "algorithm": "undefined",
+      "sqlSecurity": "definer"
+    }
+  },
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {
+      "idx_text_value": {
+        "columns": {
+          "`value`(191)": {
+            "isExpression": true
+          }
+        }
+      },
+      "idx_text_locale_value": {
+        "columns": {
+          "`value`(191)": {
+            "isExpression": true
+          }
+        }
+      },
+      "idx_text_path_value": {
+        "columns": {
+          "`value`(191)": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/db-mysql/src/database/migrations/meta/_journal.json
+++ b/packages/db-mysql/src/database/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1784944142980,
       "tag": "0000_empty_naoko",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "5",
+      "when": 1784957015430,
+      "tag": "0001_burly_slyde",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db-mysql/src/database/migrations/meta/_journal.json
+++ b/packages/db-mysql/src/database/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1784957015430,
       "tag": "0001_burly_slyde",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "5",
+      "when": 1784959229763,
+      "tag": "0002_furry_silverclaw",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db-mysql/src/database/schema/auth.ts
+++ b/packages/db-mysql/src/database/schema/auth.ts
@@ -65,7 +65,10 @@ export const adminUsers = mysqlTable(
     /** Full PHC string, e.g. `$argon2id$v=19$m=…$…$…`. */
     password: varchar('password', { length: 255 }).notNull(),
     remember_me: boolean('remember_me').notNull().default(false),
-    last_login: datetime('last_login', { fsp: 3 }),
+    // fsp 6, matching pg's `timestamp('last_login', { precision: 6, withTimezone: true })` —
+    // see `common.ts`'s `auditTimestamp` docblock for why every temporal column
+    // in this schema moved from fsp 3 to fsp 6.
+    last_login: datetime('last_login', { fsp: 6 }),
     last_login_ip: varchar('last_login_ip', { length: 45 }),
     failed_login_attempts: int('failed_login_attempts').notNull().default(0),
     /**
@@ -214,15 +217,18 @@ export const adminRefreshTokens = mysqlTable(
     admin_user_id: uuidChar('admin_user_id').notNull(),
     /** SHA-256 hex digest of the raw refresh-token string. 64 chars. */
     token_hash: varchar('token_hash', { length: 64 }).notNull().unique(),
-    issued_at: datetime('issued_at', { fsp: 3 }).notNull().default(sql`CURRENT_TIMESTAMP(3)`),
-    expires_at: datetime('expires_at', { fsp: 3 }).notNull(),
-    revoked_at: datetime('revoked_at', { fsp: 3 }),
+    // fsp 6 throughout this table, matching pg — see `common.ts`'s
+    // `auditTimestamp` docblock for why every temporal column in this
+    // schema moved from fsp 3 to fsp 6.
+    issued_at: datetime('issued_at', { fsp: 6 }).notNull().default(sql`CURRENT_TIMESTAMP(6)`),
+    expires_at: datetime('expires_at', { fsp: 6 }).notNull(),
+    revoked_at: datetime('revoked_at', { fsp: 6 }),
     /**
      * When this token was rotated, the id of the new token issued in its
      * place. Self-referential; set atomically alongside `revoked_at`.
      */
     rotated_to_id: uuidChar('rotated_to_id'),
-    last_used_at: datetime('last_used_at', { fsp: 3 }),
+    last_used_at: datetime('last_used_at', { fsp: 6 }),
     user_agent: varchar('user_agent', { length: 512 }),
     ip: varchar('ip', { length: 45 }),
     ...timestamps,

--- a/packages/db-mysql/src/database/schema/common.ts
+++ b/packages/db-mysql/src/database/schema/common.ts
@@ -86,18 +86,36 @@ export const varcharCaseSensitive = customType<{
 
 /**
  * Audit-timestamp column shape used across every Byline table.
- * `DATETIME(3)` — millisecond precision; stored and read as UTC by
- * convention (the mysql2 pool is opened with `timezone: 'Z'` so values
- * round-trip without local-timezone reinterpretation). MySQL's `DATETIME`
- * has no timezone-aware storage the way Postgres's `TIMESTAMPTZ` does, so
- * the UTC discipline is enforced entirely at the connection layer rather
- * than the column type.
+ * `DATETIME(6)` — microsecond precision, matching the Postgres adapter's
+ * `timestamp(name, { precision: 6, withTimezone: true })` exactly (see
+ * `packages/db-postgres/src/database/schema/common.ts`'s `auditTimestamp`).
+ * MySQL supports fractional seconds 0–6; picking 6 gives this adapter the
+ * same clock resolution as pg rather than a coarser one.
+ *
+ * This was `fsp: 3` (millisecond) originally, rejected only for
+ * `TIMESTAMP`'s 2038 range limit — with no stated rationale for choosing 3
+ * over 6. That turned out to matter: at millisecond resolution, two
+ * statements issued back-to-back on a fast local connection can land in the
+ * same tick and receive an *identical* `CURRENT_TIMESTAMP(3)` value, which
+ * is a real correctness gap for anything that orders or windows by these
+ * columns (found via `packages/db-conformance`'s audit activity-feed
+ * fixture — see docs/09-testing.md and the Task 11 report for the
+ * live-server evidence: four rapid statements produced 2 distinct values at
+ * fsp 3 versus 4 distinct values at fsp 6). Matching pg's precision closes
+ * that gap at the source instead of asking every fixture/consumer to work
+ * around a coarser clock.
+ *
+ * Stored and read as UTC by convention (the mysql2 pool is opened with
+ * `timezone: 'Z'` so values round-trip without local-timezone
+ * reinterpretation). MySQL's `DATETIME` has no timezone-aware storage the
+ * way Postgres's `TIMESTAMPTZ` does, so the UTC discipline is enforced
+ * entirely at the connection layer rather than the column type.
  *
  * Defined once here so adding a new column to every table — or changing
  * the precision across the schema — is a one-line edit.
  */
 const auditTimestamp = (name: string) =>
-  datetime(name, { fsp: 3 }).notNull().default(sql`CURRENT_TIMESTAMP(3)`)
+  datetime(name, { fsp: 6 }).notNull().default(sql`CURRENT_TIMESTAMP(6)`)
 
 /**
  * Both `created_at` and `updated_at` for tables whose rows are

--- a/packages/db-mysql/src/database/schema/index.ts
+++ b/packages/db-mysql/src/database/schema/index.ts
@@ -594,9 +594,14 @@ export const datetimeStore = mysqlTable(
     // hypothetical: a document with a fractional-second time value would
     // read back truncated after a write, MySQL-only.
     value_time: time('value_time', { fsp: 3 }),
-    // Postgres `timestamptz` → `datetime(3)` (spec §2). UTC by convention —
-    // see `common.ts`'s `auditTimestamp` doc comment.
-    value_timestamp_tz: datetime('value_timestamp_tz', { fsp: 3 }),
+    // Postgres `timestamptz` → `datetime(6)`. pg declares this column with
+    // no explicit `precision`, which defaults to TIMESTAMPTZ's full
+    // microsecond resolution — fsp 6 matches that exactly, and keeps this
+    // column on the same precision as every other `datetime(...)` in this
+    // schema (see `common.ts`'s `auditTimestamp` doc comment for why a
+    // mixed-precision schema is worse than a uniform one). UTC by
+    // convention — see `common.ts`'s `auditTimestamp` doc comment.
+    value_timestamp_tz: datetime('value_timestamp_tz', { fsp: 6 }),
   },
   (table) => [
     foreignKey({
@@ -1041,7 +1046,15 @@ export const auditLog = mysqlTable(
     field: varchar('field', { length: 128 }), // the changed field where meaningful (e.g. 'path'), else NULL
     before: json('before'),
     after: json('after'),
-    occurred_at: datetime('occurred_at', { fsp: 3 }).notNull().default(sql`CURRENT_TIMESTAMP(3)`),
+    // fsp 6, matching pg's `timestamp('occurred_at', { precision: 6, withTimezone: true })`
+    // — see `common.ts`'s `auditTimestamp` doc comment for why every
+    // temporal column in this schema moved from fsp 3 to fsp 6. This is
+    // the column that surfaced the issue: at fsp 3, two audit rows (or an
+    // audit row and a version-stream row) appended in quick succession on a
+    // fast local connection could receive an identical or ambiguously
+    // ordered `occurred_at`, confirmed live via `packages/db-conformance`'s
+    // audit activity-feed fixture — see the Task 11 report.
+    occurred_at: datetime('occurred_at', { fsp: 6 }).notNull().default(sql`CURRENT_TIMESTAMP(6)`),
   },
   (table) => [
     // Per-document history, time-ordered (id is UUIDv7).

--- a/packages/db-mysql/src/database/schema/index.ts
+++ b/packages/db-mysql/src/database/schema/index.ts
@@ -834,14 +834,24 @@ export const jsonStore = mysqlTable(
 // Counter groups registry
 // ---------------------------------------------------------------------------
 //
-// One row per counter `group` discovered in collection field definitions.
-// On Postgres the actual ID allocator is a SEQUENCE object (named in
-// `sequence_name`), reconciled at boot by `IDbAdapter.ensureCounterGroup`.
-// MySQL has no native user-defined SEQUENCE object (unlike Postgres, or
-// MariaDB's own extension) — the concrete allocation mechanism this column
-// backs on MySQL is a Task 11 decision, not this schema-only task's. The
-// registry table itself only records that the group exists and which
-// allocator object backs it; it is not used in the hot allocation path.
+// One row per counter `group` discovered in collection field definitions,
+// plus one row per runtime-scoped counter self-registered by
+// `nextScopedCounterValue`. On Postgres the actual ID allocator is a
+// SEQUENCE object (named in `sequence_name`), reconciled at boot by
+// `IDbAdapter.ensureCounterGroup`. MySQL has no native user-defined SEQUENCE
+// object (unlike Postgres, or MariaDB's own extension), so this table IS the
+// allocator (Task 11 decision): `current_value` is the counter state itself,
+// advanced in place via `UPDATE ... SET current_value = LAST_INSERT_ID(current_value + 1)`
+// (`nextCounterValue`) or, for first-use self-registration, a single
+// `INSERT ... ON DUPLICATE KEY UPDATE current_value = LAST_INSERT_ID(current_value + 1)`
+// (`nextScopedCounterValue`) — both read the freshly-assigned value back via
+// `SELECT LAST_INSERT_ID()` on the same checked-out connection. Static and
+// scoped counters deliberately share this one table/row-per-name rather than
+// splitting scoped counters into a second table: `ICounterCommands` documents
+// that `nextCounterValue` on a name `nextScopedCounterValue` has already
+// registered must continue the very same count — a second table could not
+// honour that without every scoped call double-writing to keep both in sync.
+// See `packages/db-mysql/src/modules/counters/counters-commands.ts`.
 //
 // Why a separate table rather than reading allocator objects from
 // `information_schema`: the mapping from `group_name` → allocator identity
@@ -856,6 +866,9 @@ export const jsonStore = mysqlTable(
 export const counterGroups = mysqlTable('byline_counter_groups', {
   group_name: varchar('group_name', { length: 255 }).primaryKey(),
   sequence_name: text('sequence_name').notNull(),
+  // The counter's live state on this dialect (see comment block above).
+  // Postgres has no equivalent column — its allocator is a SEQUENCE object.
+  current_value: bigint('current_value', { mode: 'number' }).notNull().default(0),
   ...createdAt,
 })
 

--- a/packages/db-mysql/src/database/schema/schema-pins.test.node.ts
+++ b/packages/db-mysql/src/database/schema/schema-pins.test.node.ts
@@ -20,10 +20,20 @@
  *      `ascii_bin` collation (byte-wise, case-sensitive comparison —
  *      what makes id equality case-sensitive and `order_key`'s DB sort
  *      match JS string sort on the `generateKeyBetween` alphabet).
- *   3. Every timestamp (instant) column is `datetime(3)` — millisecond
- *      precision — and every bare time-of-day column is `time(3)`, the
- *      same millisecond precision, so a fractional time value round-trips
- *      instead of silently truncating to whole seconds.
+ *   3. Every timestamp (instant) column is `datetime(6)` — microsecond
+ *      precision, matching the Postgres adapter's `timestamp(..., {
+ *      precision: 6, withTimezone: true })` exactly (see `common.ts`'s
+ *      `auditTimestamp` docblock: this was `datetime(3)` originally, and a
+ *      live `packages/db-conformance` run caught back-to-back statements on
+ *      a fast local connection landing in the same millisecond tick and
+ *      receiving an identical `CURRENT_TIMESTAMP(3)` value — a real
+ *      correctness gap for anything ordering or windowing by these
+ *      columns). Every bare time-of-day column is still `time(3)`,
+ *      millisecond precision, so a fractional time value round-trips
+ *      instead of silently truncating to whole seconds — `time` values are
+ *      user-authored field data, not statement-ordering timestamps, so the
+ *      race that motivated the instant-column bump upstream doesn't apply
+ *      to them.
  *   4. The `byline_document_paths` per-collection path-uniqueness index
  *      keeps the exact name `idx_document_paths_collection_locale_path`,
  *      because `packages/core/src/services/document-lifecycle/internals.ts`
@@ -75,8 +85,11 @@ function bytesPerChar(sqlType: string): number {
 /**
  * Bytes of fractional-seconds storage MySQL adds to a `TIME`/`DATETIME`/
  * `TIMESTAMP` base width for a given `fsp` (0-6): 0 for fsp 0, 1 byte for
- * fsp 1-2, 2 bytes for fsp 3-4, 3 bytes for fsp 5-6. Byline uses fsp 3
- * uniformly (see `common.ts`), which is 2 bytes.
+ * fsp 1-2, 2 bytes for fsp 3-4, 3 bytes for fsp 5-6. Every instant
+ * (`datetime`) column in this schema uses fsp 6 (see `common.ts`), which is
+ * 3 bytes; the one bare time-of-day column (`value_time`) stays at fsp 3
+ * (2 bytes) — see the timestamp-precision pin below for why the two are
+ * treated differently.
  */
 function fractionalSecondsBytes(fsp: number): number {
   if (fsp === 0) return 0
@@ -375,11 +388,12 @@ describe('schema pins — timestamp precision (spec §F.3)', () => {
   const timeColumns: { tableName: string; column: AnyMySqlColumn }[] = []
 
   // Any temporal type that represents an instant (date + time-of-day) must
-  // be `datetime(3)`. `MySqlDateTime` is what `datetime()` produces —
+  // be `datetime(6)`. `MySqlDateTime` is what `datetime()` produces —
   // every timestamp column in this schema uses it — but a future column
   // accidentally declared with mysql-core's `timestamp()` builder instead
-  // would produce `MySqlTimestamp` (rendered `timestamp(3)`, a distinct
-  // MySQL type this schema never intends to use). Filtering on
+  // would produce `MySqlTimestamp` (rendered `timestamp(N)`, a distinct
+  // MySQL type this schema never intends to use, so it would fail the
+  // `datetime(6)` assertion below regardless of its own fsp). Filtering on
   // `MySqlDateTime` alone would silently skip that column rather than
   // failing it, so both instant-shaped types are checked here.
   const INSTANT_COLUMN_TYPES = new Set(['MySqlDateTime', 'MySqlTimestamp'])
@@ -401,9 +415,9 @@ describe('schema pins — timestamp precision (spec §F.3)', () => {
   })
 
   it.each(instantColumns.map((c) => [`${c.tableName}.${c.column.name}`, c.column] as const))(
-    '%s is datetime(3) — millisecond precision',
+    '%s is datetime(6) — microsecond precision (pg parity)',
     (_label, column) => {
-      expect(column.getSQLType()).toBe('datetime(3)')
+      expect(column.getSQLType()).toBe('datetime(6)')
     }
   )
 

--- a/packages/db-mysql/src/index.ts
+++ b/packages/db-mysql/src/index.ts
@@ -120,13 +120,16 @@ export const mysqlAdapter = ({
   const commandBuilders = createCommandBuilders(dbManager, defaultContentLocale)
   // Most reads run on the raw `db` (not the DBManager) — they don't need to
   // join an ambient `withTransaction`. `dbManager` is still threaded through
-  // as the 4th argument (matching pg's `storage-queries.ts:147`) because
+  // as the 4th argument (matching pg's `storage-queries.ts`) because
   // `DocumentQueries` accepts it as `transactionDb` for the one read that
-  // DOES need the ambient transaction: a future `getDocumentSystemFieldsForUpdate`
+  // DOES need the ambient transaction: `getDocumentSystemFieldsForUpdate`
   // (Task 10B) takes a `SELECT … FOR UPDATE` lock that must run inside the
   // caller's transaction to serialise concurrent system-field writers —
   // dropping `dbManager` here would silently run that lock outside the
   // transaction and defeat the concurrency guard it exists to provide.
+  // `transactionDb` is a required parameter (no default) precisely so this
+  // can never be omitted by accident — see the §H ruling in the Task 10B
+  // report.
   const queryBuilders = createQueryBuilders(db, collections, defaultContentLocale, dbManager)
 
   // Boot check: run lazily on the pool's first physical connection rather
@@ -182,46 +185,9 @@ export const mysqlAdapter = ({
       // `queryBuilders.collections` fully implements `ICollectionQueries`
       // (Task 10A) — see `./modules/storage/storage-queries.js`.
       collections: queryBuilders.collections,
-      documents: {
-        getDocumentSystemFieldsForUpdate: notImplemented(
-          'queries.documents.getDocumentSystemFieldsForUpdate',
-          10
-        ),
-        // `queryBuilders.documents` (`DocumentQueries`) implements the
-        // reconstruction path as of Task 10A — see that class's docblock
-        // for exactly what's deferred to Task 10B.
-        getDocumentById: (params) => queryBuilders.documents.getDocumentById(params),
-        getCurrentVersionMetadata: notImplemented(
-          'queries.documents.getCurrentVersionMetadata',
-          10
-        ),
-        getCurrentPath: notImplemented('queries.documents.getCurrentPath', 10),
-        getDocumentByPath: notImplemented('queries.documents.getDocumentByPath', 10),
-        getDocumentByVersion: (params) => queryBuilders.documents.getDocumentByVersion(params),
-        getDocumentsByVersionIds: notImplemented('queries.documents.getDocumentsByVersionIds', 10),
-        getDocumentsByDocumentIds: notImplemented(
-          'queries.documents.getDocumentsByDocumentIds',
-          10
-        ),
-        getDocumentHistory: (params) => queryBuilders.documents.getDocumentHistory(params),
-        getPublishedVersion: notImplemented('queries.documents.getPublishedVersion', 10),
-        getPublishedDocumentIds: notImplemented('queries.documents.getPublishedDocumentIds', 10),
-        getDocumentCountsByStatus: notImplemented(
-          'queries.documents.getDocumentCountsByStatus',
-          10
-        ),
-        findDocuments: (params) => queryBuilders.documents.findDocuments(params),
-        getLastOrderKey: notImplemented('queries.documents.getLastOrderKey', 10),
-        getNeighborOrderKeys: notImplemented('queries.documents.getNeighborOrderKeys', 10),
-        getCanonicalDocumentOrder: notImplemented(
-          'queries.documents.getCanonicalDocumentOrder',
-          10
-        ),
-        getTreeAncestors: notImplemented('queries.documents.getTreeAncestors', 10),
-        getTreeChildren: notImplemented('queries.documents.getTreeChildren', 10),
-        getTreeParent: notImplemented('queries.documents.getTreeParent', 10),
-        getTreeSubtree: notImplemented('queries.documents.getTreeSubtree', 10),
-      },
+      // `queryBuilders.documents` (`DocumentQueries`) fully implements
+      // `IDocumentQueries` as of Task 10B — see that class's docblock.
+      documents: queryBuilders.documents,
       audit: {
         getDocumentAuditLog: notImplemented('queries.audit.getDocumentAuditLog', 11),
         findAuditLog: notImplemented('queries.audit.findAuditLog', 11),

--- a/packages/db-mysql/src/index.ts
+++ b/packages/db-mysql/src/index.ts
@@ -144,16 +144,17 @@ export const mysqlAdapter = ({
       // `ICollectionCommands` — see `./modules/storage/storage-commands.js`.
       collections: commandBuilders.collections,
       documents: {
-        // Task 9A. `commandBuilders.documents` (`DocumentCommands`) is a
-        // deliberate partial — only `createDocumentVersion` is implemented;
-        // see that class's docblock. Every other member below is Task 9B.
+        // `commandBuilders.documents` (`DocumentCommands`) is a partial —
+        // see that class's docblock for what's implemented so far. Every
+        // other member below is still the rest of Task 9B.
         createDocumentVersion: commandBuilders.documents.createDocumentVersion.bind(
           commandBuilders.documents
         ),
-        updateDocumentPath: notImplemented('commands.documents.updateDocumentPath', 9),
-        setDocumentAvailableLocales: notImplemented(
-          'commands.documents.setDocumentAvailableLocales',
-          9
+        updateDocumentPath: commandBuilders.documents.updateDocumentPath.bind(
+          commandBuilders.documents
+        ),
+        setDocumentAvailableLocales: commandBuilders.documents.setDocumentAvailableLocales.bind(
+          commandBuilders.documents
         ),
         setDocumentStatus: notImplemented('commands.documents.setDocumentStatus', 9),
         archivePublishedVersions: notImplemented('commands.documents.archivePublishedVersions', 9),

--- a/packages/db-mysql/src/index.ts
+++ b/packages/db-mysql/src/index.ts
@@ -118,9 +118,16 @@ export const mysqlAdapter = ({
   const dbManager = new DBManagerImpl({ dbPool: db })
   const txManager = new TXManagerImpl({ db: dbManager })
   const commandBuilders = createCommandBuilders(dbManager, defaultContentLocale)
-  // Queries stay on the raw `db` (not the DBManager) — reads don't need to
-  // join an ambient `withTransaction`. Mirrors the pg adapter.
-  const queryBuilders = createQueryBuilders(db, collections, defaultContentLocale)
+  // Most reads run on the raw `db` (not the DBManager) — they don't need to
+  // join an ambient `withTransaction`. `dbManager` is still threaded through
+  // as the 4th argument (matching pg's `storage-queries.ts:147`) because
+  // `DocumentQueries` accepts it as `transactionDb` for the one read that
+  // DOES need the ambient transaction: a future `getDocumentSystemFieldsForUpdate`
+  // (Task 10B) takes a `SELECT … FOR UPDATE` lock that must run inside the
+  // caller's transaction to serialise concurrent system-field writers —
+  // dropping `dbManager` here would silently run that lock outside the
+  // transaction and defeat the concurrency guard it exists to provide.
+  const queryBuilders = createQueryBuilders(db, collections, defaultContentLocale, dbManager)
 
   // Boot check: run lazily on the pool's first physical connection rather
   // than eagerly here, because `mysqlAdapter` is synchronous (mirroring

--- a/packages/db-mysql/src/index.ts
+++ b/packages/db-mysql/src/index.ts
@@ -14,6 +14,8 @@ import mysql from 'mysql2/promise'
 import * as schema from './database/schema/index.js'
 import { assertMySqlVersion } from './lib/boot-check.js'
 import { DBManagerImpl, TXManagerImpl } from './lib/db-manager.js'
+import { classifyError } from './modules/storage/classify-error.js'
+import { createCommandBuilders } from './modules/storage/storage-commands.js'
 
 /**
  * Public return type of `mysqlAdapter`. Extends `IDbAdapter` with concrete
@@ -51,7 +53,6 @@ export const mysqlAdapter = ({
   connectionString,
   // biome-ignore lint/correctness/noUnusedFunctionParameters: threaded through the signature now for parity with pgAdapter; wired into the storage query builders in Task 10.
   collections,
-  // biome-ignore lint/correctness/noUnusedFunctionParameters: threaded through the signature now for parity with pgAdapter; wired into the storage command/query builders starting Task 9.
   defaultContentLocale,
   connectionLimit = 20,
 }: {
@@ -102,8 +103,8 @@ export const mysqlAdapter = ({
   // ambient transaction when a `withTransaction` boundary is open, else the
   // pool.
   const dbManager = new DBManagerImpl({ dbPool: db })
-  // biome-ignore lint/correctness/noUnusedVariables: constructed now so Tasks 9-12 wire withTransaction to it; unused until then (see the withTransaction stub below).
   const txManager = new TXManagerImpl({ db: dbManager })
+  const commandBuilders = createCommandBuilders(dbManager, defaultContentLocale)
 
   // Boot check: run lazily on the pool's first physical connection rather
   // than eagerly here, because `mysqlAdapter` is synchronous (mirroring
@@ -139,13 +140,16 @@ export const mysqlAdapter = ({
 
   return {
     commands: {
-      collections: {
-        create: notImplemented('commands.collections.create', 9),
-        update: notImplemented('commands.collections.update', 9),
-        delete: notImplemented('commands.collections.delete', 9),
-      },
+      // Task 9A. `commandBuilders.collections` fully implements
+      // `ICollectionCommands` — see `./modules/storage/storage-commands.js`.
+      collections: commandBuilders.collections,
       documents: {
-        createDocumentVersion: notImplemented('commands.documents.createDocumentVersion', 9),
+        // Task 9A. `commandBuilders.documents` (`DocumentCommands`) is a
+        // deliberate partial — only `createDocumentVersion` is implemented;
+        // see that class's docblock. Every other member below is Task 9B.
+        createDocumentVersion: commandBuilders.documents.createDocumentVersion.bind(
+          commandBuilders.documents
+        ),
         updateDocumentPath: notImplemented('commands.documents.updateDocumentPath', 9),
         setDocumentAvailableLocales: notImplemented(
           'commands.documents.setDocumentAvailableLocales',
@@ -220,7 +224,8 @@ export const mysqlAdapter = ({
         findAuditLog: notImplemented('queries.audit.findAuditLog', 11),
       },
     },
-    withTransaction: notImplemented('withTransaction', 9),
+    withTransaction: (fn) => txManager.withTransaction(fn),
+    classifyError,
     drizzle: db,
     pool,
   }

--- a/packages/db-mysql/src/index.ts
+++ b/packages/db-mysql/src/index.ts
@@ -66,7 +66,7 @@ export const mysqlAdapter = ({
   const pool = mysql.createPool({
     uri: connectionString,
     connectionLimit,
-    // Every DATETIME(3) column is UTC by convention (spec §2). 'Z' stops
+    // Every DATETIME column is UTC by convention (spec §2). 'Z' stops
     // mysql2 from reinterpreting stored UTC values against the server's or
     // session's local timezone on the way in and out.
     timezone: 'Z',

--- a/packages/db-mysql/src/index.ts
+++ b/packages/db-mysql/src/index.ts
@@ -156,11 +156,19 @@ export const mysqlAdapter = ({
         setDocumentAvailableLocales: commandBuilders.documents.setDocumentAvailableLocales.bind(
           commandBuilders.documents
         ),
-        setDocumentStatus: notImplemented('commands.documents.setDocumentStatus', 9),
-        archivePublishedVersions: notImplemented('commands.documents.archivePublishedVersions', 9),
-        softDeleteDocument: notImplemented('commands.documents.softDeleteDocument', 9),
-        deleteDocumentLocale: notImplemented('commands.documents.deleteDocumentLocale', 9),
-        setOrderKey: notImplemented('commands.documents.setOrderKey', 9),
+        setDocumentStatus: commandBuilders.documents.setDocumentStatus.bind(
+          commandBuilders.documents
+        ),
+        archivePublishedVersions: commandBuilders.documents.archivePublishedVersions.bind(
+          commandBuilders.documents
+        ),
+        softDeleteDocument: commandBuilders.documents.softDeleteDocument.bind(
+          commandBuilders.documents
+        ),
+        deleteDocumentLocale: commandBuilders.documents.deleteDocumentLocale.bind(
+          commandBuilders.documents
+        ),
+        setOrderKey: commandBuilders.documents.setOrderKey.bind(commandBuilders.documents),
         placeTreeNode: notImplemented('commands.documents.placeTreeNode', 9),
         removeFromTree: notImplemented('commands.documents.removeFromTree', 9),
         promoteChildrenAndRemoveFromTree: notImplemented(

--- a/packages/db-mysql/src/index.ts
+++ b/packages/db-mysql/src/index.ts
@@ -140,42 +140,12 @@ export const mysqlAdapter = ({
 
   return {
     commands: {
-      // Task 9A. `commandBuilders.collections` fully implements
-      // `ICollectionCommands` — see `./modules/storage/storage-commands.js`.
+      // `commandBuilders.collections` fully implements `ICollectionCommands`
+      // (Task 9A) — see `./modules/storage/storage-commands.js`.
       collections: commandBuilders.collections,
-      documents: {
-        // `commandBuilders.documents` (`DocumentCommands`) is a partial —
-        // see that class's docblock for what's implemented so far. Every
-        // other member below is still the rest of Task 9B.
-        createDocumentVersion: commandBuilders.documents.createDocumentVersion.bind(
-          commandBuilders.documents
-        ),
-        updateDocumentPath: commandBuilders.documents.updateDocumentPath.bind(
-          commandBuilders.documents
-        ),
-        setDocumentAvailableLocales: commandBuilders.documents.setDocumentAvailableLocales.bind(
-          commandBuilders.documents
-        ),
-        setDocumentStatus: commandBuilders.documents.setDocumentStatus.bind(
-          commandBuilders.documents
-        ),
-        archivePublishedVersions: commandBuilders.documents.archivePublishedVersions.bind(
-          commandBuilders.documents
-        ),
-        softDeleteDocument: commandBuilders.documents.softDeleteDocument.bind(
-          commandBuilders.documents
-        ),
-        deleteDocumentLocale: commandBuilders.documents.deleteDocumentLocale.bind(
-          commandBuilders.documents
-        ),
-        setOrderKey: commandBuilders.documents.setOrderKey.bind(commandBuilders.documents),
-        placeTreeNode: notImplemented('commands.documents.placeTreeNode', 9),
-        removeFromTree: notImplemented('commands.documents.removeFromTree', 9),
-        promoteChildrenAndRemoveFromTree: notImplemented(
-          'commands.documents.promoteChildrenAndRemoveFromTree',
-          9
-        ),
-      },
+      // `commandBuilders.documents` (`DocumentCommands`) fully implements
+      // `IDocumentCommands` as of Task 9B — see that class's docblock.
+      documents: commandBuilders.documents,
       counters: {
         ensureCounterGroup: notImplemented('commands.counters.ensureCounterGroup', 11),
         nextCounterValue: notImplemented('commands.counters.nextCounterValue', 11),

--- a/packages/db-mysql/src/index.ts
+++ b/packages/db-mysql/src/index.ts
@@ -14,6 +14,9 @@ import mysql from 'mysql2/promise'
 import * as schema from './database/schema/index.js'
 import { assertMySqlVersion } from './lib/boot-check.js'
 import { DBManagerImpl, TXManagerImpl } from './lib/db-manager.js'
+import { createAuditCommands } from './modules/audit/audit-commands.js'
+import { createAuditQueries } from './modules/audit/audit-queries.js'
+import { createCounterCommands } from './modules/counters/counters-commands.js'
 import { classifyError } from './modules/storage/classify-error.js'
 import { createCommandBuilders } from './modules/storage/storage-commands.js'
 import { createQueryBuilders } from './modules/storage/storage-queries.js'
@@ -33,21 +36,6 @@ export interface MySqlAdapter extends IDbAdapter {
   drizzle: MySql2Database<typeof schema>
   /** The mysql2 connection pool — exposed for housekeeping and teardown. */
   pool: mysql.Pool
-}
-
-/**
- * Build a stub matching one `IDbAdapter` command/query member's exact call
- * signature. Every real implementation lands task by task (9: storage
- * commands, 10: storage queries, 11: counters/audit) — the adapter this
- * factory returns is deliberately non-functional until then. Throwing keeps
- * that honest at the call site: `MySqlAdapter` satisfies `IDbAdapter`
- * structurally today, but invoking any operation before its task lands
- * fails loudly instead of silently doing nothing.
- */
-function notImplemented<T>(member: string, task: number): T {
-  return (() => {
-    throw new Error(`@byline/db-mysql: ${member} is not implemented yet (Task ${task})`)
-  }) as unknown as T
 }
 
 export const mysqlAdapter = ({
@@ -132,6 +120,18 @@ export const mysqlAdapter = ({
   // report.
   const queryBuilders = createQueryBuilders(db, collections, defaultContentLocale, dbManager)
 
+  // Counters run on the raw mysql2 `pool` — never `dbManager` — so they never
+  // join an ambient `withTransaction`: a long document-create transaction
+  // holding the counter row would serialise every other writer in that
+  // group (Task 11). Audit appends run on `dbManager` so they DO join the
+  // ambient transaction and commit atomically with the mutation they
+  // record; audit reads run on the plain `db` (the pool) since they never
+  // need to join that transaction. See ./modules/counters/counters-commands.js
+  // and ./modules/audit/{audit-commands,audit-queries}.js.
+  const counterCommands = createCounterCommands(pool)
+  const auditCommands = createAuditCommands(dbManager)
+  const auditQueries = createAuditQueries(db)
+
   // Boot check: run lazily on the pool's first physical connection rather
   // than eagerly here, because `mysqlAdapter` is synchronous (mirroring
   // `pgAdapter`) and cannot await a round trip before returning. mysql2
@@ -172,14 +172,12 @@ export const mysqlAdapter = ({
       // `commandBuilders.documents` (`DocumentCommands`) fully implements
       // `IDocumentCommands` as of Task 9B — see that class's docblock.
       documents: commandBuilders.documents,
-      counters: {
-        ensureCounterGroup: notImplemented('commands.counters.ensureCounterGroup', 11),
-        nextCounterValue: notImplemented('commands.counters.nextCounterValue', 11),
-        nextScopedCounterValue: notImplemented('commands.counters.nextScopedCounterValue', 11),
-      },
-      audit: {
-        append: notImplemented('commands.audit.append', 11),
-      },
+      // `counterCommands` fully implements `ICounterCommands` as of Task 11
+      // — see `./modules/counters/counters-commands.js`.
+      counters: counterCommands,
+      // `auditCommands` fully implements `IAuditCommands` as of Task 11 —
+      // see `./modules/audit/audit-commands.js`.
+      audit: auditCommands,
     },
     queries: {
       // `queryBuilders.collections` fully implements `ICollectionQueries`
@@ -188,10 +186,9 @@ export const mysqlAdapter = ({
       // `queryBuilders.documents` (`DocumentQueries`) fully implements
       // `IDocumentQueries` as of Task 10B — see that class's docblock.
       documents: queryBuilders.documents,
-      audit: {
-        getDocumentAuditLog: notImplemented('queries.audit.getDocumentAuditLog', 11),
-        findAuditLog: notImplemented('queries.audit.findAuditLog', 11),
-      },
+      // `auditQueries` fully implements `IAuditQueries` as of Task 11 — see
+      // `./modules/audit/audit-queries.js`.
+      audit: auditQueries,
     },
     withTransaction: (fn) => txManager.withTransaction(fn),
     classifyError,

--- a/packages/db-mysql/src/index.ts
+++ b/packages/db-mysql/src/index.ts
@@ -16,6 +16,7 @@ import { assertMySqlVersion } from './lib/boot-check.js'
 import { DBManagerImpl, TXManagerImpl } from './lib/db-manager.js'
 import { classifyError } from './modules/storage/classify-error.js'
 import { createCommandBuilders } from './modules/storage/storage-commands.js'
+import { createQueryBuilders } from './modules/storage/storage-queries.js'
 
 /**
  * Public return type of `mysqlAdapter`. Extends `IDbAdapter` with concrete
@@ -51,7 +52,6 @@ function notImplemented<T>(member: string, task: number): T {
 
 export const mysqlAdapter = ({
   connectionString,
-  // biome-ignore lint/correctness/noUnusedFunctionParameters: threaded through the signature now for parity with pgAdapter; wired into the storage query builders in Task 10.
   collections,
   defaultContentLocale,
   connectionLimit = 20,
@@ -87,6 +87,19 @@ export const mysqlAdapter = ({
     // (Task 9) treats decimal store values as strings end to end, matching
     // the pg adapter's `numeric` handling.
     decimalNumbers: false,
+    // Task 10A divergence, found live: mysql2 negotiates
+    // `utf8mb4_unicode_ci` as the connection's default collation unless told
+    // otherwise — it does NOT inherit the schema/database default
+    // (`utf8mb4_0900_ai_ci`, see `database/schema/common.ts`). A typed
+    // `CAST(NULL AS CHAR)` expression (the UNION ALL null-cast machinery in
+    // `storage-store-manifest.ts`) carries the *connection's* collation, so
+    // without this, `getAllFieldValuesForMultipleVersions`'s 7-way UNION ALL
+    // fails with `ER_CANT_AGGREGATE_NCOLLATIONS` ("Illegal mix of
+    // collations") the moment a CAST'd column and a real schema column with
+    // a different collation land in the same UNION output position.
+    // Pinning the connection's collation to match the schema fixes it at
+    // the source rather than adding a `COLLATE` clause to every cast.
+    charset: 'UTF8MB4_0900_AI_CI',
   })
 
   // `drizzle-orm/mysql2` requires `mode` whenever `schema` is supplied.
@@ -105,6 +118,9 @@ export const mysqlAdapter = ({
   const dbManager = new DBManagerImpl({ dbPool: db })
   const txManager = new TXManagerImpl({ db: dbManager })
   const commandBuilders = createCommandBuilders(dbManager, defaultContentLocale)
+  // Queries stay on the raw `db` (not the DBManager) — reads don't need to
+  // join an ambient `withTransaction`. Mirrors the pg adapter.
+  const queryBuilders = createQueryBuilders(db, collections, defaultContentLocale)
 
   // Boot check: run lazily on the pool's first physical connection rather
   // than eagerly here, because `mysqlAdapter` is synchronous (mirroring
@@ -156,37 +172,38 @@ export const mysqlAdapter = ({
       },
     },
     queries: {
-      collections: {
-        getAllCollections: notImplemented('queries.collections.getAllCollections', 10),
-        getCollectionByPath: notImplemented('queries.collections.getCollectionByPath', 10),
-        getCollectionById: notImplemented('queries.collections.getCollectionById', 10),
-      },
+      // `queryBuilders.collections` fully implements `ICollectionQueries`
+      // (Task 10A) — see `./modules/storage/storage-queries.js`.
+      collections: queryBuilders.collections,
       documents: {
         getDocumentSystemFieldsForUpdate: notImplemented(
           'queries.documents.getDocumentSystemFieldsForUpdate',
           10
         ),
-        getDocumentById: notImplemented('queries.documents.getDocumentById', 10),
+        // `queryBuilders.documents` (`DocumentQueries`) implements the
+        // reconstruction path as of Task 10A — see that class's docblock
+        // for exactly what's deferred to Task 10B.
+        getDocumentById: (params) => queryBuilders.documents.getDocumentById(params),
         getCurrentVersionMetadata: notImplemented(
           'queries.documents.getCurrentVersionMetadata',
           10
         ),
         getCurrentPath: notImplemented('queries.documents.getCurrentPath', 10),
         getDocumentByPath: notImplemented('queries.documents.getDocumentByPath', 10),
-        getDocumentByVersion: notImplemented('queries.documents.getDocumentByVersion', 10),
+        getDocumentByVersion: (params) => queryBuilders.documents.getDocumentByVersion(params),
         getDocumentsByVersionIds: notImplemented('queries.documents.getDocumentsByVersionIds', 10),
         getDocumentsByDocumentIds: notImplemented(
           'queries.documents.getDocumentsByDocumentIds',
           10
         ),
-        getDocumentHistory: notImplemented('queries.documents.getDocumentHistory', 10),
+        getDocumentHistory: (params) => queryBuilders.documents.getDocumentHistory(params),
         getPublishedVersion: notImplemented('queries.documents.getPublishedVersion', 10),
         getPublishedDocumentIds: notImplemented('queries.documents.getPublishedDocumentIds', 10),
         getDocumentCountsByStatus: notImplemented(
           'queries.documents.getDocumentCountsByStatus',
           10
         ),
-        findDocuments: notImplemented('queries.documents.findDocuments', 10),
+        findDocuments: (params) => queryBuilders.documents.findDocuments(params),
         getLastOrderKey: notImplemented('queries.documents.getLastOrderKey', 10),
         getNeighborOrderKeys: notImplemented('queries.documents.getNeighborOrderKeys', 10),
         getCanonicalDocumentOrder: notImplemented(

--- a/packages/db-mysql/src/lib/test-db.ts
+++ b/packages/db-mysql/src/lib/test-db.ts
@@ -1,0 +1,122 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { drizzle, type MySql2Database } from 'drizzle-orm/mysql2'
+import { migrate } from 'drizzle-orm/mysql2/migrator'
+import mysql from 'mysql2/promise'
+
+import * as schema from '../database/schema/index.js'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+/**
+ * Drizzle migrations folder. Migrations (`*.sql` + `meta/_journal.json`)
+ * live only under `src/` — the TypeScript build doesn't copy them into
+ * `dist/`. Anchor on `src/database/migrations` from either location:
+ *
+ *   src/lib/test-db.ts  → ../../src/database/migrations ✓
+ *   dist/lib/test-db.js → ../../src/database/migrations ✓
+ *
+ * `path.resolve` normalises the `../..` away, so the same string works
+ * for both build modes. Mirrors `packages/db-postgres/src/lib/test-db.ts`.
+ */
+const MIGRATIONS_FOLDER = path.resolve(__dirname, '../../src/database/migrations')
+
+/**
+ * Belt for the script-level braces in `common.sh`. Parses the connection
+ * string and refuses to continue unless the database name ends in `_test`.
+ * Called at every test-process entry point so a stray `.env` pointed at
+ * `byline_dev` (or anything else) trips the guard before any DDL runs.
+ */
+export function assertTestDatabase(connectionString: string | undefined): string {
+  if (!connectionString) {
+    throw new Error(
+      'BYLINE_DB_MYSQL_CONNECTION_STRING is not set. Copy .env.test.example to .env.test.'
+    )
+  }
+  let dbName: string
+  try {
+    const url = new URL(connectionString)
+    dbName = url.pathname.replace(/^\//, '')
+  } catch (err) {
+    throw new Error(
+      `BYLINE_DB_MYSQL_CONNECTION_STRING is not a valid URL: ${(err as Error).message}`
+    )
+  }
+  if (!dbName.endsWith('_test')) {
+    throw new Error(
+      `Refusing to run tests against database '${dbName}'. ` +
+        `Integration tests require a database whose name ends in '_test'. ` +
+        `Update BYLINE_DB_MYSQL_CONNECTION_STRING in .env.test.`
+    )
+  }
+  return dbName
+}
+
+/**
+ * Run Drizzle migrations against the configured connection. Idempotent —
+ * Drizzle tracks applied migrations in `__drizzle_migrations`. Opens and
+ * closes its own pool; safe to call from a vitest globalSetup.
+ */
+export async function migrateTestDatabase(connectionString: string): Promise<void> {
+  assertTestDatabase(connectionString)
+  const pool = mysql.createPool({ uri: connectionString, connectionLimit: 1, timezone: 'Z' })
+  try {
+    const db = drizzle(pool, { schema, mode: 'default' })
+    await migrate(db, { migrationsFolder: MIGRATIONS_FOLDER })
+  } finally {
+    await pool.end()
+  }
+}
+
+/**
+ * Wipe every user table so each test file starts from a known state. MySQL
+ * has no `TRUNCATE ... CASCADE` — foreign keys must be disabled around the
+ * truncates instead, and restored afterwards (including on failure), or a
+ * later test file inherits a permanently-disabled FK session setting.
+ * Skips Drizzle's own `__drizzle_migrations` ledger. Self-maintaining as the
+ * schema grows — new tables come along for the ride without any code change.
+ */
+export async function truncateAllTables(db: MySql2Database<typeof schema>): Promise<void> {
+  const [rows] = await db.execute<{ table_name: string }>(`
+    SELECT TABLE_NAME AS table_name FROM information_schema.tables
+    WHERE table_schema = DATABASE()
+      AND table_type = 'BASE TABLE'
+      AND table_name <> '__drizzle_migrations'
+  `)
+  const tables = (rows as unknown as { table_name: string }[]).map((r) => `\`${r.table_name}\``)
+  if (tables.length === 0) return
+
+  await db.execute('SET FOREIGN_KEY_CHECKS = 0')
+  try {
+    for (const table of tables) {
+      await db.execute(`TRUNCATE TABLE ${table}`)
+    }
+  } finally {
+    await db.execute('SET FOREIGN_KEY_CHECKS = 1')
+  }
+}
+
+/**
+ * Convenience: assert + open a short-lived pool + truncate + close. Useful
+ * from a vitest setupFile (`beforeAll`) where the caller doesn't otherwise
+ * need a long-lived db handle.
+ */
+export async function resetTestDatabase(connectionString: string): Promise<void> {
+  assertTestDatabase(connectionString)
+  const pool = mysql.createPool({ uri: connectionString, connectionLimit: 1, timezone: 'Z' })
+  try {
+    const db = drizzle(pool, { schema, mode: 'default' })
+    await truncateAllTables(db)
+  } finally {
+    await pool.end()
+  }
+}

--- a/packages/db-mysql/src/lib/test-helper.ts
+++ b/packages/db-mysql/src/lib/test-helper.ts
@@ -12,6 +12,7 @@ import mysql from 'mysql2/promise'
 
 import * as schema from '../database/schema/index.js'
 import { createCommandBuilders } from '../modules/storage/storage-commands.js'
+import { createQueryBuilders } from '../modules/storage/storage-queries.js'
 import { DBManagerImpl, TXManagerImpl } from './db-manager.js'
 import { assertTestDatabase } from './test-db.js'
 
@@ -20,15 +21,18 @@ let db: MySql2Database<typeof schema>
 let dbManager: DBManagerImpl
 let txManager: TXManagerImpl
 let commandBuilders: ReturnType<typeof createCommandBuilders>
+let queryBuilders: ReturnType<typeof createQueryBuilders>
 
 /**
  * Mirrors `packages/db-postgres/src/lib/test-helper.ts`. `queryBuilders` is
- * intentionally not wired here yet — `storage-queries.ts` is Task 10; the
- * conformance suites this package currently registers
- * (`tests/conformance.integration.test.ts`) only exercise the command/write
- * surface plus the narrow read slice Task 9A ported alongside it.
+ * wired as of Task 10A — `DocumentQueries` implements the reconstruction
+ * path (`getDocumentById`/`getDocumentByVersion`/`getDocumentHistory`) and
+ * a `findDocuments` scoped to what the `versioning`/`field-types`
+ * `@byline/db-conformance` suites exercise; see
+ * `src/modules/storage/storage-queries.ts`'s module docblock for exactly
+ * what's deferred to Task 10B.
  */
-export function setupTestDB(_collections: CollectionDefinition[] = []) {
+export function setupTestDB(collections: CollectionDefinition[] = []) {
   if (!pool) {
     assertTestDatabase(process.env.BYLINE_DB_MYSQL_CONNECTION_STRING)
     pool = mysql.createPool({
@@ -38,6 +42,10 @@ export function setupTestDB(_collections: CollectionDefinition[] = []) {
       connectionLimit: 4,
       timezone: 'Z',
       decimalNumbers: false,
+      // Match the schema's collation — see the identical option on the
+      // production pool in `src/index.ts` for why this is required (not
+      // just a nicety) once the storage-queries UNION ALL is in play.
+      charset: 'UTF8MB4_0900_AI_CI',
     })
   }
 
@@ -54,7 +62,11 @@ export function setupTestDB(_collections: CollectionDefinition[] = []) {
     commandBuilders = createCommandBuilders(dbManager, 'en')
   }
 
-  return { pool, db, dbManager, txManager, commandBuilders }
+  // Recreate queryBuilders when collections are provided so that
+  // DocumentQueries can resolve collection definitions by path.
+  queryBuilders = createQueryBuilders(db, collections, 'en', dbManager)
+
+  return { pool, db, dbManager, txManager, commandBuilders, queryBuilders }
 }
 
 export async function teardownTestDB() {
@@ -65,5 +77,6 @@ export async function teardownTestDB() {
     dbManager = undefined as any
     txManager = undefined as any
     commandBuilders = undefined as any
+    queryBuilders = undefined as any
   }
 }

--- a/packages/db-mysql/src/lib/test-helper.ts
+++ b/packages/db-mysql/src/lib/test-helper.ts
@@ -25,12 +25,9 @@ let queryBuilders: ReturnType<typeof createQueryBuilders>
 
 /**
  * Mirrors `packages/db-postgres/src/lib/test-helper.ts`. `queryBuilders` is
- * wired as of Task 10A — `DocumentQueries` implements the reconstruction
- * path (`getDocumentById`/`getDocumentByVersion`/`getDocumentHistory`) and
- * a `findDocuments` scoped to what the `versioning`/`field-types`
- * `@byline/db-conformance` suites exercise; see
- * `src/modules/storage/storage-queries.ts`'s module docblock for exactly
- * what's deferred to Task 10B.
+ * wired as of Task 10A (the UNION ALL reconstruction path) and fully
+ * implements `IDocumentQueries` as of Task 10B (the predicate compiler,
+ * `findDocuments`' full surface, tree reads, and `getDocumentSystemFieldsForUpdate`).
  */
 export function setupTestDB(collections: CollectionDefinition[] = []) {
   if (!pool) {

--- a/packages/db-mysql/src/lib/test-helper.ts
+++ b/packages/db-mysql/src/lib/test-helper.ts
@@ -1,0 +1,69 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import type { CollectionDefinition } from '@byline/core'
+import { drizzle, type MySql2Database } from 'drizzle-orm/mysql2'
+import mysql from 'mysql2/promise'
+
+import * as schema from '../database/schema/index.js'
+import { createCommandBuilders } from '../modules/storage/storage-commands.js'
+import { DBManagerImpl, TXManagerImpl } from './db-manager.js'
+import { assertTestDatabase } from './test-db.js'
+
+let pool: mysql.Pool
+let db: MySql2Database<typeof schema>
+let dbManager: DBManagerImpl
+let txManager: TXManagerImpl
+let commandBuilders: ReturnType<typeof createCommandBuilders>
+
+/**
+ * Mirrors `packages/db-postgres/src/lib/test-helper.ts`. `queryBuilders` is
+ * intentionally not wired here yet — `storage-queries.ts` is Task 10; the
+ * conformance suites this package currently registers
+ * (`tests/conformance.integration.test.ts`) only exercise the command/write
+ * surface plus the narrow read slice Task 9A ported alongside it.
+ */
+export function setupTestDB(_collections: CollectionDefinition[] = []) {
+  if (!pool) {
+    assertTestDatabase(process.env.BYLINE_DB_MYSQL_CONNECTION_STRING)
+    pool = mysql.createPool({
+      uri: process.env.BYLINE_DB_MYSQL_CONNECTION_STRING,
+      // Mirrors the pg test helper: tests are serial and run one query at a
+      // time, so a small pool per test file is sufficient.
+      connectionLimit: 4,
+      timezone: 'Z',
+      decimalNumbers: false,
+    })
+  }
+
+  if (!db) {
+    db = drizzle(pool, { schema, mode: 'default' })
+  }
+
+  if (!dbManager) {
+    dbManager = new DBManagerImpl({ dbPool: db })
+    txManager = new TXManagerImpl({ db: dbManager })
+  }
+
+  if (!commandBuilders) {
+    commandBuilders = createCommandBuilders(dbManager, 'en')
+  }
+
+  return { pool, db, dbManager, txManager, commandBuilders }
+}
+
+export async function teardownTestDB() {
+  if (pool) {
+    await pool.end()
+    pool = undefined as any
+    db = undefined as any
+    dbManager = undefined as any
+    txManager = undefined as any
+    commandBuilders = undefined as any
+  }
+}

--- a/packages/db-mysql/src/modules/admin/admin-permissions-repository.ts
+++ b/packages/db-mysql/src/modules/admin/admin-permissions-repository.ts
@@ -1,0 +1,121 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import type { AdminPermissionsRepository } from '@byline/admin/admin-permissions'
+import { DbErrorCodes } from '@byline/core'
+import { and, eq } from 'drizzle-orm'
+import type { MySql2Database } from 'drizzle-orm/mysql2'
+import { v7 as uuidv7 } from 'uuid'
+
+import { adminPermissions, adminRoleAdminUser } from '../../database/schema/auth.js'
+import { classifyError } from '../storage/classify-error.js'
+import type * as schema from '../../database/schema/index.js'
+
+/**
+ * MySQL implementation of `AdminPermissionsRepository` — per-role ability
+ * grants and the distinct-abilities-for-user join that drives
+ * `resolveActor()`. Ported from
+ * `packages/db-postgres/src/modules/admin/admin-permissions-repository.ts`.
+ *
+ * `grantAbility` — pg's `onConflictDoNothing({ target: [admin_role_id,
+ * ability] })` targets the named `uq_byline_admin_permissions_role_ability`
+ * constraint specifically. `byline_admin_permissions` carries **two** unique
+ * keys — the `id` primary key and that named constraint — so, per the
+ * per-table rule this port follows throughout (see
+ * `admin-roles-repository.ts`'s `assignToUser` for the one-unique-key
+ * counter-case), a plain `.onDuplicateKeyUpdate()` is not safe here: MySQL
+ * has no per-constraint targeting, so it would fire — and silently rewrite
+ * an existing row — on *either* unique key, when only a collision on the
+ * role+ability pair should be swallowed. This uses the insert-then-catch
+ * pattern instead (mirrors `writeDocumentPath` in
+ * `storage-commands.ts`): try the insert; if it fails with `ER_DUP_ENTRY`
+ * on `uq_byline_admin_permissions_role_ability` specifically (detected via
+ * the shared `classifyError`), treat it as the idempotent no-op pg's
+ * `onConflictDoNothing` gives; any other error (in particular a duplicate
+ * on `id`, which — being a fresh UUIDv7 — should never happen in practice,
+ * but is structurally a different unique key) rethrows unchanged.
+ */
+export function createAdminPermissionsRepository(
+  db: MySql2Database<typeof schema>
+): AdminPermissionsRepository {
+  return {
+    async grantAbility(roleId, ability) {
+      try {
+        await db.insert(adminPermissions).values({ id: uuidv7(), admin_role_id: roleId, ability })
+      } catch (err) {
+        const classification = classifyError(err)
+        const isRoleAbilityConflict =
+          classification.code === DbErrorCodes.UNIQUE_VIOLATION &&
+          classification.constraint === 'uq_byline_admin_permissions_role_ability'
+        if (!isRoleAbilityConflict) throw err
+        // Already granted — idempotent no-op, matching pg's onConflictDoNothing.
+      }
+    },
+
+    async revokeAbility(roleId, ability) {
+      await db
+        .delete(adminPermissions)
+        .where(
+          and(eq(adminPermissions.admin_role_id, roleId), eq(adminPermissions.ability, ability))
+        )
+    },
+
+    async listAbilities(roleId) {
+      const rows = await db
+        .select({ ability: adminPermissions.ability })
+        .from(adminPermissions)
+        .where(eq(adminPermissions.admin_role_id, roleId))
+      return rows.map((r) => r.ability)
+    },
+
+    async setAbilities(roleId, abilities) {
+      await db.transaction(async (tx) => {
+        await tx.delete(adminPermissions).where(eq(adminPermissions.admin_role_id, roleId))
+        if (abilities.length === 0) return
+        const rows = abilities.map((ability) => ({
+          id: uuidv7(),
+          admin_role_id: roleId,
+          ability,
+        }))
+        await tx.insert(adminPermissions).values(rows)
+      })
+    },
+
+    async listAbilitiesForUser(userId) {
+      const rows = await db
+        .selectDistinct({ ability: adminPermissions.ability })
+        .from(adminPermissions)
+        .innerJoin(
+          adminRoleAdminUser,
+          eq(adminRoleAdminUser.admin_role_id, adminPermissions.admin_role_id)
+        )
+        .where(eq(adminRoleAdminUser.admin_user_id, userId))
+      return rows.map((r) => r.ability)
+    },
+
+    async listRolesForAbility(ability) {
+      const rows = await db
+        .select({ admin_role_id: adminPermissions.admin_role_id })
+        .from(adminPermissions)
+        .where(eq(adminPermissions.ability, ability))
+      return rows.map((r) => r.admin_role_id)
+    },
+
+    async listUsersForAbility(ability) {
+      const rows = await db
+        .selectDistinct({ admin_user_id: adminRoleAdminUser.admin_user_id })
+        .from(adminRoleAdminUser)
+        .innerJoin(
+          adminPermissions,
+          eq(adminPermissions.admin_role_id, adminRoleAdminUser.admin_role_id)
+        )
+        .where(eq(adminPermissions.ability, ability))
+      return rows.map((r) => r.admin_user_id)
+    },
+  }
+}

--- a/packages/db-mysql/src/modules/admin/admin-preferences-repository.ts
+++ b/packages/db-mysql/src/modules/admin/admin-preferences-repository.ts
@@ -10,10 +10,12 @@ import type {
   AdminPreferencesRepository,
   AdminUserPreferenceRow,
 } from '@byline/admin/admin-preferences'
+import { DbErrorCodes } from '@byline/core'
 import { and, eq } from 'drizzle-orm'
 import type { MySql2Database } from 'drizzle-orm/mysql2'
 
 import { adminUserPreferences } from '../../database/schema/auth.js'
+import { classifyError } from '../storage/classify-error.js'
 import type * as schema from '../../database/schema/index.js'
 
 /**
@@ -24,21 +26,38 @@ import type * as schema from '../../database/schema/index.js'
  * single `ON CONFLICT DO UPDATE value = value || patch` statement, computed
  * atomically at the database. MySQL's nearest built-in, `JSON_MERGE_PATCH`,
  * implements RFC 7396 merge-patch semantics — which recurse into matching
- * nested *object* values instead of replacing them wholesale — a genuine
- * divergence from Postgres's `||`, which only ever merges top-level keys
- * (confirmed against the Postgres docs for the jsonb concatenation
- * operator, not assumed). `AdminUserPreferenceRow.value` is a
+ * nested *object* values instead of replacing them wholesale. Confirmed
+ * live, not assumed: `JSON_MERGE_PATCH('{"filters":{"status":"draft",
+ * "author":"ada"}}', '{"filters":{"status":"published"}}')` returns
+ * `{"filters":{"author":"ada","status":"published"}}` — it keeps `author`.
+ * Postgres's `||` on the same two documents returns `{"filters":
+ * {"status":"published"}}` — it replaces the nested `filters` object
+ * wholesale, discarding `author`. `AdminUserPreferenceRow.value` is a
  * `Record<string, unknown>` a caller could one day populate with a nested
  * object, so this doesn't reach for `JSON_MERGE_PATCH` — it computes the
- * merge in JS instead (`{ ...current, ...patch }`, an exact shallow-merge
- * equivalent of `||`), inside a transaction that `SELECT … FOR UPDATE`-locks
- * the target row first, closing the read-then-write race a naive two-step
- * merge would otherwise open (`byline_admin_user_preferences` has exactly
- * one unique key — the composite `(user_id, scope)` primary key — so the
- * lock is unambiguous). `.returning()` has no MySQL equivalent; `created_at`/
- * `updated_at` are captured once as `now` and reused for both the write and
- * the returned row (on first insert; `updated_at` alone on a merge, exactly
- * as pg's own `SET updated_at = now()` does) — no re-`SELECT` needed.
+ * merge in JS instead (`{ ...current, ...patch }`), an exact shallow-merge
+ * equivalent of `||` that matches pg's actual (not RFC 7396) semantics.
+ *
+ * Race safety: rather than a `SELECT` (locked or not) followed by a
+ * conditional `INSERT`/`UPDATE` — which leaves a window on the
+ * *first-ever* write for a (user, scope) pair, since two concurrent
+ * transactions can each observe "no row yet" before either commits — this
+ * tries the `INSERT` first. `byline_admin_user_preferences` has exactly one
+ * unique key, the composite `(user_id, scope)` primary key, so the SQL
+ * engine itself is the single arbiter of "does this row already exist":
+ * the loser of a genuine race gets `ER_DUP_ENTRY` back atomically and falls
+ * through to a `SELECT … FOR UPDATE` + merge + `UPDATE`, run inside a
+ * transaction so the lock is held across the read-modify-write. A
+ * duplicate-key error is only treated as "row exists, merge" when
+ * `classifyError` confirms it's the `PRIMARY` key specifically (verified
+ * live: a composite-PK collision on this table reports `for key
+ * '<table>.PRIMARY'`) — any other error (e.g. the `fk_admin_user_
+ * preferences_user_id` foreign key rejecting an unknown `userId`) rethrows
+ * unchanged rather than being misread as a pre-existing row.
+ *
+ * `.returning()` has no MySQL equivalent; `created_at`/`updated_at` are
+ * captured once as `now` and reused for both the write and the returned
+ * row — no re-`SELECT` needed.
  */
 export function createAdminPreferencesRepository(
   db: MySql2Database<typeof schema>
@@ -53,6 +72,33 @@ export function createAdminPreferencesRepository(
     },
 
     async upsert(userId, scope, patch) {
+      const insertNow = new Date()
+      try {
+        await db.insert(adminUserPreferences).values({
+          user_id: userId,
+          scope,
+          value: patch,
+          created_at: insertNow,
+          updated_at: insertNow,
+        })
+        return {
+          user_id: userId,
+          scope,
+          value: { ...patch },
+          created_at: insertNow,
+          updated_at: insertNow,
+        } satisfies AdminUserPreferenceRow
+      } catch (err) {
+        const classification = classifyError(err)
+        const isExistingRow =
+          classification.code === DbErrorCodes.UNIQUE_VIOLATION &&
+          classification.constraint === 'PRIMARY'
+        if (!isExistingRow) throw err
+      }
+
+      // A row already exists for (userId, scope) — lock it, merge in JS, and
+      // write the merge back. Locked inside a transaction so a second
+      // concurrent upsert blocks on this row rather than racing it.
       return db.transaction(async (tx) => {
         const [existing] = await tx
           .select()
@@ -68,34 +114,21 @@ export function createAdminPreferencesRepository(
           ...patch,
         }
 
-        if (existing) {
-          await tx
-            .update(adminUserPreferences)
-            .set({ value: merged, updated_at: now })
-            .where(
-              and(eq(adminUserPreferences.user_id, userId), eq(adminUserPreferences.scope, scope))
-            )
-          return {
-            user_id: userId,
-            scope,
-            value: merged,
-            created_at: existing.created_at,
-            updated_at: now,
-          } satisfies AdminUserPreferenceRow
-        }
-
-        await tx.insert(adminUserPreferences).values({
-          user_id: userId,
-          scope,
-          value: merged,
-          created_at: now,
-          updated_at: now,
-        })
+        await tx
+          .update(adminUserPreferences)
+          .set({ value: merged, updated_at: now })
+          .where(
+            and(eq(adminUserPreferences.user_id, userId), eq(adminUserPreferences.scope, scope))
+          )
         return {
           user_id: userId,
           scope,
           value: merged,
-          created_at: now,
+          // `existing` is expected present (the failed INSERT above proved a
+          // row exists) — the `?? now` fallback only guards the
+          // vanishingly unlikely window where it was deleted between the
+          // failed INSERT and this locked read.
+          created_at: existing?.created_at ?? now,
           updated_at: now,
         } satisfies AdminUserPreferenceRow
       })

--- a/packages/db-mysql/src/modules/admin/admin-preferences-repository.ts
+++ b/packages/db-mysql/src/modules/admin/admin-preferences-repository.ts
@@ -10,12 +10,13 @@ import type {
   AdminPreferencesRepository,
   AdminUserPreferenceRow,
 } from '@byline/admin/admin-preferences'
-import { DbErrorCodes } from '@byline/core'
+import { DbErrorCodes, ERR_DATABASE, getLogger } from '@byline/core'
 import { and, eq } from 'drizzle-orm'
 import type { MySql2Database } from 'drizzle-orm/mysql2'
 
 import { adminUserPreferences } from '../../database/schema/auth.js'
 import { classifyError } from '../storage/classify-error.js'
+import { affectedRowCount } from '../storage/storage-utils.js'
 import type * as schema from '../../database/schema/index.js'
 
 /**
@@ -54,6 +55,16 @@ import type * as schema from '../../database/schema/index.js'
  * '<table>.PRIMARY'`) — any other error (e.g. the `fk_admin_user_
  * preferences_user_id` foreign key rejecting an unknown `userId`) rethrows
  * unchanged rather than being misread as a pre-existing row.
+ *
+ * The conflict-fallback branch handles the row vanishing out from under it
+ * too: if a concurrent delete (e.g. cascading from the owning admin user)
+ * removes the row between the failed `INSERT` and the locked `SELECT`,
+ * `existing` comes back empty and this inserts fresh rather than merging
+ * onto — and reporting success for — a snapshot of a row that no longer
+ * exists. The subsequent `UPDATE`'s affected-row count is checked too,
+ * defensively, even though the `FOR UPDATE` lock held across the
+ * read-modify-write should make a mid-transaction disappearance there
+ * unreachable.
  *
  * `.returning()` has no MySQL equivalent; `created_at`/`updated_at` are
  * captured once as `now` and reused for both the write and the returned
@@ -109,26 +120,55 @@ export function createAdminPreferencesRepository(
           .for('update')
 
         const now = new Date()
+
+        if (!existing) {
+          // The row that made our INSERT fail is gone by the time we got
+          // here — a concurrent delete (e.g. cascading from the owning
+          // admin user) raced us between the failed INSERT and this locked
+          // read. There is truly no row now, so insert fresh rather than
+          // merging onto a snapshot that no longer exists.
+          await tx.insert(adminUserPreferences).values({
+            user_id: userId,
+            scope,
+            value: patch,
+            created_at: now,
+            updated_at: now,
+          })
+          return {
+            user_id: userId,
+            scope,
+            value: { ...patch },
+            created_at: now,
+            updated_at: now,
+          } satisfies AdminUserPreferenceRow
+        }
+
         const merged: Record<string, unknown> = {
-          ...(existing?.value as Record<string, unknown> | undefined),
+          ...(existing.value as Record<string, unknown>),
           ...patch,
         }
 
-        await tx
+        const result = await tx
           .update(adminUserPreferences)
           .set({ value: merged, updated_at: now })
           .where(
             and(eq(adminUserPreferences.user_id, userId), eq(adminUserPreferences.scope, scope))
           )
+        if (affectedRowCount(result) === 0) {
+          // Unreachable in practice — `existing` was read via `FOR UPDATE`
+          // inside this same transaction, so the row is locked and cannot
+          // vanish before the `UPDATE` above. Guarded anyway so a write
+          // that didn't happen is never reported as a success.
+          throw ERR_DATABASE({
+            message: 'admin preferences upsert: locked row vanished before UPDATE',
+          }).log(getLogger())
+        }
+
         return {
           user_id: userId,
           scope,
           value: merged,
-          // `existing` is expected present (the failed INSERT above proved a
-          // row exists) — the `?? now` fallback only guards the
-          // vanishingly unlikely window where it was deleted between the
-          // failed INSERT and this locked read.
-          created_at: existing?.created_at ?? now,
+          created_at: existing.created_at,
           updated_at: now,
         } satisfies AdminUserPreferenceRow
       })

--- a/packages/db-mysql/src/modules/admin/admin-preferences-repository.ts
+++ b/packages/db-mysql/src/modules/admin/admin-preferences-repository.ts
@@ -1,0 +1,104 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import type {
+  AdminPreferencesRepository,
+  AdminUserPreferenceRow,
+} from '@byline/admin/admin-preferences'
+import { and, eq } from 'drizzle-orm'
+import type { MySql2Database } from 'drizzle-orm/mysql2'
+
+import { adminUserPreferences } from '../../database/schema/auth.js'
+import type * as schema from '../../database/schema/index.js'
+
+/**
+ * MySQL implementation of `AdminPreferencesRepository`. Ported from
+ * `packages/db-postgres/src/modules/admin/admin-preferences-repository.ts`.
+ *
+ * `jsonb` → `json`. pg's upsert merges the JSONB patch per key inside a
+ * single `ON CONFLICT DO UPDATE value = value || patch` statement, computed
+ * atomically at the database. MySQL's nearest built-in, `JSON_MERGE_PATCH`,
+ * implements RFC 7396 merge-patch semantics — which recurse into matching
+ * nested *object* values instead of replacing them wholesale — a genuine
+ * divergence from Postgres's `||`, which only ever merges top-level keys
+ * (confirmed against the Postgres docs for the jsonb concatenation
+ * operator, not assumed). `AdminUserPreferenceRow.value` is a
+ * `Record<string, unknown>` a caller could one day populate with a nested
+ * object, so this doesn't reach for `JSON_MERGE_PATCH` — it computes the
+ * merge in JS instead (`{ ...current, ...patch }`, an exact shallow-merge
+ * equivalent of `||`), inside a transaction that `SELECT … FOR UPDATE`-locks
+ * the target row first, closing the read-then-write race a naive two-step
+ * merge would otherwise open (`byline_admin_user_preferences` has exactly
+ * one unique key — the composite `(user_id, scope)` primary key — so the
+ * lock is unambiguous). `.returning()` has no MySQL equivalent; `created_at`/
+ * `updated_at` are captured once as `now` and reused for both the write and
+ * the returned row (on first insert; `updated_at` alone on a merge, exactly
+ * as pg's own `SET updated_at = now()` does) — no re-`SELECT` needed.
+ */
+export function createAdminPreferencesRepository(
+  db: MySql2Database<typeof schema>
+): AdminPreferencesRepository {
+  return {
+    async get(userId, scope) {
+      const [row] = await db
+        .select()
+        .from(adminUserPreferences)
+        .where(and(eq(adminUserPreferences.user_id, userId), eq(adminUserPreferences.scope, scope)))
+      return (row as AdminUserPreferenceRow | undefined) ?? null
+    },
+
+    async upsert(userId, scope, patch) {
+      return db.transaction(async (tx) => {
+        const [existing] = await tx
+          .select()
+          .from(adminUserPreferences)
+          .where(
+            and(eq(adminUserPreferences.user_id, userId), eq(adminUserPreferences.scope, scope))
+          )
+          .for('update')
+
+        const now = new Date()
+        const merged: Record<string, unknown> = {
+          ...(existing?.value as Record<string, unknown> | undefined),
+          ...patch,
+        }
+
+        if (existing) {
+          await tx
+            .update(adminUserPreferences)
+            .set({ value: merged, updated_at: now })
+            .where(
+              and(eq(adminUserPreferences.user_id, userId), eq(adminUserPreferences.scope, scope))
+            )
+          return {
+            user_id: userId,
+            scope,
+            value: merged,
+            created_at: existing.created_at,
+            updated_at: now,
+          } satisfies AdminUserPreferenceRow
+        }
+
+        await tx.insert(adminUserPreferences).values({
+          user_id: userId,
+          scope,
+          value: merged,
+          created_at: now,
+          updated_at: now,
+        })
+        return {
+          user_id: userId,
+          scope,
+          value: merged,
+          created_at: now,
+          updated_at: now,
+        } satisfies AdminUserPreferenceRow
+      })
+    },
+  }
+}

--- a/packages/db-mysql/src/modules/admin/admin-roles-repository.ts
+++ b/packages/db-mysql/src/modules/admin/admin-roles-repository.ts
@@ -16,6 +16,7 @@ import type { MySql2Database } from 'drizzle-orm/mysql2'
 import { v7 as uuidv7 } from 'uuid'
 
 import { adminRoleAdminUser, adminRoles } from '../../database/schema/auth.js'
+import { affectedRowCount } from '../storage/storage-utils.js'
 import type * as schema from '../../database/schema/index.js'
 
 /**
@@ -31,6 +32,15 @@ import type * as schema from '../../database/schema/index.js'
  * the current row first (values the patch didn't touch aren't otherwise
  * knowable) and merges the patch onto it in JS, with the vid-guarded
  * `UPDATE`'s affected-row count as the sole accept/reject authority.
+ *
+ * Unlike `admin-users-repository.ts`'s `update`/`setPasswordHash` (which
+ * re-`SELECT` post-`UPDATE` — see that file's docblock for why), `update`
+ * here safely returns the pre-read-merged row: every mutator of
+ * `byline_admin_roles` — `update` itself and `reorder` — bumps `vid`, so
+ * there is no vid-less mutator on this table analogous to admin-users'
+ * `recordLoginSuccess`/`recordLoginFailure` that could leave a pre-read
+ * snapshot stale while the guarded `UPDATE` still succeeds. If a future
+ * change adds a vid-less mutator to this table, revisit this.
  *
  * `assignToUser`'s upsert uses a plain `.onDuplicateKeyUpdate()` no-op
  * idiom (`admin_role_id = admin_role_id`) rather than the insert-then-catch
@@ -127,9 +137,7 @@ export function createAdminRolesRepository(
         .update(adminRoles)
         .set(updateSet)
         .where(and(eq(adminRoles.id, id), eq(adminRoles.vid, expectedVid)))
-      const affectedRows = (result as unknown as [{ affectedRows: number }, unknown])[0]
-        ?.affectedRows
-      if (!affectedRows || !current) throw ERR_ADMIN_ROLE_VERSION_CONFLICT()
+      if (affectedRowCount(result) === 0 || !current) throw ERR_ADMIN_ROLE_VERSION_CONFLICT()
 
       return {
         ...current,
@@ -147,9 +155,7 @@ export function createAdminRolesRepository(
       const result = await db
         .delete(adminRoles)
         .where(and(eq(adminRoles.id, id), eq(adminRoles.vid, expectedVid)))
-      const affectedRows = (result as unknown as [{ affectedRows: number }, unknown])[0]
-        ?.affectedRows
-      if (!affectedRows) throw ERR_ADMIN_ROLE_VERSION_CONFLICT()
+      if (affectedRowCount(result) === 0) throw ERR_ADMIN_ROLE_VERSION_CONFLICT()
     },
 
     async reorder(ids) {

--- a/packages/db-mysql/src/modules/admin/admin-roles-repository.ts
+++ b/packages/db-mysql/src/modules/admin/admin-roles-repository.ts
@@ -1,0 +1,230 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import {
+  type AdminRoleRow,
+  type AdminRolesRepository,
+  ERR_ADMIN_ROLE_VERSION_CONFLICT,
+} from '@byline/admin/admin-roles'
+import { and, asc, eq, sql } from 'drizzle-orm'
+import type { MySql2Database } from 'drizzle-orm/mysql2'
+import { v7 as uuidv7 } from 'uuid'
+
+import { adminRoleAdminUser, adminRoles } from '../../database/schema/auth.js'
+import type * as schema from '../../database/schema/index.js'
+
+/**
+ * MySQL implementation of `AdminRolesRepository` — role CRUD, reorder, and
+ * role ↔ user assignments. Ability grants live on `AdminPermissionsRepository`
+ * (see `admin-permissions-repository.ts`). Ported from
+ * `packages/db-postgres/src/modules/admin/admin-roles-repository.ts`.
+ *
+ * `create`/`update` follow the same `.returning()` → construct-in-JS
+ * approach as `admin-users-repository.ts` (see that file's docblock for the
+ * full rationale): `create`'s `created_at`/`updated_at` are captured once as
+ * `now` and used for both the `INSERT` and the returned row; `update` reads
+ * the current row first (values the patch didn't touch aren't otherwise
+ * knowable) and merges the patch onto it in JS, with the vid-guarded
+ * `UPDATE`'s affected-row count as the sole accept/reject authority.
+ *
+ * `assignToUser`'s upsert uses a plain `.onDuplicateKeyUpdate()` no-op
+ * idiom (`admin_role_id = admin_role_id`) rather than the insert-then-catch
+ * pattern `admin-permissions-repository.ts` needs: `byline_admin_role_
+ * admin_user` carries exactly one unique key — the composite primary key
+ * `(admin_role_id, admin_user_id)` targeted here — so a duplicate-key
+ * collision on this table can only be that one key, and MySQL's lack of
+ * per-constraint targeting is a non-issue.
+ */
+
+const PUBLIC_ROLE_COLUMNS = {
+  id: adminRoles.id,
+  vid: adminRoles.vid,
+  name: adminRoles.name,
+  machine_name: adminRoles.machine_name,
+  description: adminRoles.description,
+  order: adminRoles.order,
+  created_at: adminRoles.created_at,
+  updated_at: adminRoles.updated_at,
+} as const
+
+export function createAdminRolesRepository(
+  db: MySql2Database<typeof schema>
+): AdminRolesRepository {
+  return {
+    // -----------------------------------------------------------------
+    // Role CRUD
+    // -----------------------------------------------------------------
+
+    async create(input): Promise<AdminRoleRow> {
+      const id = uuidv7()
+      const now = new Date()
+      const row: AdminRoleRow = {
+        id,
+        vid: 1,
+        name: input.name,
+        machine_name: input.machine_name,
+        description: input.description ?? null,
+        order: input.order ?? 0,
+        created_at: now,
+        updated_at: now,
+      }
+      await db.insert(adminRoles).values({
+        id: row.id,
+        name: row.name,
+        machine_name: row.machine_name,
+        description: row.description,
+        order: row.order,
+        created_at: now,
+        updated_at: now,
+      })
+      return row
+    },
+
+    async getById(id) {
+      const [row] = await db
+        .select(PUBLIC_ROLE_COLUMNS)
+        .from(adminRoles)
+        .where(eq(adminRoles.id, id))
+      return row ?? null
+    },
+
+    async getByMachineName(machineName) {
+      const [row] = await db
+        .select(PUBLIC_ROLE_COLUMNS)
+        .from(adminRoles)
+        .where(eq(adminRoles.machine_name, machineName))
+      return row ?? null
+    },
+
+    async list() {
+      return db
+        .select(PUBLIC_ROLE_COLUMNS)
+        .from(adminRoles)
+        .orderBy(asc(adminRoles.order), asc(adminRoles.created_at))
+    },
+
+    async update(id, expectedVid, patch): Promise<AdminRoleRow> {
+      const [current] = await db
+        .select(PUBLIC_ROLE_COLUMNS)
+        .from(adminRoles)
+        .where(eq(adminRoles.id, id))
+
+      const now = new Date()
+      const updateSet: Record<string, unknown> = {
+        updated_at: now,
+        vid: sql`${adminRoles.vid} + 1`,
+      }
+      if (patch.name !== undefined) updateSet.name = patch.name
+      if (patch.description !== undefined) updateSet.description = patch.description
+      if (patch.order !== undefined) updateSet.order = patch.order
+
+      const result = await db
+        .update(adminRoles)
+        .set(updateSet)
+        .where(and(eq(adminRoles.id, id), eq(adminRoles.vid, expectedVid)))
+      const affectedRows = (result as unknown as [{ affectedRows: number }, unknown])[0]
+        ?.affectedRows
+      if (!affectedRows || !current) throw ERR_ADMIN_ROLE_VERSION_CONFLICT()
+
+      return {
+        ...current,
+        name: patch.name !== undefined ? patch.name : current.name,
+        description: patch.description !== undefined ? patch.description : current.description,
+        order: patch.order !== undefined ? patch.order : current.order,
+        vid: expectedVid + 1,
+        updated_at: now,
+      }
+    },
+
+    async delete(id, expectedVid) {
+      // Cascades remove role ↔ user assignments and per-role permissions
+      // (`ON DELETE CASCADE` on both FKs — see `database/schema/auth.ts`).
+      const result = await db
+        .delete(adminRoles)
+        .where(and(eq(adminRoles.id, id), eq(adminRoles.vid, expectedVid)))
+      const affectedRows = (result as unknown as [{ affectedRows: number }, unknown])[0]
+        ?.affectedRows
+      if (!affectedRows) throw ERR_ADMIN_ROLE_VERSION_CONFLICT()
+    },
+
+    async reorder(ids) {
+      if (ids.length === 0) return
+      // Single transaction so the list is never observed half-reordered.
+      // No vid gate: see `AdminRolesRepository.reorder` contract docs.
+      await db.transaction(async (tx) => {
+        const now = new Date()
+        for (let i = 0; i < ids.length; i++) {
+          await tx
+            .update(adminRoles)
+            .set({
+              order: i,
+              updated_at: now,
+              vid: sql`${adminRoles.vid} + 1`,
+            })
+            .where(eq(adminRoles.id, ids[i] as string))
+        }
+      })
+    },
+
+    // -----------------------------------------------------------------
+    // Role ↔ user assignments
+    // -----------------------------------------------------------------
+
+    async assignToUser(roleId, userId) {
+      await db
+        .insert(adminRoleAdminUser)
+        .values({ admin_role_id: roleId, admin_user_id: userId })
+        .onDuplicateKeyUpdate({
+          set: { admin_role_id: sql`admin_role_id` },
+        })
+    },
+
+    async unassignFromUser(roleId, userId) {
+      await db
+        .delete(adminRoleAdminUser)
+        .where(
+          and(
+            eq(adminRoleAdminUser.admin_role_id, roleId),
+            eq(adminRoleAdminUser.admin_user_id, userId)
+          )
+        )
+    },
+
+    async listRolesForUser(userId) {
+      const rows = await db
+        .select(PUBLIC_ROLE_COLUMNS)
+        .from(adminRoles)
+        .innerJoin(adminRoleAdminUser, eq(adminRoleAdminUser.admin_role_id, adminRoles.id))
+        .where(eq(adminRoleAdminUser.admin_user_id, userId))
+        .orderBy(asc(adminRoles.order))
+      return rows
+    },
+
+    async listUsersForRole(roleId) {
+      const rows = await db
+        .select({ admin_user_id: adminRoleAdminUser.admin_user_id })
+        .from(adminRoleAdminUser)
+        .where(eq(adminRoleAdminUser.admin_role_id, roleId))
+      return rows.map((r) => r.admin_user_id)
+    },
+
+    async setRolesForUser(userId, roleIds) {
+      // Single transaction — user assignments are never observed
+      // half-edited. Symmetric to AdminPermissionsRepository.setAbilities.
+      await db.transaction(async (tx) => {
+        await tx.delete(adminRoleAdminUser).where(eq(adminRoleAdminUser.admin_user_id, userId))
+        if (roleIds.length === 0) return
+        const rows = roleIds.map((admin_role_id) => ({
+          admin_role_id,
+          admin_user_id: userId,
+        }))
+        await tx.insert(adminRoleAdminUser).values(rows)
+      })
+    },
+  }
+}

--- a/packages/db-mysql/src/modules/admin/admin-store.ts
+++ b/packages/db-mysql/src/modules/admin/admin-store.ts
@@ -1,0 +1,36 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import type { AdminStore } from '@byline/admin'
+import type { MySql2Database } from 'drizzle-orm/mysql2'
+
+import { createAdminPermissionsRepository } from './admin-permissions-repository.js'
+import { createAdminPreferencesRepository } from './admin-preferences-repository.js'
+import { createAdminRolesRepository } from './admin-roles-repository.js'
+import { createAdminUsersRepository } from './admin-users-repository.js'
+import { createRefreshTokensRepository } from './refresh-tokens-repository.js'
+import type * as schema from '../../database/schema/index.js'
+
+/**
+ * Wire the five admin repositories against a Drizzle handle and return the
+ * `AdminStore` bundle expected by `@byline/admin` — specifically by the
+ * built-in `JwtSessionProvider`, by `seedSuperAdmin`, and by the admin-user /
+ * admin-role commands. Mirrors
+ * `packages/db-postgres/src/modules/admin/admin-store.ts`.
+ *
+ * Construct once per process, alongside the `mysqlAdapter` call.
+ */
+export function createAdminStore(db: MySql2Database<typeof schema>): AdminStore {
+  return {
+    adminUsers: createAdminUsersRepository(db),
+    adminRoles: createAdminRolesRepository(db),
+    adminPermissions: createAdminPermissionsRepository(db),
+    refreshTokens: createRefreshTokensRepository(db),
+    adminPreferences: createAdminPreferencesRepository(db),
+  }
+}

--- a/packages/db-mysql/src/modules/admin/admin-users-repository.ts
+++ b/packages/db-mysql/src/modules/admin/admin-users-repository.ts
@@ -1,0 +1,336 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import {
+  type AdminUserRow,
+  type AdminUsersRepository,
+  ERR_ADMIN_USER_VERSION_CONFLICT,
+} from '@byline/admin/admin-users'
+import { and, asc, desc, eq, inArray, like, or, sql } from 'drizzle-orm'
+import type { MySql2Database } from 'drizzle-orm/mysql2'
+import { v7 as uuidv7 } from 'uuid'
+
+import { adminUsers } from '../../database/schema/auth.js'
+import type * as schema from '../../database/schema/index.js'
+
+/**
+ * MySQL implementation of `AdminUsersRepository`. Ported from
+ * `packages/db-postgres/src/modules/admin/admin-users-repository.ts`.
+ *
+ * The DB column for the password hash is `password`; the public interface
+ * exposes it as `password_hash`. The mapping happens entirely inside this
+ * factory — callers speak the interface shape and never see the column
+ * name.
+ *
+ * Password hashing is *not* done here — the interface takes a pre-hashed
+ * PHC string. Callers (seed, admin-user commands) hash first via
+ * `hashPassword` from `@byline/admin/auth`.
+ *
+ * Divergences from the pg source (found live, not assumed):
+ *   - `ilike` → `like`. `byline_admin_users` (like every table in this
+ *     schema) uses the database's default `utf8mb4_0900_ai_ci` collation,
+ *     which is itself accent- *and* case-insensitive — confirmed against
+ *     the live container with a throwaway table (`'Alice@Example.com'`
+ *     matched `LIKE '%alice%'`). So a plain `like()` already reproduces
+ *     `ilike()`'s behaviour; MySQL has no `ILIKE` keyword to reach for.
+ *   - `count(*)::int` → `CAST(COUNT(*) AS SIGNED)`, with a `Number()`
+ *     normalisation at the result edge — mirrors the identical conversion
+ *     in `storage-queries.ts` (mysql2 can return `BIGINT` aggregates as
+ *     strings).
+ *   - `.returning()` (4 sites: `create`, `update`, `setPasswordHash`,
+ *     `delete`) → MySQL has no `RETURNING`. `create`'s id is app-generated
+ *     UUIDv7 and every other column is either caller-supplied or a literal
+ *     default, so the row is constructed in JS directly — the `created_at`/
+ *     `updated_at` pair is captured once as `now` and used for *both* the
+ *     `INSERT` values and the returned row, so there is no drift between
+ *     what is persisted and what is returned (the failure mode the Task 9
+ *     deferred-minor note warns about: two independent `new Date()` calls
+ *     that can disagree). `update` and `setPasswordHash` return the full
+ *     public row, including columns the patch didn't touch — those values
+ *     aren't knowable from the patch alone, so both read the current row
+ *     first and merge the patch onto it in JS. This pre-read does not
+ *     weaken the optimistic-concurrency guarantee: the accept/reject
+ *     decision is still made entirely by the vid-guarded `UPDATE`'s
+ *     affected-row count, exactly as pg's guarded `UPDATE … RETURNING`
+ *     does — a stale pre-read can only cause the guarded `UPDATE` to affect
+ *     zero rows (correctly rejected), never a false accept. `delete` needs
+ *     no pre-read at all — it returns `void`, so the affected-row count is
+ *     the entire contract.
+ */
+
+const PUBLIC_COLUMNS = {
+  id: adminUsers.id,
+  vid: adminUsers.vid,
+  given_name: adminUsers.given_name,
+  family_name: adminUsers.family_name,
+  username: adminUsers.username,
+  email: adminUsers.email,
+  remember_me: adminUsers.remember_me,
+  last_login: adminUsers.last_login,
+  last_login_ip: adminUsers.last_login_ip,
+  failed_login_attempts: adminUsers.failed_login_attempts,
+  is_super_admin: adminUsers.is_super_admin,
+  is_enabled: adminUsers.is_enabled,
+  is_email_verified: adminUsers.is_email_verified,
+  preferred_locale: adminUsers.preferred_locale,
+  created_at: adminUsers.created_at,
+  updated_at: adminUsers.updated_at,
+} as const
+
+const ORDER_COLUMN = {
+  given_name: adminUsers.given_name,
+  family_name: adminUsers.family_name,
+  email: adminUsers.email,
+  username: adminUsers.username,
+  created_at: adminUsers.created_at,
+  updated_at: adminUsers.updated_at,
+} as const
+
+function affectedRowCount(result: unknown): number {
+  return (result as [{ affectedRows: number }, unknown])[0]?.affectedRows ?? 0
+}
+
+export function createAdminUsersRepository(
+  db: MySql2Database<typeof schema>
+): AdminUsersRepository {
+  return {
+    async create(input): Promise<AdminUserRow> {
+      const id = uuidv7()
+      const now = new Date()
+      const row: AdminUserRow = {
+        id,
+        vid: 1,
+        given_name: input.given_name ?? null,
+        family_name: input.family_name ?? null,
+        username: input.username ?? null,
+        email: input.email.toLowerCase(),
+        remember_me: false,
+        last_login: null,
+        last_login_ip: null,
+        failed_login_attempts: 0,
+        is_super_admin: input.is_super_admin ?? false,
+        is_enabled: input.is_enabled ?? false,
+        is_email_verified: input.is_email_verified ?? false,
+        preferred_locale: input.preferred_locale ?? null,
+        created_at: now,
+        updated_at: now,
+      }
+      await db.insert(adminUsers).values({
+        id: row.id,
+        email: row.email,
+        password: input.password_hash,
+        given_name: row.given_name,
+        family_name: row.family_name,
+        username: row.username,
+        is_super_admin: row.is_super_admin,
+        is_enabled: row.is_enabled,
+        is_email_verified: row.is_email_verified,
+        preferred_locale: row.preferred_locale,
+        created_at: now,
+        updated_at: now,
+      })
+      return row
+    },
+
+    async getById(id) {
+      const [row] = await db.select(PUBLIC_COLUMNS).from(adminUsers).where(eq(adminUsers.id, id))
+      return row ?? null
+    },
+
+    async getByIds(ids) {
+      if (ids.length === 0) return []
+      return db.select(PUBLIC_COLUMNS).from(adminUsers).where(inArray(adminUsers.id, ids))
+    },
+
+    async getByEmail(email) {
+      const [row] = await db
+        .select(PUBLIC_COLUMNS)
+        .from(adminUsers)
+        .where(eq(adminUsers.email, email.toLowerCase()))
+      return row ?? null
+    },
+
+    async getByUsername(username) {
+      const [row] = await db
+        .select(PUBLIC_COLUMNS)
+        .from(adminUsers)
+        .where(eq(adminUsers.username, username))
+      return row ?? null
+    },
+
+    async getByEmailForSignIn(email) {
+      const [row] = await db
+        .select({ ...PUBLIC_COLUMNS, password_hash: adminUsers.password })
+        .from(adminUsers)
+        .where(eq(adminUsers.email, email.toLowerCase()))
+      return row ?? null
+    },
+
+    async getByIdForSignIn(id) {
+      const [row] = await db
+        .select({ ...PUBLIC_COLUMNS, password_hash: adminUsers.password })
+        .from(adminUsers)
+        .where(eq(adminUsers.id, id))
+      return row ?? null
+    },
+
+    async list(options) {
+      const needle = options.query?.trim()
+      const filter =
+        needle && needle.length > 0
+          ? or(
+              like(adminUsers.email, `%${needle}%`),
+              like(adminUsers.given_name, `%${needle}%`),
+              like(adminUsers.family_name, `%${needle}%`),
+              like(adminUsers.username, `%${needle}%`)
+            )
+          : undefined
+
+      const sortCol = ORDER_COLUMN[options.order]
+      const orderExpr = options.desc ? desc(sortCol) : asc(sortCol)
+      const offset = Math.max(0, (options.page - 1) * options.pageSize)
+
+      const query = db.select(PUBLIC_COLUMNS).from(adminUsers)
+      const filtered = filter ? query.where(filter) : query
+      return filtered.orderBy(orderExpr).limit(options.pageSize).offset(offset)
+    },
+
+    async count(options) {
+      const needle = options?.query?.trim()
+      const filter =
+        needle && needle.length > 0
+          ? or(
+              like(adminUsers.email, `%${needle}%`),
+              like(adminUsers.given_name, `%${needle}%`),
+              like(adminUsers.family_name, `%${needle}%`),
+              like(adminUsers.username, `%${needle}%`)
+            )
+          : undefined
+
+      const base = db.select({ value: sql<number>`CAST(COUNT(*) AS SIGNED)` }).from(adminUsers)
+      const [row] = await (filter ? base.where(filter) : base)
+      return Number(row?.value ?? 0)
+    },
+
+    async update(id, expectedVid, patch): Promise<AdminUserRow> {
+      const [current] = await db
+        .select(PUBLIC_COLUMNS)
+        .from(adminUsers)
+        .where(eq(adminUsers.id, id))
+
+      const now = new Date()
+      const updateSet: Record<string, unknown> = {
+        updated_at: now,
+        vid: sql`${adminUsers.vid} + 1`,
+      }
+      if (patch.given_name !== undefined) updateSet.given_name = patch.given_name
+      if (patch.family_name !== undefined) updateSet.family_name = patch.family_name
+      if (patch.username !== undefined) updateSet.username = patch.username
+      if (patch.email !== undefined) updateSet.email = patch.email.toLowerCase()
+      if (patch.is_super_admin !== undefined) updateSet.is_super_admin = patch.is_super_admin
+      if (patch.is_enabled !== undefined) updateSet.is_enabled = patch.is_enabled
+      if (patch.is_email_verified !== undefined)
+        updateSet.is_email_verified = patch.is_email_verified
+      if (patch.remember_me !== undefined) updateSet.remember_me = patch.remember_me
+      if (patch.preferred_locale !== undefined) updateSet.preferred_locale = patch.preferred_locale
+
+      const result = await db
+        .update(adminUsers)
+        .set(updateSet)
+        .where(and(eq(adminUsers.id, id), eq(adminUsers.vid, expectedVid)))
+      if (affectedRowCount(result) === 0 || !current) throw ERR_ADMIN_USER_VERSION_CONFLICT()
+
+      return {
+        ...current,
+        given_name: patch.given_name !== undefined ? patch.given_name : current.given_name,
+        family_name: patch.family_name !== undefined ? patch.family_name : current.family_name,
+        username: patch.username !== undefined ? patch.username : current.username,
+        email: patch.email !== undefined ? patch.email.toLowerCase() : current.email,
+        is_super_admin:
+          patch.is_super_admin !== undefined ? patch.is_super_admin : current.is_super_admin,
+        is_enabled: patch.is_enabled !== undefined ? patch.is_enabled : current.is_enabled,
+        is_email_verified:
+          patch.is_email_verified !== undefined
+            ? patch.is_email_verified
+            : current.is_email_verified,
+        remember_me: patch.remember_me !== undefined ? patch.remember_me : current.remember_me,
+        preferred_locale:
+          patch.preferred_locale !== undefined ? patch.preferred_locale : current.preferred_locale,
+        vid: expectedVid + 1,
+        updated_at: now,
+      }
+    },
+
+    async setPasswordHash(id, expectedVid, passwordHash): Promise<AdminUserRow> {
+      const [current] = await db
+        .select(PUBLIC_COLUMNS)
+        .from(adminUsers)
+        .where(eq(adminUsers.id, id))
+
+      const now = new Date()
+      const result = await db
+        .update(adminUsers)
+        .set({
+          password: passwordHash,
+          updated_at: now,
+          vid: sql`${adminUsers.vid} + 1`,
+        })
+        .where(and(eq(adminUsers.id, id), eq(adminUsers.vid, expectedVid)))
+      if (affectedRowCount(result) === 0 || !current) throw ERR_ADMIN_USER_VERSION_CONFLICT()
+
+      return {
+        ...current,
+        vid: expectedVid + 1,
+        updated_at: now,
+      }
+    },
+
+    async setEnabled(id, enabled) {
+      await db
+        .update(adminUsers)
+        .set({ is_enabled: enabled, updated_at: new Date(), vid: sql`${adminUsers.vid} + 1` })
+        .where(eq(adminUsers.id, id))
+    },
+
+    async setPreferredLocale(id, locale) {
+      await db
+        .update(adminUsers)
+        .set({ preferred_locale: locale, updated_at: new Date(), vid: sql`${adminUsers.vid} + 1` })
+        .where(eq(adminUsers.id, id))
+    },
+
+    async recordLoginSuccess(id, ip) {
+      await db
+        .update(adminUsers)
+        .set({
+          last_login: new Date(),
+          last_login_ip: ip,
+          failed_login_attempts: 0,
+          updated_at: new Date(),
+        })
+        .where(eq(adminUsers.id, id))
+    },
+
+    async recordLoginFailure(id) {
+      await db
+        .update(adminUsers)
+        .set({
+          failed_login_attempts: sql`${adminUsers.failed_login_attempts} + 1`,
+          updated_at: new Date(),
+        })
+        .where(eq(adminUsers.id, id))
+    },
+
+    async delete(id, expectedVid) {
+      const result = await db
+        .delete(adminUsers)
+        .where(and(eq(adminUsers.id, id), eq(adminUsers.vid, expectedVid)))
+      if (affectedRowCount(result) === 0) throw ERR_ADMIN_USER_VERSION_CONFLICT()
+    },
+  }
+}

--- a/packages/db-mysql/src/modules/admin/admin-users-repository.ts
+++ b/packages/db-mysql/src/modules/admin/admin-users-repository.ts
@@ -52,20 +52,32 @@ import type * as schema from '../../database/schema/index.js'
  *     what is persisted and what is returned (the failure mode the Task 9
  *     deferred-minor note warns about: two independent `new Date()` calls
  *     that can disagree). `update` and `setPasswordHash` re-`SELECT` the
- *     row after a successful guarded `UPDATE` rather than merging the patch
- *     onto a pre-read snapshot — an earlier version of this file did the
- *     latter and was correct on accept/reject (the vid-guarded `UPDATE`'s
- *     affected-row count is still the sole accept/reject authority, exactly
- *     as pg's guarded `UPDATE … RETURNING` is) but not on return-value
- *     freshness: `recordLoginSuccess`/`recordLoginFailure` mutate
- *     `last_login`/`last_login_ip`/`failed_login_attempts` *without*
- *     bumping `vid` (by design, matching pg), so either racing between the
- *     pre-read and the guarded `UPDATE` left the returned object reporting
- *     stale values for those columns — self-heals on the next read, but a
- *     real divergence from pg, where `UPDATE … RETURNING` always reflects
- *     the row's true post-statement state. The re-`SELECT` closes that gap
- *     entirely. `delete` needs no read at all — it returns `void`, so the
- *     affected-row count is the entire contract.
+ *     row after a successful guarded `UPDATE`, both statements sharing one
+ *     `db.transaction()`, rather than merging the patch onto a pre-read
+ *     snapshot — an earlier version of this file did the latter and was
+ *     correct on accept/reject (the vid-guarded `UPDATE`'s affected-row
+ *     count is still the sole accept/reject authority, exactly as pg's
+ *     guarded `UPDATE … RETURNING` is) but not on return-value freshness:
+ *     `recordLoginSuccess`/`recordLoginFailure` mutate `last_login`/
+ *     `last_login_ip`/`failed_login_attempts` *without* bumping `vid` (by
+ *     design, matching pg), so either racing against the pre-read left the
+ *     returned object reporting stale values for those columns.
+ *
+ *     A second version of this fix re-`SELECT`ed but as two separate
+ *     statements outside a transaction — better, but still left a window: a
+ *     `recordLoginSuccess`/`recordLoginFailure` committing *between* the
+ *     guarded `UPDATE` and the re-`SELECT` would leak into the returned
+ *     object. The transaction closes that too, and the mechanism is not a
+ *     REPEATABLE-READ-snapshot argument (a snapshot would just as easily
+ *     read the *pre*-mutation state) — it's that the guarded `UPDATE`
+ *     acquires an exclusive lock on this row that InnoDB holds until the
+ *     transaction commits, so `recordLoginSuccess`/`recordLoginFailure`
+ *     issued against the same row block until after the re-`SELECT` has run
+ *     and the transaction has committed. That is what makes "the re-`SELECT`
+ *     closes the freshness gap entirely" actually true, rather than true
+ *     modulo the specific window between the two statements. `delete` needs
+ *     no read at all — it returns `void`, so the affected-row count is the
+ *     entire contract.
  */
 
 const PUBLIC_COLUMNS = {
@@ -235,39 +247,47 @@ export function createAdminUsersRepository(
       if (patch.remember_me !== undefined) updateSet.remember_me = patch.remember_me
       if (patch.preferred_locale !== undefined) updateSet.preferred_locale = patch.preferred_locale
 
-      const result = await db
-        .update(adminUsers)
-        .set(updateSet)
-        .where(and(eq(adminUsers.id, id), eq(adminUsers.vid, expectedVid)))
-      if (affectedRowCount(result) === 0) throw ERR_ADMIN_USER_VERSION_CONFLICT()
+      // Guarded `UPDATE` + re-`SELECT` share one transaction — see this
+      // file's docblock for why the transaction boundary (not just the
+      // re-`SELECT`) is what actually closes the freshness gap.
+      return db.transaction(async (tx) => {
+        const result = await tx
+          .update(adminUsers)
+          .set(updateSet)
+          .where(and(eq(adminUsers.id, id), eq(adminUsers.vid, expectedVid)))
+        if (affectedRowCount(result) === 0) throw ERR_ADMIN_USER_VERSION_CONFLICT()
 
-      // Re-`SELECT` rather than merge the patch onto a pre-read snapshot —
-      // `recordLoginSuccess`/`recordLoginFailure` can touch this row without
-      // bumping `vid`, so a pre-read snapshot can be stale on those columns
-      // even though the guarded `UPDATE` above legitimately succeeded. See
-      // this file's docblock.
-      const [fresh] = await db.select(PUBLIC_COLUMNS).from(adminUsers).where(eq(adminUsers.id, id))
-      if (!fresh) throw ERR_ADMIN_USER_VERSION_CONFLICT()
-      return fresh
+        const [fresh] = await tx
+          .select(PUBLIC_COLUMNS)
+          .from(adminUsers)
+          .where(eq(adminUsers.id, id))
+        if (!fresh) throw ERR_ADMIN_USER_VERSION_CONFLICT()
+        return fresh
+      })
     },
 
     async setPasswordHash(id, expectedVid, passwordHash): Promise<AdminUserRow> {
       const now = new Date()
-      const result = await db
-        .update(adminUsers)
-        .set({
-          password: passwordHash,
-          updated_at: now,
-          vid: sql`${adminUsers.vid} + 1`,
-        })
-        .where(and(eq(adminUsers.id, id), eq(adminUsers.vid, expectedVid)))
-      if (affectedRowCount(result) === 0) throw ERR_ADMIN_USER_VERSION_CONFLICT()
+      // Guarded `UPDATE` + re-`SELECT` share one transaction — see `update()`
+      // above and this file's docblock.
+      return db.transaction(async (tx) => {
+        const result = await tx
+          .update(adminUsers)
+          .set({
+            password: passwordHash,
+            updated_at: now,
+            vid: sql`${adminUsers.vid} + 1`,
+          })
+          .where(and(eq(adminUsers.id, id), eq(adminUsers.vid, expectedVid)))
+        if (affectedRowCount(result) === 0) throw ERR_ADMIN_USER_VERSION_CONFLICT()
 
-      // Re-`SELECT` — see `update()` above for why a pre-read snapshot isn't
-      // safe to return here.
-      const [fresh] = await db.select(PUBLIC_COLUMNS).from(adminUsers).where(eq(adminUsers.id, id))
-      if (!fresh) throw ERR_ADMIN_USER_VERSION_CONFLICT()
-      return fresh
+        const [fresh] = await tx
+          .select(PUBLIC_COLUMNS)
+          .from(adminUsers)
+          .where(eq(adminUsers.id, id))
+        if (!fresh) throw ERR_ADMIN_USER_VERSION_CONFLICT()
+        return fresh
+      })
     },
 
     async setEnabled(id, enabled) {

--- a/packages/db-mysql/src/modules/admin/admin-users-repository.ts
+++ b/packages/db-mysql/src/modules/admin/admin-users-repository.ts
@@ -16,6 +16,7 @@ import type { MySql2Database } from 'drizzle-orm/mysql2'
 import { v7 as uuidv7 } from 'uuid'
 
 import { adminUsers } from '../../database/schema/auth.js'
+import { affectedRowCount } from '../storage/storage-utils.js'
 import type * as schema from '../../database/schema/index.js'
 
 /**
@@ -50,17 +51,21 @@ import type * as schema from '../../database/schema/index.js'
  *     `INSERT` values and the returned row, so there is no drift between
  *     what is persisted and what is returned (the failure mode the Task 9
  *     deferred-minor note warns about: two independent `new Date()` calls
- *     that can disagree). `update` and `setPasswordHash` return the full
- *     public row, including columns the patch didn't touch — those values
- *     aren't knowable from the patch alone, so both read the current row
- *     first and merge the patch onto it in JS. This pre-read does not
- *     weaken the optimistic-concurrency guarantee: the accept/reject
- *     decision is still made entirely by the vid-guarded `UPDATE`'s
- *     affected-row count, exactly as pg's guarded `UPDATE … RETURNING`
- *     does — a stale pre-read can only cause the guarded `UPDATE` to affect
- *     zero rows (correctly rejected), never a false accept. `delete` needs
- *     no pre-read at all — it returns `void`, so the affected-row count is
- *     the entire contract.
+ *     that can disagree). `update` and `setPasswordHash` re-`SELECT` the
+ *     row after a successful guarded `UPDATE` rather than merging the patch
+ *     onto a pre-read snapshot — an earlier version of this file did the
+ *     latter and was correct on accept/reject (the vid-guarded `UPDATE`'s
+ *     affected-row count is still the sole accept/reject authority, exactly
+ *     as pg's guarded `UPDATE … RETURNING` is) but not on return-value
+ *     freshness: `recordLoginSuccess`/`recordLoginFailure` mutate
+ *     `last_login`/`last_login_ip`/`failed_login_attempts` *without*
+ *     bumping `vid` (by design, matching pg), so either racing between the
+ *     pre-read and the guarded `UPDATE` left the returned object reporting
+ *     stale values for those columns — self-heals on the next read, but a
+ *     real divergence from pg, where `UPDATE … RETURNING` always reflects
+ *     the row's true post-statement state. The re-`SELECT` closes that gap
+ *     entirely. `delete` needs no read at all — it returns `void`, so the
+ *     affected-row count is the entire contract.
  */
 
 const PUBLIC_COLUMNS = {
@@ -90,10 +95,6 @@ const ORDER_COLUMN = {
   created_at: adminUsers.created_at,
   updated_at: adminUsers.updated_at,
 } as const
-
-function affectedRowCount(result: unknown): number {
-  return (result as [{ affectedRows: number }, unknown])[0]?.affectedRows ?? 0
-}
 
 export function createAdminUsersRepository(
   db: MySql2Database<typeof schema>
@@ -218,11 +219,6 @@ export function createAdminUsersRepository(
     },
 
     async update(id, expectedVid, patch): Promise<AdminUserRow> {
-      const [current] = await db
-        .select(PUBLIC_COLUMNS)
-        .from(adminUsers)
-        .where(eq(adminUsers.id, id))
-
       const now = new Date()
       const updateSet: Record<string, unknown> = {
         updated_at: now,
@@ -243,35 +239,19 @@ export function createAdminUsersRepository(
         .update(adminUsers)
         .set(updateSet)
         .where(and(eq(adminUsers.id, id), eq(adminUsers.vid, expectedVid)))
-      if (affectedRowCount(result) === 0 || !current) throw ERR_ADMIN_USER_VERSION_CONFLICT()
+      if (affectedRowCount(result) === 0) throw ERR_ADMIN_USER_VERSION_CONFLICT()
 
-      return {
-        ...current,
-        given_name: patch.given_name !== undefined ? patch.given_name : current.given_name,
-        family_name: patch.family_name !== undefined ? patch.family_name : current.family_name,
-        username: patch.username !== undefined ? patch.username : current.username,
-        email: patch.email !== undefined ? patch.email.toLowerCase() : current.email,
-        is_super_admin:
-          patch.is_super_admin !== undefined ? patch.is_super_admin : current.is_super_admin,
-        is_enabled: patch.is_enabled !== undefined ? patch.is_enabled : current.is_enabled,
-        is_email_verified:
-          patch.is_email_verified !== undefined
-            ? patch.is_email_verified
-            : current.is_email_verified,
-        remember_me: patch.remember_me !== undefined ? patch.remember_me : current.remember_me,
-        preferred_locale:
-          patch.preferred_locale !== undefined ? patch.preferred_locale : current.preferred_locale,
-        vid: expectedVid + 1,
-        updated_at: now,
-      }
+      // Re-`SELECT` rather than merge the patch onto a pre-read snapshot —
+      // `recordLoginSuccess`/`recordLoginFailure` can touch this row without
+      // bumping `vid`, so a pre-read snapshot can be stale on those columns
+      // even though the guarded `UPDATE` above legitimately succeeded. See
+      // this file's docblock.
+      const [fresh] = await db.select(PUBLIC_COLUMNS).from(adminUsers).where(eq(adminUsers.id, id))
+      if (!fresh) throw ERR_ADMIN_USER_VERSION_CONFLICT()
+      return fresh
     },
 
     async setPasswordHash(id, expectedVid, passwordHash): Promise<AdminUserRow> {
-      const [current] = await db
-        .select(PUBLIC_COLUMNS)
-        .from(adminUsers)
-        .where(eq(adminUsers.id, id))
-
       const now = new Date()
       const result = await db
         .update(adminUsers)
@@ -281,13 +261,13 @@ export function createAdminUsersRepository(
           vid: sql`${adminUsers.vid} + 1`,
         })
         .where(and(eq(adminUsers.id, id), eq(adminUsers.vid, expectedVid)))
-      if (affectedRowCount(result) === 0 || !current) throw ERR_ADMIN_USER_VERSION_CONFLICT()
+      if (affectedRowCount(result) === 0) throw ERR_ADMIN_USER_VERSION_CONFLICT()
 
-      return {
-        ...current,
-        vid: expectedVid + 1,
-        updated_at: now,
-      }
+      // Re-`SELECT` — see `update()` above for why a pre-read snapshot isn't
+      // safe to return here.
+      const [fresh] = await db.select(PUBLIC_COLUMNS).from(adminUsers).where(eq(adminUsers.id, id))
+      if (!fresh) throw ERR_ADMIN_USER_VERSION_CONFLICT()
+      return fresh
     },
 
     async setEnabled(id, enabled) {

--- a/packages/db-mysql/src/modules/admin/index.ts
+++ b/packages/db-mysql/src/modules/admin/index.ts
@@ -1,0 +1,29 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+/**
+ * `@byline/db-mysql/admin` — MySQL implementations of the admin repository
+ * contracts declared in `@byline/admin`.
+ *
+ * Most callers want `createAdminStore(db)` — it bundles all five
+ * repositories into the `AdminStore` shape that `@byline/admin` consumers
+ * (the built-in `JwtSessionProvider`, `seedSuperAdmin`, admin-user and
+ * admin-role commands) expect. Individual factories remain exported for
+ * unusual cases (custom wiring, partial testing).
+ *
+ * No session-provider code lives here — `JwtSessionProvider` lives in
+ * `@byline/admin/auth`. This package only supplies the adapter-shaped
+ * pieces it implements. Mirrors `packages/db-postgres/src/modules/admin/index.ts`.
+ */
+
+export { createAdminPermissionsRepository } from './admin-permissions-repository.js'
+export { createAdminPreferencesRepository } from './admin-preferences-repository.js'
+export { createAdminRolesRepository } from './admin-roles-repository.js'
+export { createAdminStore } from './admin-store.js'
+export { createAdminUsersRepository } from './admin-users-repository.js'
+export { createRefreshTokensRepository } from './refresh-tokens-repository.js'

--- a/packages/db-mysql/src/modules/admin/refresh-tokens-repository.ts
+++ b/packages/db-mysql/src/modules/admin/refresh-tokens-repository.ts
@@ -11,6 +11,7 @@ import { and, eq, isNull, lt } from 'drizzle-orm'
 import type { MySql2Database } from 'drizzle-orm/mysql2'
 
 import { adminRefreshTokens } from '../../database/schema/auth.js'
+import { affectedRowCount } from '../storage/storage-utils.js'
 import type * as schema from '../../database/schema/index.js'
 
 /**
@@ -140,14 +141,14 @@ export function createRefreshTokensRepository(
             isNull(adminRefreshTokens.revoked_at)
           )
         )
-      return (result as unknown as [{ affectedRows: number }, unknown])[0]?.affectedRows ?? 0
+      return affectedRowCount(result)
     },
 
     async purgeExpired(now = new Date()) {
       const result = await db
         .delete(adminRefreshTokens)
         .where(lt(adminRefreshTokens.expires_at, now))
-      return (result as unknown as [{ affectedRows: number }, unknown])[0]?.affectedRows ?? 0
+      return affectedRowCount(result)
     },
 
     async listActiveForUser(adminUserId) {

--- a/packages/db-mysql/src/modules/admin/refresh-tokens-repository.ts
+++ b/packages/db-mysql/src/modules/admin/refresh-tokens-repository.ts
@@ -1,0 +1,188 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import type { RefreshTokenRow, RefreshTokensRepository } from '@byline/admin/auth'
+import { and, eq, isNull, lt } from 'drizzle-orm'
+import type { MySql2Database } from 'drizzle-orm/mysql2'
+
+import { adminRefreshTokens } from '../../database/schema/auth.js'
+import type * as schema from '../../database/schema/index.js'
+
+/**
+ * MySQL implementation of `RefreshTokensRepository`, backing the built-in
+ * `JwtSessionProvider`. Ported from
+ * `packages/db-postgres/src/modules/admin/refresh-tokens-repository.ts`.
+ *
+ * `issue()`'s `.returning()` has no MySQL equivalent. Every field
+ * `RefreshTokenRow` exposes is either caller-supplied (`id`, `admin_user_id`,
+ * `token_hash`, `expires_at`, `user_agent`, `ip`) or a fresh row's literal
+ * default (`revoked_at`/`rotated_to_id`/`last_used_at` all `null`) — except
+ * `issued_at`, which the schema defaults to `CURRENT_TIMESTAMP(6)`. Rather
+ * than let the insert rely on that default and approximate the returned
+ * value with a second, independent `new Date()` call (the drift the Task 9
+ * deferred-minor note flags), `issued_at` — and the underlying table's
+ * `created_at`/`updated_at`, which `RefreshTokenRow` doesn't expose but
+ * which exist on the row — are set explicitly from one `now` captured
+ * before the insert and reused for the returned row, so there is no gap
+ * between what is persisted and what is returned. No re-`SELECT` needed.
+ *
+ * `revokeAllForUser` and `purgeExpired` only ever consumed
+ * `.returning({ id })` for its `.length` (the affected-row count); MySQL's
+ * driver result surfaces that directly via `affectedRows` — no row
+ * reconstruction needed at all.
+ */
+export function createRefreshTokensRepository(
+  db: MySql2Database<typeof schema>
+): RefreshTokensRepository {
+  return {
+    async issue(input): Promise<RefreshTokenRow> {
+      const now = new Date()
+      const row: RefreshTokenRow = {
+        id: input.id,
+        admin_user_id: input.admin_user_id,
+        token_hash: input.token_hash,
+        issued_at: now,
+        expires_at: input.expires_at,
+        revoked_at: null,
+        rotated_to_id: null,
+        last_used_at: null,
+        user_agent: input.user_agent ?? null,
+        ip: input.ip ?? null,
+      }
+      await db.insert(adminRefreshTokens).values({
+        id: row.id,
+        admin_user_id: row.admin_user_id,
+        token_hash: row.token_hash,
+        issued_at: now,
+        expires_at: row.expires_at,
+        user_agent: row.user_agent,
+        ip: row.ip,
+        created_at: now,
+        updated_at: now,
+      })
+      return row
+    },
+
+    async findByHash(tokenHash) {
+      const [row] = await db
+        .select()
+        .from(adminRefreshTokens)
+        .where(eq(adminRefreshTokens.token_hash, tokenHash))
+      return row ?? null
+    },
+
+    async findById(id) {
+      const [row] = await db.select().from(adminRefreshTokens).where(eq(adminRefreshTokens.id, id))
+      return row ?? null
+    },
+
+    async touch(id, at = new Date()) {
+      await db
+        .update(adminRefreshTokens)
+        .set({ last_used_at: at, updated_at: new Date() })
+        .where(eq(adminRefreshTokens.id, id))
+    },
+
+    async markRotated(oldId, newId, at = new Date()) {
+      await db
+        .update(adminRefreshTokens)
+        .set({ revoked_at: at, rotated_to_id: newId, updated_at: new Date() })
+        .where(eq(adminRefreshTokens.id, oldId))
+    },
+
+    async revoke(id, at = new Date()) {
+      await db
+        .update(adminRefreshTokens)
+        .set({ revoked_at: at, updated_at: new Date() })
+        .where(and(eq(adminRefreshTokens.id, id), isNull(adminRefreshTokens.revoked_at)))
+    },
+
+    async revokeChain(startId, at = new Date()) {
+      let cursor: string | null = startId
+      let touched = 0
+      // Bounded walk — chains in practice are short; 1000 is a safety ceiling.
+      for (let step = 0; cursor != null && step < 1000; step++) {
+        const [row] = await db
+          .select({
+            id: adminRefreshTokens.id,
+            rotated_to_id: adminRefreshTokens.rotated_to_id,
+            revoked_at: adminRefreshTokens.revoked_at,
+          })
+          .from(adminRefreshTokens)
+          .where(eq(adminRefreshTokens.id, cursor))
+        if (!row) break
+
+        if (row.revoked_at == null) {
+          await db
+            .update(adminRefreshTokens)
+            .set({ revoked_at: at, updated_at: new Date() })
+            .where(eq(adminRefreshTokens.id, row.id))
+          touched++
+        }
+
+        cursor = row.rotated_to_id
+      }
+      return touched
+    },
+
+    async revokeAllForUser(adminUserId, at = new Date()) {
+      const result = await db
+        .update(adminRefreshTokens)
+        .set({ revoked_at: at, updated_at: new Date() })
+        .where(
+          and(
+            eq(adminRefreshTokens.admin_user_id, adminUserId),
+            isNull(adminRefreshTokens.revoked_at)
+          )
+        )
+      return (result as unknown as [{ affectedRows: number }, unknown])[0]?.affectedRows ?? 0
+    },
+
+    async purgeExpired(now = new Date()) {
+      const result = await db
+        .delete(adminRefreshTokens)
+        .where(lt(adminRefreshTokens.expires_at, now))
+      return (result as unknown as [{ affectedRows: number }, unknown])[0]?.affectedRows ?? 0
+    },
+
+    async listActiveForUser(adminUserId) {
+      return db
+        .select()
+        .from(adminRefreshTokens)
+        .where(
+          and(
+            eq(adminRefreshTokens.admin_user_id, adminUserId),
+            isNull(adminRefreshTokens.revoked_at)
+          )
+        )
+    },
+
+    async listAllForUser(adminUserId) {
+      return db
+        .select()
+        .from(adminRefreshTokens)
+        .where(eq(adminRefreshTokens.admin_user_id, adminUserId))
+        .orderBy(adminRefreshTokens.issued_at)
+    },
+
+    async listRotationChain(startId) {
+      const chain: RefreshTokenRow[] = []
+      let cursor: string | null = startId
+      for (let step = 0; cursor != null && step < 1000; step++) {
+        const [row] = await db
+          .select()
+          .from(adminRefreshTokens)
+          .where(eq(adminRefreshTokens.id, cursor))
+        if (!row) break
+        chain.push(row)
+        cursor = row.rotated_to_id
+      }
+      return chain
+    },
+  }
+}

--- a/packages/db-mysql/src/modules/audit/audit-commands.ts
+++ b/packages/db-mysql/src/modules/audit/audit-commands.ts
@@ -49,7 +49,7 @@ export class AuditCommands implements IAuditCommands {
       // before/after value is preserved.
       before: input.before ?? null,
       after: input.after ?? null,
-      // occurred_at defaults to CURRENT_TIMESTAMP(3) at the DB.
+      // occurred_at defaults to CURRENT_TIMESTAMP(6) at the DB.
     })
     return { id }
   }

--- a/packages/db-mysql/src/modules/audit/audit-commands.ts
+++ b/packages/db-mysql/src/modules/audit/audit-commands.ts
@@ -1,0 +1,60 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+/**
+ * Append-only audit-log writes (docs/06-auth-and-security/02-auditability.md — Workstream 2). A deliberately
+ * dumb command: it inserts one row and knows nothing about *which* changes
+ * warrant an audit entry — that policy lives in the lifecycle services, which
+ * wrap the mutation + this append in `withTransaction` so they commit
+ * atomically. Runs on the `DBManager` executor, so an `append` issued inside a
+ * `withTransaction` boundary joins the ambient transaction. Mirrors
+ * `packages/db-postgres/src/modules/audit/audit-commands.ts` exactly — the
+ * transaction-join split is the load-bearing property, not the dialect.
+ */
+
+import type { AuditLogAppendInput, IAuditCommands } from '@byline/core'
+import type { MySql2Database } from 'drizzle-orm/mysql2'
+import { v7 as uuidv7 } from 'uuid'
+
+import { auditLog } from '../../database/schema/index.js'
+import type * as schema from '../../database/schema/index.js'
+import type { DBManager } from '../../lib/db-manager.js'
+
+type DatabaseConnection = MySql2Database<typeof schema>
+
+export class AuditCommands implements IAuditCommands {
+  constructor(private dbManager: DBManager) {}
+
+  /** Ambient transaction when a `withTransaction` boundary is open, else the pool. */
+  private get db(): DatabaseConnection {
+    return this.dbManager.get()
+  }
+
+  async append(input: AuditLogAppendInput): Promise<{ id: string }> {
+    const id = uuidv7() // time-ordered, so id ordering ≈ occurred_at ordering
+    await this.db.insert(auditLog).values({
+      id,
+      document_id: input.documentId ?? null,
+      collection_id: input.collectionId ?? null,
+      actor_id: input.actorId ?? null,
+      actor_realm: input.actorRealm,
+      action: input.action,
+      field: input.field ?? null,
+      // `?? null` only coerces undefined → SQL NULL; a real `false`/`0`/`''`
+      // before/after value is preserved.
+      before: input.before ?? null,
+      after: input.after ?? null,
+      // occurred_at defaults to CURRENT_TIMESTAMP(3) at the DB.
+    })
+    return { id }
+  }
+}
+
+export function createAuditCommands(dbManager: DBManager): AuditCommands {
+  return new AuditCommands(dbManager)
+}

--- a/packages/db-mysql/src/modules/audit/audit-queries.ts
+++ b/packages/db-mysql/src/modules/audit/audit-queries.ts
@@ -22,6 +22,7 @@ import { desc, eq, type SQL, sql } from 'drizzle-orm'
 import type { MySql2Database } from 'drizzle-orm/mysql2'
 
 import { auditLog, documentVersions } from '../../database/schema/index.js'
+import { toDate } from '../storage/storage-utils.js'
 import type * as schema from '../../database/schema/index.js'
 
 type DatabaseConnection = MySql2Database<typeof schema>
@@ -47,11 +48,10 @@ function toEntry(row: AuditRow): AuditLogEntry {
  * mysql2 driver parses JSON columns already (confirmed live, matching
  * `normalize-row.ts`'s finding for the storage UNION ALL — an inserted JS
  * object round-trips as an object, not a JSON string), but `occurred_at`
- * comes back as a MySQL datetime **string**, not a `Date` — see
- * `toDate()`'s docstring for why, confirmed live against this exact query
- * shape (a divergence from `normalize-row.ts`'s DATETIME(3)→Date finding,
- * which was confirmed against a schema-typed `.select()`, not a bare
- * `db.execute(sql\`...\`)` call like this one).
+ * comes back as a MySQL datetime **string**, not a `Date` — the same
+ * raw-execute `typeCast` behaviour documented on the shared `toDate()`
+ * helper (`storage-utils.ts`), confirmed live against this exact query
+ * shape as one of that helper's independent call sites.
  */
 type ActivityRow = {
   id: string
@@ -64,29 +64,6 @@ type ActivityRow = {
   before: unknown
   after: unknown
   occurred_at: string
-}
-
-/**
- * Coerce a raw mysql2 `db.execute(sql\`...\`)` `DATETIME(3)` value to a real
- * `Date`. Confirmed live: drizzle-orm's mysql2 driver installs its own
- * `typeCast` on every `execute()`/`query()` call that is not backed by a
- * schema-typed `fields` mapper (`node_modules/drizzle-orm/mysql2/session.js`
- * — `MySql2PreparedQuery`'s `rawQuery.typeCast` unconditionally calls
- * `field.string()` for `TIMESTAMP`/`DATETIME`/`DATE` columns), overriding
- * whatever the underlying mysql2 pool's own `timezone`/date-parsing options
- * would otherwise do. `this.db.execute(sql\`...\`)` — the pattern this class
- * and `storage-queries.ts`'s raw UNION ALL reads both use — always takes
- * that no-`fields` path, so every hand-written SQL read through `db.execute`
- * gets datetime columns back as `'YYYY-MM-DD HH:MM:SS.mmm'` strings, never
- * `Date` objects, regardless of pool configuration. The string carries no
- * timezone marker, but every `DATETIME(3)` column in this schema is UTC by
- * convention (the pool's `timezone: 'Z'` option — see `src/index.ts` —
- * documents that discipline even though it does not apply here), so
- * appending `Z` after normalising the separator is the correct — not an
- * assumed — interpretation.
- */
-function toDate(value: string): Date {
-  return new Date(`${value.replace(' ', 'T')}Z`)
 }
 
 export class AuditQueries implements IAuditQueries {
@@ -232,7 +209,7 @@ export class AuditQueries implements IAuditQueries {
   }
 }
 
-/** Like `toEntry`, but for a raw `ActivityRow` off the UNION — see `toDate`. */
+/** Like `toEntry`, but for a raw `ActivityRow` off the UNION — see `toDate` (`storage-utils.ts`). */
 function toEntryFromActivityRow(row: ActivityRow): AuditLogEntry {
   return {
     id: row.id,
@@ -244,7 +221,10 @@ function toEntryFromActivityRow(row: ActivityRow): AuditLogEntry {
     field: row.field,
     before: row.before,
     after: row.after,
-    occurredAt: toDate(row.occurred_at),
+    // `occurred_at` is NOT NULL on both UNION legs (`documentVersions.created_at`,
+    // `auditLog.occurred_at`), so the shared `toDate`'s `null` branch is
+    // unreachable here — the cast reflects that, not an assumption.
+    occurredAt: toDate(row.occurred_at) as Date,
   }
 }
 

--- a/packages/db-mysql/src/modules/audit/audit-queries.ts
+++ b/packages/db-mysql/src/modules/audit/audit-queries.ts
@@ -1,0 +1,253 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+/**
+ * Audit-log reads (docs/06-auth-and-security/02-auditability.md — Workstreams 3 & 4). Reads run on the pool
+ * directly — they never need to join an audit write's transaction — so this
+ * takes the raw `db` (drizzle over the pool) rather than the `DBManager`.
+ * Access scoping is the caller's responsibility (the document's own read
+ * gate); these queries do no scoping of their own. Mirrors
+ * `packages/db-postgres/src/modules/audit/audit-queries.ts` with the CAST /
+ * string-concat / result-shape adjustments the mysql2 driver requires — see
+ * inline comments at each divergence.
+ */
+
+import type { AuditLogEntry, AuditLogPage, IAuditQueries } from '@byline/core'
+import { desc, eq, type SQL, sql } from 'drizzle-orm'
+import type { MySql2Database } from 'drizzle-orm/mysql2'
+
+import { auditLog, documentVersions } from '../../database/schema/index.js'
+import type * as schema from '../../database/schema/index.js'
+
+type DatabaseConnection = MySql2Database<typeof schema>
+type AuditRow = typeof auditLog.$inferSelect
+
+function toEntry(row: AuditRow): AuditLogEntry {
+  return {
+    id: row.id,
+    documentId: row.document_id,
+    collectionId: row.collection_id,
+    actorId: row.actor_id,
+    actorRealm: row.actor_realm,
+    action: row.action,
+    field: row.field,
+    before: row.before,
+    after: row.after,
+    occurredAt: row.occurred_at,
+  }
+}
+
+/**
+ * One activity row off the UNION — same columns as `byline_audit_log`. The
+ * mysql2 driver parses JSON columns already (confirmed live, matching
+ * `normalize-row.ts`'s finding for the storage UNION ALL — an inserted JS
+ * object round-trips as an object, not a JSON string), but `occurred_at`
+ * comes back as a MySQL datetime **string**, not a `Date` — see
+ * `toDate()`'s docstring for why, confirmed live against this exact query
+ * shape (a divergence from `normalize-row.ts`'s DATETIME(3)→Date finding,
+ * which was confirmed against a schema-typed `.select()`, not a bare
+ * `db.execute(sql\`...\`)` call like this one).
+ */
+type ActivityRow = {
+  id: string
+  document_id: string | null
+  collection_id: string | null
+  actor_id: string | null
+  actor_realm: string
+  action: string
+  field: string | null
+  before: unknown
+  after: unknown
+  occurred_at: string
+}
+
+/**
+ * Coerce a raw mysql2 `db.execute(sql\`...\`)` `DATETIME(3)` value to a real
+ * `Date`. Confirmed live: drizzle-orm's mysql2 driver installs its own
+ * `typeCast` on every `execute()`/`query()` call that is not backed by a
+ * schema-typed `fields` mapper (`node_modules/drizzle-orm/mysql2/session.js`
+ * — `MySql2PreparedQuery`'s `rawQuery.typeCast` unconditionally calls
+ * `field.string()` for `TIMESTAMP`/`DATETIME`/`DATE` columns), overriding
+ * whatever the underlying mysql2 pool's own `timezone`/date-parsing options
+ * would otherwise do. `this.db.execute(sql\`...\`)` — the pattern this class
+ * and `storage-queries.ts`'s raw UNION ALL reads both use — always takes
+ * that no-`fields` path, so every hand-written SQL read through `db.execute`
+ * gets datetime columns back as `'YYYY-MM-DD HH:MM:SS.mmm'` strings, never
+ * `Date` objects, regardless of pool configuration. The string carries no
+ * timezone marker, but every `DATETIME(3)` column in this schema is UTC by
+ * convention (the pool's `timezone: 'Z'` option — see `src/index.ts` —
+ * documents that discipline even though it does not apply here), so
+ * appending `Z` after normalising the separator is the correct — not an
+ * assumed — interpretation.
+ */
+function toDate(value: string): Date {
+  return new Date(`${value.replace(' ', 'T')}Z`)
+}
+
+export class AuditQueries implements IAuditQueries {
+  constructor(private db: DatabaseConnection) {}
+
+  async getDocumentAuditLog(params: {
+    document_id: string
+    page?: number
+    page_size?: number
+  }): Promise<AuditLogPage> {
+    const page = params.page ?? 1
+    const pageSize = params.page_size ?? 20
+    const offset = (page - 1) * pageSize
+
+    // `count(*)::int` (pg) → `CAST(COUNT(*) AS SIGNED)` (design spec §2).
+    const totalResult = await this.db
+      .select({ count: sql<number>`CAST(COUNT(*) AS SIGNED)` })
+      .from(auditLog)
+      .where(eq(auditLog.document_id, params.document_id))
+    const total = Number(totalResult[0]?.count) || 0
+    const totalPages = Math.ceil(total / pageSize)
+
+    const rows = await this.db
+      .select()
+      .from(auditLog)
+      .where(eq(auditLog.document_id, params.document_id))
+      // id is UUIDv7 — DESC is newest-first without a separate sort column.
+      .orderBy(desc(auditLog.id))
+      .limit(pageSize)
+      .offset(offset)
+
+    return {
+      entries: rows.map(toEntry),
+      meta: { total, page, pageSize, totalPages },
+    }
+  }
+
+  async findAuditLog(params: {
+    actorId?: string
+    collectionId?: string
+    action?: string
+    from?: Date
+    to?: Date
+    page?: number
+    page_size?: number
+  }): Promise<AuditLogPage> {
+    const page = params.page ?? 1
+    const pageSize = params.page_size ?? 20
+    const offset = (page - 1) * pageSize
+
+    // The activity feed is the UNION of two disjoint event sources, normalised
+    // onto the audit-log column shape (see IAuditQueries.findAuditLog):
+    //
+    //   1. byline_document_versions — content saves. event_type maps to a
+    //      `document.created` / `document.updated` action; created_by/created_at
+    //      become actor_id/occurred_at; field/before/after are null. Restricted
+    //      to create+update so any legacy 'delete' version rows can't surface
+    //      (deletions live only in the audit log — the union double-counts
+    //      nothing).
+    //   2. byline_audit_log — path/locale/status changes, deletions, and
+    //      future admin-realm events, used as-is.
+    //
+    // Filters and ordering apply to the unioned result; occurred_at is the only
+    // cross-source sort key (the per-source UUIDv7 ids are separate sequences).
+    //
+    // MySQL divergences from the pg source (design spec §2, confirmed live):
+    //   - `NULL::varchar` / `NULL::jsonb` casts → `CAST(NULL AS CHAR(128))` /
+    //     `CAST(NULL AS JSON)`. An untyped bare `NULL` in one UNION leg while
+    //     the sibling leg has a real typed column is fine for MySQL's type
+    //     resolution, but an explicit CAST keeps the two legs' declared types
+    //     symmetric and self-documenting, matching the pg source's intent.
+    //   - `'document.' || event_type` → `CONCAT('document.', event_type)` —
+    //     MySQL's `||` is logical OR by default (PIPES_AS_CONCAT is not a
+    //     baseline assumption for this adapter), so string concatenation must
+    //     use `CONCAT`.
+    //   - `before` backtick-quoted throughout — confirmed live:
+    //     `BEFORE` is a reserved word in MySQL (trigger syntax, `CREATE
+    //     TRIGGER ... BEFORE INSERT`), so an unquoted `before` column alias
+    //     or bare column reference is a syntax error (`ER_PARSE_ERROR`) both
+    //     as an `AS before` alias declaration and as a bare `SELECT ...,
+    //     before, ...` reference in the outer wrapper. `after` is NOT
+    //     reserved (confirmed live) but is backtick-quoted alongside it for
+    //     symmetry.
+    const union = sql`
+      SELECT id, document_id, collection_id, actor_id, actor_realm, action, field, \`before\`, \`after\`, occurred_at FROM (
+        SELECT
+          ${documentVersions.id} AS id,
+          ${documentVersions.document_id} AS document_id,
+          ${documentVersions.collection_id} AS collection_id,
+          ${documentVersions.created_by} AS actor_id,
+          CASE WHEN ${documentVersions.created_by} IS NULL THEN 'system' ELSE 'admin' END AS actor_realm,
+          CASE ${documentVersions.event_type}
+            WHEN 'create' THEN 'document.created'
+            WHEN 'update' THEN 'document.updated'
+            ELSE CONCAT('document.', ${documentVersions.event_type})
+          END AS action,
+          CAST(NULL AS CHAR(128)) AS field,
+          CAST(NULL AS JSON) AS \`before\`,
+          CAST(NULL AS JSON) AS \`after\`,
+          ${documentVersions.created_at} AS occurred_at
+        FROM ${documentVersions}
+        WHERE ${documentVersions.event_type} IN ('create', 'update')
+        UNION ALL
+        SELECT
+          ${auditLog.id} AS id,
+          ${auditLog.document_id} AS document_id,
+          ${auditLog.collection_id} AS collection_id,
+          ${auditLog.actor_id} AS actor_id,
+          ${auditLog.actor_realm} AS actor_realm,
+          ${auditLog.action} AS action,
+          ${auditLog.field} AS field,
+          ${auditLog.before} AS \`before\`,
+          ${auditLog.after} AS \`after\`,
+          ${auditLog.occurred_at} AS occurred_at
+        FROM ${auditLog}
+      ) AS activity`
+
+    const filters: SQL[] = []
+    if (params.actorId) filters.push(sql`actor_id = ${params.actorId}`)
+    if (params.collectionId) filters.push(sql`collection_id = ${params.collectionId}`)
+    if (params.action) filters.push(sql`action = ${params.action}`)
+    if (params.from) filters.push(sql`occurred_at >= ${params.from}`)
+    if (params.to) filters.push(sql`occurred_at <= ${params.to}`)
+    const whereClause = filters.length > 0 ? sql` WHERE ${sql.join(filters, sql` AND `)}` : sql``
+
+    // `db.execute()` on the mysql2 driver returns a `[rows, fields]` tuple
+    // (unlike pg's `{ rows }` result object) — see `storage-queries.ts` for
+    // the established pattern this mirrors.
+    const totalResult = (await this.db.execute(
+      sql`SELECT CAST(COUNT(*) AS SIGNED) AS count FROM (${union}${whereClause}) AS filtered`
+    )) as unknown as [Array<{ count: number }>, unknown]
+    const total = Number(totalResult[0][0]?.count) || 0
+    const totalPages = Math.ceil(total / pageSize)
+
+    const result = (await this.db.execute(
+      sql`${union}${whereClause} ORDER BY occurred_at DESC, id DESC LIMIT ${pageSize} OFFSET ${offset}`
+    )) as unknown as [ActivityRow[], unknown]
+
+    return {
+      entries: result[0].map((row) => toEntryFromActivityRow(row)),
+      meta: { total, page, pageSize, totalPages },
+    }
+  }
+}
+
+/** Like `toEntry`, but for a raw `ActivityRow` off the UNION — see `toDate`. */
+function toEntryFromActivityRow(row: ActivityRow): AuditLogEntry {
+  return {
+    id: row.id,
+    documentId: row.document_id,
+    collectionId: row.collection_id,
+    actorId: row.actor_id,
+    actorRealm: row.actor_realm,
+    action: row.action,
+    field: row.field,
+    before: row.before,
+    after: row.after,
+    occurredAt: toDate(row.occurred_at),
+  }
+}
+
+export function createAuditQueries(db: DatabaseConnection): AuditQueries {
+  return new AuditQueries(db)
+}

--- a/packages/db-mysql/src/modules/counters/counters-commands.ts
+++ b/packages/db-mysql/src/modules/counters/counters-commands.ts
@@ -1,0 +1,150 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import type { ICounterCommands } from '@byline/core'
+import type { Pool, ResultSetHeader, RowDataPacket } from 'mysql2/promise'
+
+/**
+ * Table-emulated counters (design spec §3 — "the one real design
+ * divergence"). MySQL has no `CREATE SEQUENCE`, so `byline_counter_groups`
+ * IS the allocator: `current_value` holds the counter's live state, advanced
+ * in place with the classic `LAST_INSERT_ID(expr)` idiom, which makes an
+ * atomic `UPDATE`/`INSERT ... ON DUPLICATE KEY UPDATE` return its own new
+ * value via a same-connection `SELECT LAST_INSERT_ID()` — no separate
+ * `SELECT ... FOR UPDATE` round trip needed.
+ *
+ * Static (`ensureCounterGroup` + `nextCounterValue`) and runtime-scoped
+ * (`nextScopedCounterValue`) counters deliberately share the one
+ * `byline_counter_groups` table, keyed by name — see the schema comment on
+ * `counterGroups` (`packages/db-mysql/src/database/schema/index.ts`) for why
+ * a second `byline_counter_scopes` table (as the plan's implementation note
+ * first sketched) cannot honour `ICounterCommands`'s documented contract
+ * that a scope self-registered via `nextScopedCounterValue` continues the
+ * very same count when subsequently read through `nextCounterValue` — two
+ * independently-incrementing tables cannot both be "the same sequence"
+ * without every scoped call also writing the static table to keep them in
+ * sync, at which point it is one table with extra steps.
+ *
+ * Every method here takes the raw mysql2 **pool**, not `DBManager` — counters
+ * must never run inside the ambient `withTransaction` (a long document-create
+ * transaction holding the counter row would serialise every other writer in
+ * that group; gaps on rollback are already contractual, see
+ * `ICounterCommands.nextCounterValue`'s docstring). `nextCounterValue` and
+ * `nextScopedCounterValue` additionally check out a single connection via
+ * `pool.getConnection()` for their two-statement bodies — `LAST_INSERT_ID()`
+ * is per-connection session state (confirmed live: a second, freshly-opened
+ * connection reads it back as `0` regardless of what a sibling connection
+ * just set it to), so issuing the two statements through `pool.execute()` /
+ * `pool.query()` directly would let the pool hand each one a different
+ * physical connection and silently return another session's value.
+ */
+export class CounterCommands implements ICounterCommands {
+  constructor(private pool: Pool) {}
+
+  async ensureCounterGroup(
+    groupName: string
+  ): Promise<{ groupName: string; sequenceName: string }> {
+    if (!groupName || typeof groupName !== 'string') {
+      throw new Error(`ensureCounterGroup: groupName must be a non-empty string`)
+    }
+
+    // No DB sequence object exists on this dialect — the emulation row's own
+    // identity stands in for the sequence name the Postgres adapter reports.
+    const sequenceName = `byline_counter_groups:${groupName}`
+
+    // `ON DUPLICATE KEY UPDATE group_name = group_name` is a race-safe no-op
+    // on an existing row (confirmed live: reports `ROW_COUNT() = 0` and
+    // leaves `current_value` untouched) — unlike Postgres's `CREATE SEQUENCE
+    // IF NOT EXISTS`, this single statement has no two-phase check-then-act
+    // window for two booting processes to race through, so there is no
+    // unique-violation to absorb here.
+    await this.pool.execute(
+      'INSERT INTO byline_counter_groups (group_name, sequence_name, current_value) VALUES (?, ?, 0) ON DUPLICATE KEY UPDATE group_name = group_name',
+      [groupName, sequenceName]
+    )
+
+    return { groupName, sequenceName }
+  }
+
+  async nextCounterValue(groupName: string): Promise<number> {
+    if (!groupName || typeof groupName !== 'string') {
+      throw new Error(`nextCounterValue: groupName must be a non-empty string`)
+    }
+
+    // Never `this.pool.execute()` here — see the class docblock. Both
+    // statements below must land on the one checked-out connection.
+    const connection = await this.pool.getConnection()
+    try {
+      const [result] = await connection.execute<ResultSetHeader>(
+        'UPDATE byline_counter_groups SET current_value = LAST_INSERT_ID(current_value + 1) WHERE group_name = ?',
+        [groupName]
+      )
+
+      // Zero affected rows means the group was never registered — surface
+      // that immediately rather than silently seeding it (mirrors pg's
+      // "unregistered group is a configuration error" honesty).
+      if (result.affectedRows === 0) {
+        throw new Error(
+          `nextCounterValue: counter group "${groupName}" is not registered. ` +
+            `Call ensureCounterGroup at boot before any document create that uses it.`
+        )
+      }
+
+      const [rows] = await connection.query<RowDataPacket[]>('SELECT LAST_INSERT_ID() AS v')
+      const row = rows[0] as { v: number | string } | undefined
+      if (row === undefined) {
+        throw new Error(
+          `nextCounterValue: LAST_INSERT_ID() returned no row for group "${groupName}"`
+        )
+      }
+      return typeof row.v === 'number' ? row.v : Number(row.v)
+    } finally {
+      connection.release()
+    }
+  }
+
+  async nextScopedCounterValue(scopeName: string): Promise<number> {
+    if (!scopeName || typeof scopeName !== 'string') {
+      throw new Error(`nextScopedCounterValue: scopeName must be a non-empty string`)
+    }
+
+    const sequenceName = `byline_counter_groups:${scopeName}`
+
+    // One atomic ensure-then-allocate statement: the `VALUES` seed itself
+    // wraps `LAST_INSERT_ID(1)`, so the insert path (brand-new scope) also
+    // leaves `LAST_INSERT_ID()` reading `1` on this connection — confirmed
+    // live, including that a second concurrent insert attempt on the same
+    // scope_name correctly falls through to the `ON DUPLICATE KEY UPDATE`
+    // branch rather than erroring. Still needs the same-connection
+    // discipline as `nextCounterValue` — see the class docblock.
+    const connection = await this.pool.getConnection()
+    try {
+      await connection.execute(
+        'INSERT INTO byline_counter_groups (group_name, sequence_name, current_value) ' +
+          'VALUES (?, ?, LAST_INSERT_ID(1)) ' +
+          'ON DUPLICATE KEY UPDATE current_value = LAST_INSERT_ID(current_value + 1)',
+        [scopeName, sequenceName]
+      )
+
+      const [rows] = await connection.query<RowDataPacket[]>('SELECT LAST_INSERT_ID() AS v')
+      const row = rows[0] as { v: number | string } | undefined
+      if (row === undefined) {
+        throw new Error(
+          `nextScopedCounterValue: LAST_INSERT_ID() returned no row for scope "${scopeName}"`
+        )
+      }
+      return typeof row.v === 'number' ? row.v : Number(row.v)
+    } finally {
+      connection.release()
+    }
+  }
+}
+
+export function createCounterCommands(pool: Pool): ICounterCommands {
+  return new CounterCommands(pool)
+}

--- a/packages/db-mysql/src/modules/counters/tests/counters-concurrency.test.ts
+++ b/packages/db-mysql/src/modules/counters/tests/counters-concurrency.test.ts
@@ -1,0 +1,127 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+/**
+ * Guards the concurrency design brief §C calls "the whole task": the
+ * two-statement `UPDATE ... SET current_value = LAST_INSERT_ID(current_value
+ * + 1)` + `SELECT LAST_INSERT_ID()` body of `nextCounterValue` MUST run on
+ * one checked-out connection (`LAST_INSERT_ID()` is per-connection state —
+ * confirmed live during Task 11: a fresh connection reads back `0` regardless
+ * of what a sibling connection just set). Nothing in the shared
+ * `@byline/db-conformance` `countersSuite` exercises this specific risk
+ * surface: its only parallel test (`counters.ts:87-98`) is 8-way on
+ * `nextScopedCounterValue`, whose body is a single atomic
+ * `INSERT ... ON DUPLICATE KEY UPDATE` statement — no same-connection
+ * discipline to get wrong, because there is only ever one statement.
+ * `nextCounterValue`'s two-statement body is the one method where a refactor
+ * could silently swap `connection.execute`/`connection.query` for
+ * `pool.execute`/`pool.query` (dropping the checked-out connection and
+ * letting the pool hand each statement to a different physical connection)
+ * and still pass every other test in this adapter — 280/280 unit, 138/138
+ * integration — because the resulting duplicate/zero counter values only
+ * show up under real concurrent load, which nothing else in the suite
+ * generates against this specific method. This test is that guard, and it
+ * belongs here (a MySQL-specific emulation detail — the shared conformance
+ * suite exercises `ICounterCommands`' contract behaviour, not this
+ * adapter's own connection-checkout implementation).
+ *
+ * Uses its own dedicated pool (not the shared singleton `test-helper.ts`
+ * hands other integration test files in this same worker process — vitest
+ * runs this suite with `fileParallelism: false` / `maxWorkers: 1`, so a
+ * monkey-patched shared pool would leak into whichever file runs next) so
+ * `pool.getConnection` can be instrumented without any cross-file risk.
+ */
+
+import mysql from 'mysql2/promise'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { assertTestDatabase, resetTestDatabase } from '../../../lib/test-db.js'
+import { createCounterCommands } from '../counters-commands.js'
+
+describe('CounterCommands connection discipline under concurrency (mysql, live database)', () => {
+  let pool: mysql.Pool
+  let counters: ReturnType<typeof createCounterCommands>
+
+  beforeAll(async () => {
+    const connectionString = process.env.BYLINE_DB_MYSQL_CONNECTION_STRING
+    assertTestDatabase(connectionString)
+    await resetTestDatabase(connectionString as string)
+
+    // connectionLimit: 4 mirrors the test harness's own pool sizing
+    // (test-helper.ts) — small enough that 20 concurrent nextCounterValue
+    // calls genuinely contend for connections, which is the point.
+    pool = mysql.createPool({
+      uri: connectionString,
+      connectionLimit: 4,
+      timezone: 'Z',
+      decimalNumbers: false,
+      charset: 'UTF8MB4_0900_AI_CI',
+    })
+    counters = createCounterCommands(pool)
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  it('20 parallel nextCounterValue calls on one group yield the expected contiguous set, genuinely contending a 4-connection pool', async () => {
+    const groupName = `concurrency-test-${Date.now()}`
+    await counters.ensureCounterGroup(groupName)
+
+    // Instrument connection checkout/release to prove the calls genuinely
+    // overlapped rather than serialized. Distinctness alone does not prove
+    // this: 20 calls run one at a time (each getting its own connection in
+    // turn, or even all 20 on the SAME connection sequentially) would also
+    // return 20 distinct, contiguous values — the two-statement
+    // same-connection defect this test exists to catch only shows up under
+    // real overlap, so the test must force and observe that overlap
+    // directly rather than infer it from the results.
+    let activeConnections = 0
+    let maxObservedConcurrency = 0
+    const originalGetConnection = pool.getConnection.bind(pool)
+    // biome-ignore lint/suspicious/noExplicitAny: instrumenting the pool's
+    // own connection lifecycle needs to reach past mysql2/promise's typed
+    // surface; scoped to this test and restored in the `finally` below.
+    ;(pool as any).getConnection = async (...args: unknown[]) => {
+      const conn = await (originalGetConnection as (...a: unknown[]) => Promise<any>)(...args)
+      activeConnections++
+      maxObservedConcurrency = Math.max(maxObservedConcurrency, activeConnections)
+      const originalRelease = conn.release.bind(conn)
+      conn.release = (...releaseArgs: unknown[]) => {
+        activeConnections--
+        return originalRelease(...releaseArgs)
+      }
+      return conn
+    }
+
+    let results: number[]
+    try {
+      results = await Promise.all(
+        Array.from({ length: 20 }, () => counters.nextCounterValue(groupName))
+      )
+    } finally {
+      pool.getConnection = originalGetConnection
+    }
+
+    // Distinct AND the exact expected contiguous set {1..20} — a silently
+    // duplicated or zero return (the actual failure mode of a connection-
+    // discipline regression, per LAST_INSERT_ID()'s per-connection scoping)
+    // fails this, not just a weaker "no two values are equal" check.
+    const sorted = [...results].sort((a, b) => a - b)
+    expect(new Set(results).size).toBe(20)
+    expect(sorted).toEqual(Array.from({ length: 20 }, (_, i) => i + 1))
+
+    // Genuine contention, not accidental interleaving: with
+    // connectionLimit: 4 and 20 concurrent callers, more than one
+    // connection must have been checked out simultaneously at some point.
+    // A fully-serialized run — the shape a same-connection-checkout
+    // regression's fix-by-coincidence could produce — would never exceed 1
+    // here.
+    expect(maxObservedConcurrency).toBeGreaterThan(1)
+  })
+})

--- a/packages/db-mysql/src/modules/storage/classify-error.test.node.ts
+++ b/packages/db-mysql/src/modules/storage/classify-error.test.node.ts
@@ -1,0 +1,101 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import { runClassifyErrorContract } from '@byline/db-conformance'
+import { describe, expect, it } from 'vitest'
+
+import { classifyError } from './classify-error.js'
+
+describe('classifyError (mysql)', () => {
+  it('classifies a raw ER_DUP_ENTRY (errno 1062) as DB_UNIQUE_VIOLATION with the bare index name', () => {
+    const err = {
+      code: 'ER_DUP_ENTRY',
+      errno: 1062,
+      sqlState: '23000',
+      message: "Duplicate entry '1' for key 't_dup.idx_document_paths_collection_locale_path'",
+    }
+    expect(classifyError(err)).toEqual({
+      code: 'DB_UNIQUE_VIOLATION',
+      constraint: 'idx_document_paths_collection_locale_path',
+    })
+  })
+
+  it('walks a Drizzle-style cause chain to the underlying mysql2 error', () => {
+    const err = {
+      name: 'DrizzleQueryError',
+      cause: {
+        code: 'ER_DUP_ENTRY',
+        errno: 1062,
+        sqlState: '23000',
+        message: "Duplicate entry '2' for key 'byline_document_paths.some_other_unique'",
+      },
+    }
+    expect(classifyError(err)).toEqual({
+      code: 'DB_UNIQUE_VIOLATION',
+      constraint: 'some_other_unique',
+    })
+  })
+
+  it('matches on the numeric errno, not the code string', () => {
+    // Same errno, a code string that would not stringwise-match anything —
+    // classification still succeeds because the match is on `errno`.
+    const err = {
+      code: 'SOME_OTHER_CODE',
+      errno: 1062,
+      message: "Duplicate entry '1' for key 't.idx_x'",
+    }
+    expect(classifyError(err).code).toBe('DB_UNIQUE_VIOLATION')
+  })
+
+  it('returns DB_UNKNOWN for a non-duplicate-key error', () => {
+    expect(
+      classifyError({
+        code: 'ER_NO_REFERENCED_ROW_2',
+        errno: 1452,
+        sqlState: '23000',
+        message: 'Cannot add or update a child row: a foreign key constraint fails',
+      })
+    ).toEqual({ code: 'DB_UNKNOWN' })
+  })
+
+  it('returns DB_UNKNOWN for a non-error value', () => {
+    expect(classifyError(undefined)).toEqual({ code: 'DB_UNKNOWN' })
+    expect(classifyError('boom')).toEqual({ code: 'DB_UNKNOWN' })
+    expect(classifyError(null)).toEqual({ code: 'DB_UNKNOWN' })
+  })
+})
+
+runClassifyErrorContract([
+  {
+    adapterName: 'mysql',
+    classifyError,
+    uniqueViolationError: {
+      code: 'ER_DUP_ENTRY',
+      errno: 1062,
+      sqlState: '23000',
+      message:
+        "Duplicate entry 'some-uuid' for key 'byline_document_paths.idx_document_paths_collection_locale_path'",
+    },
+    nestedUniqueViolationError: {
+      name: 'DrizzleQueryError',
+      cause: {
+        code: 'ER_DUP_ENTRY',
+        errno: 1062,
+        sqlState: '23000',
+        message:
+          "Duplicate entry 'some-uuid' for key 'byline_document_paths.idx_document_paths_collection_locale_path'",
+      },
+    },
+    unrelatedError: {
+      code: 'ER_NO_REFERENCED_ROW_2',
+      errno: 1452,
+      sqlState: '23000',
+      message: 'Cannot add or update a child row: a foreign key constraint fails',
+    },
+  },
+])

--- a/packages/db-mysql/src/modules/storage/classify-error.ts
+++ b/packages/db-mysql/src/modules/storage/classify-error.ts
@@ -1,0 +1,53 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import { type DbErrorClassification, DbErrorCodes } from '@byline/core'
+
+/**
+ * Classify a MySQL driver error. Walks a short `cause` chain (Drizzle's
+ * `DrizzleQueryError` → the underlying mysql2 error) looking for a
+ * duplicate-key error and returns the carried index name. Mirrors
+ * `packages/db-postgres/src/modules/storage/classify-error.ts`, whose
+ * pg-anatomy docblock this docblock intentionally parallels.
+ *
+ * MySQL error anatomy (verified against a live MySQL 9.7.1 server, not
+ * assumed): a duplicate-key violation raises `ERROR 1062 (23000)`, and
+ * mysql2 surfaces it as `{ code: 'ER_DUP_ENTRY', errno: 1062, sqlState:
+ * '23000', message: "Duplicate entry '…' for key '<table>.<index>'" }`.
+ * Unlike Postgres, there is no structural `constraint` property — the index
+ * name must be parsed out of the message, and MySQL 8.0+ qualifies it with
+ * the table name. Matching on the numeric `errno` (not the `code` string)
+ * because it is stable across mysql2 versions and locales; the message text
+ * is not guaranteed to be, though the `for key '…'` shape has held since
+ * MySQL 5.x and is what we parse.
+ *
+ * Carriage semantics (binding, from the #45 review carry-forward): strip the
+ * `<table>.` qualifier and carry the **bare index name**, so both adapters'
+ * `classifyError` report the same shape for the same logical failure — core
+ * never learns driver anatomy. `packages/core/src/services/document-lifecycle
+ * /internals.ts` only substring-matches the constraint, so the qualified
+ * form would also have worked, but a contract is uniform or it is not one.
+ */
+export function classifyError(err: unknown): DbErrorClassification {
+  type MySqlLikeError = { errno?: number; message?: string; cause?: unknown }
+  let e = err as MySqlLikeError | undefined
+  for (let i = 0; i < 3 && e != null && typeof e === 'object'; i++) {
+    if (e.errno === 1062) {
+      const match = typeof e.message === 'string' ? e.message.match(/for key '([^']+)'/) : null
+      const qualifiedName = match?.[1]
+      // MySQL 8.0+ qualifies the index name as `<table>.<index>` — strip the
+      // table qualifier so the carried value is the bare index name only.
+      const constraint = qualifiedName?.includes('.')
+        ? qualifiedName.slice(qualifiedName.indexOf('.') + 1)
+        : qualifiedName
+      return { code: DbErrorCodes.UNIQUE_VIOLATION, constraint }
+    }
+    e = e.cause as MySqlLikeError | undefined
+  }
+  return { code: DbErrorCodes.UNKNOWN }
+}

--- a/packages/db-mysql/src/modules/storage/normalize-row.test.node.ts
+++ b/packages/db-mysql/src/modules/storage/normalize-row.test.node.ts
@@ -1,0 +1,73 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import { normalizeRow } from './normalize-row.js'
+
+describe('normalizeRow (mysql)', () => {
+  it('coerces boolean_value from a driver TINYINT(1) number to boolean', () => {
+    expect(normalizeRow({ boolean_value: 1 }).boolean_value).toBe(true)
+    expect(normalizeRow({ boolean_value: 0 }).boolean_value).toBe(false)
+  })
+
+  it('coerces thumbnail_generated and cascade_delete the same way', () => {
+    const row = normalizeRow({ thumbnail_generated: 1, cascade_delete: 0 })
+    expect(row.thumbnail_generated).toBe(true)
+    expect(row.cascade_delete).toBe(false)
+  })
+
+  it('passes through null for absent tinyint(1) columns (only one value column is populated per row)', () => {
+    const row = normalizeRow({
+      boolean_value: null,
+      thumbnail_generated: null,
+      cascade_delete: null,
+    })
+    expect(row.boolean_value).toBeNull()
+    expect(row.thumbnail_generated).toBeNull()
+    expect(row.cascade_delete).toBeNull()
+  })
+
+  it('tolerates a value already coerced to a real boolean', () => {
+    expect(normalizeRow({ boolean_value: true }).boolean_value).toBe(true)
+    expect(normalizeRow({ boolean_value: false }).boolean_value).toBe(false)
+  })
+
+  it('leaves a DECIMAL string untouched (decimalNumbers: false at the pool)', () => {
+    const row = normalizeRow({ value_decimal: '299.99' })
+    expect(row.value_decimal).toBe('299.99')
+    expect(typeof row.value_decimal).toBe('string')
+  })
+
+  it('leaves an already-parsed JSON value untouched (the driver parses JSON columns itself)', () => {
+    const value = { a: 1, b: [1, 2, 3] }
+    const row = normalizeRow({ json_value: value })
+    expect(row.json_value).toBe(value)
+  })
+
+  it('leaves a DATETIME(3) Date instance untouched', () => {
+    const date = new Date('2024-01-15T10:30:00.123Z')
+    const row = normalizeRow({ value_timestamp_tz: date })
+    expect(row.value_timestamp_tz).toBe(date)
+  })
+
+  it('passes through every other column unchanged', () => {
+    const row = normalizeRow({
+      field_path: 'title',
+      field_name: 'title',
+      locale: 'en',
+      text_value: 'hello',
+    })
+    expect(row).toMatchObject({
+      field_path: 'title',
+      field_name: 'title',
+      locale: 'en',
+      text_value: 'hello',
+    })
+  })
+})

--- a/packages/db-mysql/src/modules/storage/normalize-row.test.node.ts
+++ b/packages/db-mysql/src/modules/storage/normalize-row.test.node.ts
@@ -50,10 +50,41 @@ describe('normalizeRow (mysql)', () => {
     expect(row.json_value).toBe(value)
   })
 
-  it('leaves a DATETIME(3) Date instance untouched', () => {
+  it('leaves an already-Date value_timestamp_tz untouched (defensive — not expected on the live driver path)', () => {
     const date = new Date('2024-01-15T10:30:00.123Z')
     const row = normalizeRow({ value_timestamp_tz: date })
     expect(row.value_timestamp_tz).toBe(date)
+  })
+
+  it('coerces value_timestamp_tz from the driver DATETIME string to a real Date', () => {
+    // The shape drizzle-orm's mysql2 driver actually hands back on the raw
+    // `db.execute()` path (its own typeCast forces DATETIME to a string) —
+    // confirmed live against `packages/db-mysql/scripts` probes for the
+    // Task 11 report. Space-separated, no timezone marker (UTC by schema
+    // convention).
+    const row = normalizeRow({ value_timestamp_tz: '2026-01-15 10:30:00.123456' })
+    expect(row.value_timestamp_tz).toBeInstanceOf(Date)
+    expect((row.value_timestamp_tz as Date).toISOString()).toBe('2026-01-15T10:30:00.123Z')
+  })
+
+  it('passes through null for an absent value_timestamp_tz column', () => {
+    expect(normalizeRow({ value_timestamp_tz: null }).value_timestamp_tz).toBeNull()
+  })
+
+  it('coerces value_date from the driver DATE string to a UTC-midnight Date', () => {
+    const row = normalizeRow({ value_date: '2026-01-15' })
+    expect(row.value_date).toBeInstanceOf(Date)
+    expect((row.value_date as Date).toISOString()).toBe('2026-01-15T00:00:00.000Z')
+  })
+
+  it('leaves an already-Date value_date untouched (defensive)', () => {
+    const date = new Date('2026-01-15T00:00:00.000Z')
+    const row = normalizeRow({ value_date: date })
+    expect(row.value_date).toBe(date)
+  })
+
+  it('passes through null for an absent value_date column', () => {
+    expect(normalizeRow({ value_date: null }).value_date).toBeNull()
   })
 
   it('passes through every other column unchanged', () => {

--- a/packages/db-mysql/src/modules/storage/normalize-row.ts
+++ b/packages/db-mysql/src/modules/storage/normalize-row.ts
@@ -8,6 +8,8 @@
 
 import type { UnifiedFieldValue } from '@byline/core'
 
+import { toDate } from './storage-utils.js'
+
 /**
  * Canonicalise a raw UNION ALL driver row to the shared `UnifiedFieldValue`
  * contract before it reaches `extractFlattenedFieldValue`. Mirrors
@@ -31,8 +33,22 @@ import type { UnifiedFieldValue } from '@byline/core'
  *   - `JSON` columns arrive already parsed by the driver — confirmed live
  *     (an inserted JS object round-trips as an object, not a JSON string) —
  *     so this function must not re-`JSON.parse` them.
- *   - `DATETIME(3)` → `Date`, confirmed live with the pool's `timezone: 'Z'`
- *     option, millisecond precision intact.
+ *   - `DATE`/`DATETIME` → **string**, not `Date` — the opposite of what an
+ *     earlier version of this comment claimed. `drizzle-orm`'s mysql2
+ *     driver installs its own `typeCast` on every raw `db.execute(sql\`...\`)`
+ *     call (this UNION ALL query has no schema-typed `fields` mapper, so it
+ *     always takes that path) that unconditionally calls `field.string()`
+ *     for `TIMESTAMP`/`DATETIME`/`DATE` columns, overriding whatever the
+ *     pool's own `timezone` option would otherwise do — confirmed live:
+ *     `value_date` (a `datetimeStore.date_type === 'date'` row) comes back
+ *     as `'2026-01-15'`; `value_timestamp_tz` (`date_type === 'datetime'`)
+ *     comes back as `'2026-01-15 10:30:00.123000'`. Both reach
+ *     `restoreFieldSetData` (`@byline/core`) and become the runtime value
+ *     of a document's `date`/`datetime` field, so an un-coerced string here
+ *     was a real, user-facing defect — not just an internal-tooling one —
+ *     caught by no existing test because none exercised a `date`/`datetime`
+ *     field type through this UNION ALL path. `toDate` (shared,
+ *     `storage-utils.js`) and `toDateOnly` below fix it.
  */
 export function normalizeRow(row: Record<string, unknown>): UnifiedFieldValue {
   return {
@@ -40,7 +56,21 @@ export function normalizeRow(row: Record<string, unknown>): UnifiedFieldValue {
     boolean_value: normalizeTinyIntBoolean(row.boolean_value),
     thumbnail_generated: normalizeTinyIntBoolean(row.thumbnail_generated),
     cascade_delete: normalizeTinyIntBoolean(row.cascade_delete),
+    value_date: toDateOnly(row.value_date as string | null | undefined),
+    value_timestamp_tz: toDate(row.value_timestamp_tz as string | null | undefined),
   } as unknown as UnifiedFieldValue
+}
+
+/**
+ * `'2026-01-15'` (MySQL `DATE` text, no time-of-day component) → a `Date`
+ * at UTC midnight for that calendar date — matching node-postgres's own
+ * default parser for a `date` column (pg's `normalize-row.ts` is an
+ * identity cast precisely because that adapter's driver already does this).
+ */
+function toDateOnly(value: string | Date | null | undefined): Date | null {
+  if (value == null) return null
+  if (value instanceof Date) return value
+  return new Date(`${value}T00:00:00.000Z`)
 }
 
 /**

--- a/packages/db-mysql/src/modules/storage/normalize-row.ts
+++ b/packages/db-mysql/src/modules/storage/normalize-row.ts
@@ -1,0 +1,56 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import type { UnifiedFieldValue } from '@byline/core'
+
+/**
+ * Canonicalise a raw UNION ALL driver row to the shared `UnifiedFieldValue`
+ * contract before it reaches `extractFlattenedFieldValue`. Mirrors
+ * `packages/db-postgres/src/modules/storage/normalize-row.ts`, whose pg
+ * counterpart is an identity cast — the mysql2 driver needs real
+ * canonicalisation, verified against a live MySQL 9.7.1 server rather than
+ * assumed (mysql2's declared types are a hypothesis, not fact — see
+ * `src/index.ts`'s boot-check comment for the prior instance of this on
+ * this program):
+ *
+ *   - `TINYINT(1)` → `boolean`. mysql2 returns a JS `number` (`0`/`1`) for
+ *     `TINYINT(1)` columns selected through a raw query, not a `boolean` —
+ *     confirmed live. Only the three `UnifiedFieldValue` columns backed by a
+ *     `boolean()` column need the coercion: `boolean_value` (the boolean
+ *     store's own value), `thumbnail_generated` (file store), and
+ *     `cascade_delete` (relation store).
+ *   - `DECIMAL` stays a **string** — confirmed live with the pool's
+ *     `decimalNumbers: false` option (`src/index.ts`), which must not be
+ *     undone; MySQL/JS float coercion would lose precision on money/decimal
+ *     values, matching the pg adapter's `numeric` handling.
+ *   - `JSON` columns arrive already parsed by the driver — confirmed live
+ *     (an inserted JS object round-trips as an object, not a JSON string) —
+ *     so this function must not re-`JSON.parse` them.
+ *   - `DATETIME(3)` → `Date`, confirmed live with the pool's `timezone: 'Z'`
+ *     option, millisecond precision intact.
+ */
+export function normalizeRow(row: Record<string, unknown>): UnifiedFieldValue {
+  return {
+    ...row,
+    boolean_value: normalizeTinyIntBoolean(row.boolean_value),
+    thumbnail_generated: normalizeTinyIntBoolean(row.thumbnail_generated),
+    cascade_delete: normalizeTinyIntBoolean(row.cascade_delete),
+  } as unknown as UnifiedFieldValue
+}
+
+/**
+ * `TINYINT(1)` → `boolean`, tolerant of the value already being a real
+ * boolean (a row assembled in-process rather than round-tripped through the
+ * driver) or `null`/`undefined` (column absent for this row's field type —
+ * only one value column is ever populated per UNION ALL row).
+ */
+function normalizeTinyIntBoolean(value: unknown): boolean | null {
+  if (value == null) return null
+  if (typeof value === 'boolean') return value
+  return value !== 0
+}

--- a/packages/db-mysql/src/modules/storage/normalize-row.ts
+++ b/packages/db-mysql/src/modules/storage/normalize-row.ts
@@ -63,9 +63,28 @@ export function normalizeRow(row: Record<string, unknown>): UnifiedFieldValue {
 
 /**
  * `'2026-01-15'` (MySQL `DATE` text, no time-of-day component) → a `Date`
- * at UTC midnight for that calendar date — matching node-postgres's own
- * default parser for a `date` column (pg's `normalize-row.ts` is an
- * identity cast precisely because that adapter's driver already does this).
+ * at **UTC** midnight for that calendar date.
+ *
+ * This is an elected divergence from node-postgres, not a parity claim — an
+ * earlier version of this docblock claimed UTC midnight matches
+ * node-postgres's own default parser for a `date` column. It doesn't.
+ * node-postgres's default `date` parser is `postgres-date` (see its
+ * `index.js:16-17`, whose own comment reads "Force YYYY-MM-DD dates to be
+ * parsed as local time"), so pg's `normalize-row.ts` being an identity cast
+ * means that adapter returns **local** midnight, not UTC midnight — on any
+ * host not running in UTC, the same stored `date` value materialises as a
+ * different `Date` (potentially a different calendar day once rendered)
+ * depending on which adapter served it.
+ *
+ * UTC midnight is defensible on its own terms — deterministic across hosts,
+ * where pg's local-midnight parse is host-timezone-dependent — but choosing
+ * between the two properly needs temporal fixtures in the shared
+ * `@byline/db-conformance` suite (today's `field-types.ts` only asserts
+ * `attachment.fileSize`, never a temporal value) and a non-UTC CI leg to
+ * prove either adapter's behaviour under a host offset — neither exists
+ * yet. So this stays exactly as it is: **elected, pending adjudication** —
+ * do not change this behaviour without that groundwork; see the PR 3
+ * tracking note.
  */
 function toDateOnly(value: string | Date | null | undefined): Date | null {
   if (value == null) return null

--- a/packages/db-mysql/src/modules/storage/storage-commands.ts
+++ b/packages/db-mysql/src/modules/storage/storage-commands.ts
@@ -47,7 +47,7 @@ import {
 } from '../../database/schema/index.js'
 import { classifyError } from './classify-error.js'
 import { prepareFieldInsertBuckets } from './storage-insert.js'
-import { getFirstOrThrow } from './storage-utils.js'
+import { affectedRowCount, getFirstOrThrow } from './storage-utils.js'
 import type * as schema from '../../database/schema/index.js'
 import type { DBManager } from '../../lib/db-manager.js'
 
@@ -848,7 +848,10 @@ export class DocumentCommands implements IDocumentCommands {
    * Returns the number of rows updated. MySQL has no `RETURNING` and drizzle's
    * mysql2 `update()` resolves to a `[ResultSetHeader, FieldPacket[]]` tuple
    * rather than pg's driver result object — `affectedRows` lives on the first
-   * element (confirmed live against the test database), not `.rowCount`.
+   * element (confirmed live against the test database), not `.rowCount`. See
+   * `affectedRowCount()` in `storage-utils.ts`, shared by every guarded write
+   * in this adapter (this method, `softDeleteDocument` below, and the admin
+   * repositories) for that cast.
    */
   async archivePublishedVersions(params: {
     document_id: string
@@ -867,7 +870,7 @@ export class DocumentCommands implements IDocumentCommands {
       .update(documentVersions)
       .set({ status: 'archived', updated_at: new Date() })
       .where(and(...conditions))
-    return (result as unknown as [{ affectedRows: number }, unknown])[0]?.affectedRows ?? 0
+    return affectedRowCount(result)
   }
 
   /**
@@ -902,7 +905,7 @@ export class DocumentCommands implements IDocumentCommands {
           updated_at: new Date(),
         })
         .where(eq(documentVersions.document_id, params.document_id))
-      return (result as unknown as [{ affectedRows: number }, unknown])[0]?.affectedRows ?? 0
+      return affectedRowCount(result)
     })
   }
 

--- a/packages/db-mysql/src/modules/storage/storage-commands.ts
+++ b/packages/db-mysql/src/modules/storage/storage-commands.ts
@@ -6,9 +6,24 @@
  * Copyright (c) Infonomic Company Limited
  */
 
-import type { CollectionDefinition, ICollectionCommands } from '@byline/core'
-import { DbErrorCodes, flattenFieldSetData } from '@byline/core'
-import { and, desc, eq, ne, notInArray, sql } from 'drizzle-orm'
+import type {
+  CollectionDefinition,
+  ICollectionCommands,
+  IDocumentCommands,
+  TreeDeleteMutationResult,
+  TreeMutationResult,
+  TreePlacementState,
+} from '@byline/core'
+import {
+  DbErrorCodes,
+  ERR_CONFLICT,
+  ERR_NOT_FOUND,
+  ERR_VALIDATION,
+  flattenFieldSetData,
+  generateKeyBetween,
+  TREE_PLACEMENT_STALE_MARKER,
+} from '@byline/core'
+import { and, desc, eq, inArray, ne, notInArray, sql } from 'drizzle-orm'
 import type { AnyMySqlTable } from 'drizzle-orm/mysql-core'
 import type { MySql2Database } from 'drizzle-orm/mysql2'
 import { v7 as uuidv7 } from 'uuid'
@@ -16,9 +31,11 @@ import { v7 as uuidv7 } from 'uuid'
 import {
   booleanStore,
   collections,
+  currentDocumentsView,
   datetimeStore,
   documentAvailableLocales,
   documentPaths,
+  documentRelationships,
   documents,
   documentVersions,
   fileStore,
@@ -37,6 +54,18 @@ import type { DBManager } from '../../lib/db-manager.js'
 type DatabaseConnection = MySql2Database<typeof schema>
 /** The transaction handle passed to `this.db.transaction(async (tx) => …)`. */
 type TxConnection = Parameters<Parameters<DatabaseConnection['transaction']>[0]>[0]
+
+/**
+ * Depth backstop for the document-tree recursive walks (cycle guard, ancestor
+ * walk). The write-path cycle guard prevents true cycles, so this only bounds
+ * recursion against pre-existing pathological state — far deeper than any real
+ * documentation hierarchy. Mirrors `packages/db-postgres/src/modules/storage/
+ * storage-commands.ts`. See docs/04-collections/04-document-trees.md.
+ */
+const TREE_MAX_DEPTH = 10_000
+
+const staleTreePlacementMessage = (message: string): string =>
+  `${TREE_PLACEMENT_STALE_MARKER} tree placement is stale: ${message}`
 
 /**
  * CollectionCommands
@@ -129,22 +158,23 @@ export class CollectionCommands implements ICollectionCommands {
 }
 
 /**
- * DocumentCommands — Task 9B, in progress.
+ * DocumentCommands
  *
- * `createDocumentVersion` (Task 9A) plus the standalone system-field writes
- * (`updateDocumentPath`, `setDocumentAvailableLocales`), the status /
- * archive / soft-delete / delete-locale surface (`setDocumentStatus`,
- * `archivePublishedVersions`, `softDeleteDocument`, `deleteDocumentLocale`),
- * and `setOrderKey`. The remaining `IDocumentCommands` members —
- * `placeTreeNode`, `removeFromTree`, `promoteChildrenAndRemoveFromTree` —
- * land next, ported alongside the rest of
- * `packages/db-postgres/src/modules/storage/storage-commands.ts`'s
- * `DocumentCommands`. This class deliberately does not yet `implements
- * IDocumentCommands`; `src/index.ts` composes the full interface object by
- * picking the implemented members off an instance of this class and leaving
- * every other member as the existing `notImplemented(...)` stub.
+ * Ported from `packages/db-postgres/src/modules/storage/storage-commands.ts`'s
+ * `DocumentCommands`. Task 9A landed `createDocumentVersion` and its private
+ * helpers; Task 9B (this task) ports the rest of the write surface —
+ * `updateDocumentPath`, `setDocumentAvailableLocales`, `setDocumentStatus`,
+ * `archivePublishedVersions`, `softDeleteDocument`, `deleteDocumentLocale`,
+ * `setOrderKey`, `placeTreeNode`, `removeFromTree`, and
+ * `promoteChildrenAndRemoveFromTree` — completing `IDocumentCommands`. The
+ * pg source's `reAnchorDocument` / `reAnchorDocuments` / `backfillVersionLocales`
+ * are deliberately NOT ported here: `@byline/db-conformance`'s own suites
+ * (`document-paths.ts`, `locale-fallback.ts`) document them as "Postgres-only
+ * maintenance operations documented as off the core `IDbAdapter` contract" —
+ * not something a conforming adapter is required to implement, and neither is
+ * a member of `IDocumentCommands`.
  */
-export class DocumentCommands {
+export class DocumentCommands implements IDocumentCommands {
   constructor(
     private dbManager: DBManager,
     private defaultContentLocale: string
@@ -580,6 +610,7 @@ export class DocumentCommands {
       set: { id: sql`id` },
     })
   }
+
   /**
    * updateDocumentPath
    *
@@ -639,6 +670,7 @@ export class DocumentCommands {
       })
     })
   }
+
   /**
    * copyAllVersionStoreRows
    *
@@ -875,6 +907,40 @@ export class DocumentCommands {
   }
 
   /**
+   * Write `order_key` on a single `byline_documents` row. Single-column
+   * metadata update — no new version row, no `documentVersions` touch.
+   * `updated_at` on the document row is bumped so list caches invalidate.
+   */
+  async setOrderKey(params: { document_id: string; order_key: string }): Promise<void> {
+    await this.db
+      .update(documents)
+      .set({
+        order_key: params.order_key,
+        updated_at: new Date(),
+      })
+      .where(eq(documents.id, params.document_id))
+  }
+
+  /**
+   * Serialize structural changes per collection and verify the collection
+   * exists. `FOR UPDATE` — no `FOR UPDATE OF` qualifier needed since this
+   * query selects from a single table (confirmed against a live MySQL 9.7.1
+   * server; MySQL 8.0.1+ supports `FOR UPDATE OF tbl_name` for the
+   * multi-table case used below in `lockDocumentCollection`).
+   */
+  private async lockTreeCollection(tx: TxConnection, collectionId: string): Promise<void> {
+    const locked = await tx.execute(sql`
+      SELECT id FROM byline_collections
+      WHERE id = ${collectionId}
+      FOR UPDATE
+    `)
+    const rows = (locked as unknown as [Array<{ id: string }>, unknown])[0]
+    if (rows.length === 0) {
+      throw ERR_NOT_FOUND({ message: 'collection not found', details: { collectionId } })
+    }
+  }
+
+  /**
    * Resolve a document's collection while locking only the collection row.
    * `FOR UPDATE OF c` — confirmed live against a MySQL 9.7.1 server (MySQL
    * 8.0.1+ supports the per-table lock qualifier; `::uuid` casts dropped).
@@ -893,19 +959,512 @@ export class DocumentCommands {
     const rows = (locked as unknown as [Array<{ collection_id: string }>, unknown])[0]
     return rows[0]?.collection_id ?? null
   }
-  /**
-   * Write `order_key` on a single `byline_documents` row. Single-column
-   * metadata update — no new version row, no `documentVersions` touch.
-   * `updated_at` on the document row is bumped so list caches invalidate.
-   */
-  async setOrderKey(params: { document_id: string; order_key: string }): Promise<void> {
-    await this.db
-      .update(documents)
-      .set({
-        order_key: params.order_key,
-        updated_at: new Date(),
+
+  /** Read one ordered sibling group on the already collection-locked transaction. */
+  private async treeGroup(
+    tx: TxConnection,
+    collectionId: string,
+    parentDocumentId: string | null
+  ): Promise<Array<{ documentId: string; orderKey: string }>> {
+    const rows = await tx
+      .select({
+        documentId: documentRelationships.child_document_id,
+        orderKey: documentRelationships.order_key,
       })
-      .where(eq(documents.id, params.document_id))
+      .from(documentRelationships)
+      .innerJoin(documents, eq(documents.id, documentRelationships.child_document_id))
+      .where(
+        and(
+          eq(documents.collection_id, collectionId),
+          parentDocumentId == null
+            ? sql`${documentRelationships.parent_document_id} IS NULL`
+            : eq(documentRelationships.parent_document_id, parentDocumentId)
+        )
+      )
+      .orderBy(documentRelationships.order_key)
+    return rows
+  }
+
+  /** Read a node's placement from the already collection-locked transaction. */
+  private async treePlacement(
+    tx: TxConnection,
+    collectionId: string,
+    documentId: string
+  ): Promise<{
+    state: TreePlacementState
+    siblings: Array<{ documentId: string; orderKey: string }>
+  }> {
+    const [edge] = await tx
+      .select({
+        parentDocumentId: documentRelationships.parent_document_id,
+        orderKey: documentRelationships.order_key,
+      })
+      .from(documentRelationships)
+      .where(eq(documentRelationships.child_document_id, documentId))
+      .limit(1)
+    if (edge == null) {
+      return {
+        state: { placed: false, parentDocumentId: null, orderKey: null, index: null },
+        siblings: [],
+      }
+    }
+    const siblings = await this.treeGroup(tx, collectionId, edge.parentDocumentId)
+    const index = siblings.findIndex((row) => row.documentId === documentId)
+    return {
+      state: {
+        placed: true,
+        parentDocumentId: edge.parentDocumentId,
+        orderKey: edge.orderKey,
+        index: index >= 0 ? index : null,
+      },
+      siblings,
+    }
+  }
+
+  /** Read a raw node-and-descendants set while the collection tree lock is held. */
+  private async treeSubtreeIds(
+    tx: TxConnection,
+    collectionId: string,
+    documentId: string
+  ): Promise<string[]> {
+    const result = await tx.execute(sql`
+      WITH RECURSIVE subtree AS (
+        SELECT d.id AS document_id, 0 AS depth
+        FROM byline_documents d
+        WHERE d.id = ${documentId}
+          AND d.collection_id = ${collectionId}
+        UNION ALL
+        SELECT r.child_document_id, s.depth + 1
+        FROM byline_document_relationships r
+        JOIN subtree s ON r.parent_document_id = s.document_id
+        JOIN byline_documents d ON d.id = r.child_document_id
+        WHERE d.collection_id = ${collectionId}
+          AND s.depth < ${TREE_MAX_DEPTH}
+      )
+      SELECT document_id FROM subtree ORDER BY depth
+    `)
+    const rows = (result as unknown as [Array<{ document_id: string }>, unknown])[0]
+    return rows.map((row) => row.document_id)
+  }
+
+  /**
+   * placeTreeNode — see {@link IDocumentCommands.placeTreeNode}.
+   *
+   * Single transaction: same-collection guard → cycle guard → resolve the
+   * target sibling group's neighbour keys → mint a fractional key → upsert the
+   * edge row. Unversioned; touches only `byline_document_relationships`.
+   *
+   * The edge upsert uses a plain `.onDuplicateKeyUpdate()` — unlike
+   * `writeDocumentPath`, `byline_document_relationships` carries exactly one
+   * unique constraint (`uq_document_relationships_child`, on
+   * `child_document_id`), so MySQL's lack of per-constraint targeting is not
+   * an issue here: any duplicate-key collision on this table can only be that
+   * one index, so there is no ambiguity to guard against.
+   */
+  async placeTreeNode(params: {
+    collectionId: string
+    documentId: string
+    parentDocumentId: string | null
+    beforeDocumentId?: string | null
+    afterDocumentId?: string | null
+    ifUnplaced?: boolean
+  }): Promise<TreeMutationResult> {
+    const { collectionId, documentId, parentDocumentId } = params
+    const beforeDocumentId = params.beforeDocumentId ?? null
+    const afterDocumentId = params.afterDocumentId ?? null
+
+    if (parentDocumentId === documentId) {
+      throw ERR_VALIDATION({
+        message: 'a document cannot be its own parent in the document tree',
+        details: { documentId },
+      })
+    }
+    if (beforeDocumentId === documentId || afterDocumentId === documentId) {
+      throw ERR_VALIDATION({
+        message: 'a document cannot be its own tree neighbour',
+        details: { documentId },
+      })
+    }
+    if (beforeDocumentId != null && beforeDocumentId === afterDocumentId) {
+      throw ERR_VALIDATION({
+        message: 'beforeDocumentId and afterDocumentId must identify different tree neighbours',
+        details: { documentId, beforeDocumentId, afterDocumentId },
+      })
+    }
+
+    return await this.db.transaction(async (tx) => {
+      // One collection-row lock serializes all edge and sibling-key changes in
+      // the tree, so the returned before state and no-op decision cannot race.
+      await this.lockTreeCollection(tx, collectionId)
+
+      // Same-collection guard — every supplied endpoint must live in `collectionId`.
+      const ids = [documentId, parentDocumentId, beforeDocumentId, afterDocumentId].filter(
+        (id): id is string => id != null
+      )
+      const docRows = await tx
+        .select({ id: documents.id, collection_id: documents.collection_id })
+        .from(documents)
+        .where(inArray(documents.id, ids))
+      const collectionById = new Map(docRows.map((r) => [r.id, r.collection_id]))
+
+      if (collectionById.get(documentId) == null) {
+        throw ERR_NOT_FOUND({ message: 'document not found', details: { documentId } })
+      }
+      if (collectionById.get(documentId) !== collectionId) {
+        throw ERR_VALIDATION({
+          message: 'document does not belong to the collection',
+          details: { documentId, collectionId },
+        })
+      }
+
+      if (parentDocumentId != null) {
+        if (collectionById.get(parentDocumentId) == null) {
+          throw ERR_NOT_FOUND({
+            message: 'parent document not found',
+            details: { parentDocumentId },
+          })
+        }
+        if (collectionById.get(parentDocumentId) !== collectionId) {
+          throw ERR_VALIDATION({
+            message: 'parent document is in a different collection',
+            details: { parentDocumentId, collectionId },
+          })
+        }
+      }
+
+      const neighbours = [
+        { role: 'beforeDocumentId', id: beforeDocumentId },
+        { role: 'afterDocumentId', id: afterDocumentId },
+      ] as const
+      for (const neighbour of neighbours) {
+        if (neighbour.id == null) continue
+        if (collectionById.get(neighbour.id) == null) {
+          throw ERR_NOT_FOUND({
+            message: 'tree neighbour document not found',
+            details: { documentId, [neighbour.role]: neighbour.id },
+          })
+        }
+        if (collectionById.get(neighbour.id) !== collectionId) {
+          throw ERR_VALIDATION({
+            message: 'tree neighbour is in a different collection',
+            details: { documentId, collectionId, [neighbour.role]: neighbour.id },
+          })
+        }
+      }
+
+      const liveRows = await tx
+        .select({ id: currentDocumentsView.document_id })
+        .from(currentDocumentsView)
+        .where(
+          and(
+            eq(currentDocumentsView.collection_id, collectionId),
+            inArray(currentDocumentsView.document_id, ids)
+          )
+        )
+      const liveIds = new Set(liveRows.map((row) => row.id))
+      if (!liveIds.has(documentId)) {
+        throw ERR_CONFLICT({
+          message: staleTreePlacementMessage('document no longer has a current version'),
+          details: { documentId, collectionId },
+        })
+      }
+      if (parentDocumentId != null && !liveIds.has(parentDocumentId)) {
+        throw ERR_CONFLICT({
+          message: staleTreePlacementMessage('parent no longer has a current version'),
+          details: { documentId, parentDocumentId, collectionId },
+        })
+      }
+      for (const neighbour of neighbours) {
+        if (neighbour.id != null && !liveIds.has(neighbour.id)) {
+          throw ERR_CONFLICT({
+            message: staleTreePlacementMessage(`${neighbour.role} no longer has a current version`),
+            details: { documentId, collectionId, [neighbour.role]: neighbour.id },
+          })
+        }
+      }
+
+      if (parentDocumentId != null) {
+        // Cycle guard — reject when `documentId` is the new parent itself or
+        // any of its ancestors (which would put the node below its own
+        // subtree). Walk upward from `parentDocumentId`; depth-bounded.
+        const cycle = await tx.execute(sql`
+          WITH RECURSIVE chain AS (
+            SELECT ${parentDocumentId} AS node_id, 0 AS depth
+            UNION ALL
+            SELECT r.parent_document_id, c.depth + 1
+            FROM byline_document_relationships r
+            JOIN chain c ON r.child_document_id = c.node_id
+            WHERE r.parent_document_id IS NOT NULL AND c.depth < ${TREE_MAX_DEPTH}
+          )
+          SELECT 1 FROM chain WHERE node_id = ${documentId} LIMIT 1
+        `)
+        const cycleRows = (cycle as unknown as [Array<{ 1: number }>, unknown])[0]
+        if (cycleRows.length > 0) {
+          throw ERR_VALIDATION({
+            message: 'move would create a cycle in the document tree',
+            details: { documentId, parentDocumentId },
+          })
+        }
+      }
+
+      const before = await this.treePlacement(tx, collectionId, documentId)
+      if (params.ifUnplaced === true && before.state.placed) {
+        return {
+          changed: false,
+          before: before.state,
+          after: before.state,
+          beforeSiblingDocumentIds: before.siblings.map((row) => row.documentId),
+          beforeSubtreeDocumentIds: [],
+        }
+      }
+      const targetGroup = (
+        before.state.placed && before.state.parentDocumentId === parentDocumentId
+          ? before.siblings
+          : await this.treeGroup(tx, collectionId, parentDocumentId)
+      ).filter((row) => row.documentId !== documentId)
+
+      const leftIndex = beforeDocumentId
+        ? targetGroup.findIndex((row) => row.documentId === beforeDocumentId)
+        : -1
+      const rightIndex = afterDocumentId
+        ? targetGroup.findIndex((row) => row.documentId === afterDocumentId)
+        : -1
+      if (beforeDocumentId && leftIndex < 0) {
+        throw ERR_CONFLICT({
+          message: staleTreePlacementMessage(
+            'beforeDocumentId is no longer in the target sibling group'
+          ),
+          details: { documentId, parentDocumentId, beforeDocumentId },
+        })
+      }
+      if (afterDocumentId && rightIndex < 0) {
+        throw ERR_CONFLICT({
+          message: staleTreePlacementMessage(
+            'afterDocumentId is no longer in the target sibling group'
+          ),
+          details: { documentId, parentDocumentId, afterDocumentId },
+        })
+      }
+      if (afterDocumentId && beforeDocumentId == null && rightIndex !== 0) {
+        throw ERR_CONFLICT({
+          message: staleTreePlacementMessage('right neighbour is no longer first'),
+          details: { documentId, parentDocumentId, afterDocumentId },
+        })
+      }
+      if (beforeDocumentId && afterDocumentId == null && leftIndex !== targetGroup.length - 1) {
+        throw ERR_CONFLICT({
+          message: staleTreePlacementMessage('left neighbour is no longer last'),
+          details: { documentId, parentDocumentId, beforeDocumentId },
+        })
+      }
+
+      let insertionIndex: number
+      if (beforeDocumentId && afterDocumentId) {
+        if (leftIndex + 1 !== rightIndex) {
+          throw ERR_CONFLICT({
+            message: staleTreePlacementMessage('target neighbours are no longer adjacent'),
+            details: { documentId, parentDocumentId, beforeDocumentId, afterDocumentId },
+          })
+        }
+        insertionIndex = rightIndex
+      } else if (beforeDocumentId) {
+        insertionIndex = leftIndex + 1
+      } else if (afterDocumentId) {
+        insertionIndex = rightIndex
+      } else {
+        insertionIndex = targetGroup.length
+      }
+
+      if (
+        before.state.placed &&
+        before.state.parentDocumentId === parentDocumentId &&
+        before.state.index === insertionIndex
+      ) {
+        return {
+          changed: false,
+          before: before.state,
+          after: before.state,
+          beforeSiblingDocumentIds: before.siblings.map((row) => row.documentId),
+          beforeSubtreeDocumentIds: [],
+        }
+      }
+
+      const left = targetGroup[insertionIndex - 1]?.orderKey ?? null
+      const right = targetGroup[insertionIndex]?.orderKey ?? null
+
+      let orderKey: string
+      try {
+        orderKey = generateKeyBetween(left, right)
+      } catch (err) {
+        throw ERR_VALIDATION({
+          message: 'cannot generate order_key between the supplied tree neighbours',
+          details: {
+            documentId,
+            parentDocumentId,
+            left,
+            right,
+            cause: err instanceof Error ? err.message : String(err),
+          },
+        })
+      }
+
+      await tx
+        .insert(documentRelationships)
+        .values({
+          child_document_id: documentId,
+          parent_document_id: parentDocumentId,
+          order_key: orderKey,
+        })
+        .onDuplicateKeyUpdate({
+          set: {
+            parent_document_id: parentDocumentId,
+            order_key: orderKey,
+            updated_at: new Date(),
+          },
+        })
+
+      return {
+        changed: true,
+        before: before.state,
+        after: {
+          placed: true,
+          parentDocumentId,
+          orderKey,
+          index: insertionIndex,
+        },
+        beforeSiblingDocumentIds: before.siblings.map((row) => row.documentId),
+        beforeSubtreeDocumentIds: [],
+      }
+    })
+  }
+
+  /**
+   * removeFromTree — see {@link IDocumentCommands.removeFromTree}.
+   * Single-row delete; no-op when the node is already unplaced.
+   */
+  async removeFromTree(params: {
+    collectionId: string
+    documentId: string
+    includeSubtree?: boolean
+  }): Promise<TreeMutationResult> {
+    return this.db.transaction(async (tx) => {
+      await this.lockTreeCollection(tx, params.collectionId)
+      const [document] = await tx
+        .select({ collectionId: documents.collection_id })
+        .from(documents)
+        .where(eq(documents.id, params.documentId))
+        .limit(1)
+      if (document == null) {
+        throw ERR_NOT_FOUND({
+          message: 'document not found',
+          details: { documentId: params.documentId },
+        })
+      }
+      if (document.collectionId !== params.collectionId) {
+        throw ERR_VALIDATION({
+          message: 'document does not belong to the collection',
+          details: params,
+        })
+      }
+      const before = await this.treePlacement(tx, params.collectionId, params.documentId)
+      const beforeSubtreeDocumentIds = params.includeSubtree
+        ? await this.treeSubtreeIds(tx, params.collectionId, params.documentId)
+        : []
+      if (!before.state.placed) {
+        return {
+          changed: false,
+          before: before.state,
+          after: before.state,
+          beforeSiblingDocumentIds: [],
+          beforeSubtreeDocumentIds,
+        }
+      }
+      await tx
+        .delete(documentRelationships)
+        .where(eq(documentRelationships.child_document_id, params.documentId))
+      return {
+        changed: true,
+        before: before.state,
+        after: { placed: false, parentDocumentId: null, orderKey: null, index: null },
+        beforeSiblingDocumentIds: before.siblings.map((row) => row.documentId),
+        beforeSubtreeDocumentIds,
+      }
+    })
+  }
+
+  /** Promote direct children to roots and remove the parent edge under one lock. */
+  async promoteChildrenAndRemoveFromTree(params: {
+    collectionId: string
+    documentId: string
+  }): Promise<TreeDeleteMutationResult> {
+    return this.db.transaction(async (tx) => {
+      await this.lockTreeCollection(tx, params.collectionId)
+      const [document] = await tx
+        .select({ id: documents.id, collectionId: documents.collection_id })
+        .from(documents)
+        .where(eq(documents.id, params.documentId))
+        .limit(1)
+      if (document == null) {
+        throw ERR_NOT_FOUND({
+          message: 'document not found',
+          details: { documentId: params.documentId },
+        })
+      }
+      if (document.collectionId !== params.collectionId) {
+        throw ERR_VALIDATION({
+          message: 'document does not belong to the collection',
+          details: params,
+        })
+      }
+
+      const parent = await this.treePlacement(tx, params.collectionId, params.documentId)
+      const children = await this.treeGroup(tx, params.collectionId, params.documentId)
+      const roots = (await this.treeGroup(tx, params.collectionId, null)).filter(
+        (row) => row.documentId !== params.documentId
+      )
+      const promoted: TreeDeleteMutationResult['promoted'] = []
+
+      for (const [index, child] of children.entries()) {
+        const orderKey = generateKeyBetween(roots.at(-1)?.orderKey ?? null, null)
+        const after: TreePlacementState = {
+          placed: true,
+          parentDocumentId: null,
+          orderKey,
+          index: roots.length,
+        }
+        await tx
+          .update(documentRelationships)
+          .set({ parent_document_id: null, order_key: orderKey, updated_at: new Date() })
+          .where(eq(documentRelationships.child_document_id, child.documentId))
+        promoted.push({
+          documentId: child.documentId,
+          before: {
+            placed: true,
+            parentDocumentId: params.documentId,
+            orderKey: child.orderKey,
+            index,
+          },
+          after,
+        })
+        roots.push({ documentId: child.documentId, orderKey })
+      }
+
+      if (parent.state.placed) {
+        await tx
+          .delete(documentRelationships)
+          .where(eq(documentRelationships.child_document_id, params.documentId))
+      }
+      return {
+        removed: {
+          changed: parent.state.placed,
+          before: parent.state,
+          after: { placed: false, parentDocumentId: null, orderKey: null, index: null },
+          beforeSiblingDocumentIds: parent.siblings.map((row) => row.documentId),
+          beforeSubtreeDocumentIds: [],
+        },
+        promoted,
+      }
+    })
   }
 }
 

--- a/packages/db-mysql/src/modules/storage/storage-commands.ts
+++ b/packages/db-mysql/src/modules/storage/storage-commands.ts
@@ -8,7 +8,7 @@
 
 import type { CollectionDefinition, ICollectionCommands } from '@byline/core'
 import { DbErrorCodes, flattenFieldSetData } from '@byline/core'
-import { and, eq, notInArray, sql } from 'drizzle-orm'
+import { and, desc, eq, ne, notInArray, sql } from 'drizzle-orm'
 import type { AnyMySqlTable } from 'drizzle-orm/mysql-core'
 import type { MySql2Database } from 'drizzle-orm/mysql2'
 import { v7 as uuidv7 } from 'uuid'
@@ -131,15 +131,13 @@ export class CollectionCommands implements ICollectionCommands {
 /**
  * DocumentCommands — Task 9B, in progress.
  *
- * `createDocumentVersion` (Task 9A) plus `updateDocumentPath` and
- * `setDocumentAvailableLocales` — the standalone, non-versioned system-field
- * writes, both second callers into the private `writeDocumentPath` /
- * `writeDocumentAvailableLocales` helpers `createDocumentVersion` already
- * uses. The rest of `IDocumentCommands` — `setDocumentStatus`,
- * `archivePublishedVersions`, `softDeleteDocument`, `deleteDocumentLocale`,
- * `setOrderKey`, `placeTreeNode`, `removeFromTree`,
- * `promoteChildrenAndRemoveFromTree` — lands in the rest of this task, ported
- * alongside the rest of
+ * `createDocumentVersion` (Task 9A) plus the standalone system-field writes
+ * (`updateDocumentPath`, `setDocumentAvailableLocales`), the status /
+ * archive / soft-delete / delete-locale surface (`setDocumentStatus`,
+ * `archivePublishedVersions`, `softDeleteDocument`, `deleteDocumentLocale`),
+ * and `setOrderKey`. The remaining `IDocumentCommands` members —
+ * `placeTreeNode`, `removeFromTree`, `promoteChildrenAndRemoveFromTree` —
+ * land next, ported alongside the rest of
  * `packages/db-postgres/src/modules/storage/storage-commands.ts`'s
  * `DocumentCommands`. This class deliberately does not yet `implements
  * IDocumentCommands`; `src/index.ts` composes the full interface object by
@@ -640,6 +638,274 @@ export class DocumentCommands {
         availableLocales: params.availableLocales,
       })
     })
+  }
+  /**
+   * copyAllVersionStoreRows
+   *
+   * Copy every store row — all seven value-store tables (optionally excluding
+   * one locale) plus the locale-agnostic `byline_store_meta` identity rows
+   * (always copied wholesale, unfiltered — a block's identity is shared
+   * across locales) — from one document version to another, verbatim. New
+   * `id`s are minted per row (MySQL has no per-row `gen_random_uuid()`
+   * usable from an `INSERT … SELECT`, and ids must be app-generated UUIDv7 —
+   * see `copyForwardStoreRows` above); `created_at`/`updated_at` are left off
+   * the inserted row so the column default (`CURRENT_TIMESTAMP(3)`) supplies
+   * a fresh timestamp, matching pg's explicit `NOW(), NOW()`.
+   *
+   * The target version is assumed fresh (no existing rows), so — unlike
+   * `copyForwardStoreRows`, which may collide with rows `createDocumentVersion`
+   * already wrote in the same transaction — this performs a plain `INSERT`
+   * with no conflict handling. A collision here would mean the caller reused
+   * a non-fresh version id, which should fail loudly rather than being
+   * silently absorbed. Used by `deleteDocumentLocale` to snapshot the current
+   * version into the new one with the target locale's rows dropped.
+   */
+  private async copyAllVersionStoreRows(
+    tx: TxConnection,
+    fromVersionId: string,
+    toVersionId: string,
+    excludeLocale?: string
+  ): Promise<void> {
+    await this.copyVersionStoreRows(tx, textStore, fromVersionId, toVersionId, excludeLocale)
+    await this.copyVersionStoreRows(tx, numericStore, fromVersionId, toVersionId, excludeLocale)
+    await this.copyVersionStoreRows(tx, booleanStore, fromVersionId, toVersionId, excludeLocale)
+    await this.copyVersionStoreRows(tx, datetimeStore, fromVersionId, toVersionId, excludeLocale)
+    await this.copyVersionStoreRows(tx, jsonStore, fromVersionId, toVersionId, excludeLocale)
+    await this.copyVersionStoreRows(tx, relationStore, fromVersionId, toVersionId, excludeLocale)
+    await this.copyVersionStoreRows(tx, fileStore, fromVersionId, toVersionId, excludeLocale)
+
+    const metaRows = (await tx
+      .select()
+      .from(metaStore)
+      .where(eq(metaStore.document_version_id, fromVersionId))) as unknown as Record<
+      string,
+      unknown
+    >[]
+    if (metaRows.length > 0) {
+      const values = metaRows.map((row) => {
+        const { id: _id, created_at: _createdAt, updated_at: _updatedAt, ...rest } = row
+        return { ...rest, id: uuidv7(), document_version_id: toVersionId }
+      })
+      await tx.insert(metaStore).values(values as any)
+    }
+  }
+
+  /** One value-store table's share of `copyAllVersionStoreRows`. */
+  private async copyVersionStoreRows(
+    tx: TxConnection,
+    table: AnyMySqlTable,
+    fromVersionId: string,
+    toVersionId: string,
+    excludeLocale?: string
+  ): Promise<void> {
+    const t = table as unknown as { document_version_id: any; locale: any }
+    const conditions = [eq(t.document_version_id, fromVersionId)]
+    if (excludeLocale) conditions.push(ne(t.locale, excludeLocale))
+    const rows = (await tx
+      .select()
+      .from(table as any)
+      .where(and(...conditions))) as unknown as Record<string, unknown>[]
+
+    if (rows.length === 0) return
+
+    const values = rows.map((row) => {
+      const { id: _id, created_at: _createdAt, updated_at: _updatedAt, ...rest } = row
+      return { ...rest, id: uuidv7(), document_version_id: toVersionId }
+    })
+
+    await tx.insert(table as any).values(values)
+  }
+
+  /**
+   * deleteDocumentLocale
+   *
+   * Remove one content locale's data from a document by writing a **new
+   * immutable version** that carries forward every store row except the
+   * target locale's (the `'all'` rows and all other locales are kept). The
+   * prior version still holds the deleted locale, so the operation is
+   * recoverable via version restore, and a previously-published version keeps
+   * serving until the new version is published.
+   *
+   * The new version's status is supplied by the caller (the lifecycle service
+   * passes the workflow's default — a fresh draft, matching `copyToLocale`).
+   * The derived availability ledger is recomputed from the carried-forward
+   * rows, so the deleted locale drops out automatically. The default content
+   * locale (the document's anchor) must never be passed here — the lifecycle
+   * service enforces that.
+   *
+   * Defensively returns `null` when the document has no current version (the
+   * service validates existence first, so this is a guard).
+   */
+  async deleteDocumentLocale(params: {
+    documentId: string
+    locale: string
+    status?: string
+    createdBy?: string
+  }): Promise<{ newVersionId: string; previousVersionId: string } | null> {
+    const { documentId, locale, status, createdBy } = params
+    return this.db.transaction(async (tx) => {
+      // 1. Current (latest, non-deleted) version + the document's anchor.
+      const current = await tx
+        .select({
+          versionId: documentVersions.id,
+          collectionId: documentVersions.collection_id,
+          collectionVersion: documentVersions.collection_version,
+          sourceLocale: documents.source_locale,
+        })
+        .from(documentVersions)
+        .innerJoin(documents, eq(documents.id, documentVersions.document_id))
+        .where(
+          and(eq(documentVersions.document_id, documentId), eq(documentVersions.is_deleted, false))
+        )
+        .orderBy(desc(documentVersions.id))
+        .limit(1)
+        .then((rows) => rows[0])
+
+      if (current == null) return null
+
+      const sourceLocale = current.sourceLocale ?? this.defaultContentLocale
+
+      // 2. New immutable version: a snapshot of the current version with the
+      //    target locale's value rows dropped (meta + 'all' + other locales
+      //    carried forward).
+      const newVersionId = uuidv7()
+      await tx.insert(documentVersions).values({
+        id: newVersionId,
+        document_id: documentId,
+        collection_id: current.collectionId,
+        collection_version: current.collectionVersion,
+        event_type: 'delete_locale',
+        status: status ?? 'draft',
+        change_summary: `deleted content locale ${locale}`,
+        created_by: createdBy ?? null,
+      })
+      await this.copyAllVersionStoreRows(tx, current.versionId, newVersionId, locale)
+
+      // 3. Recompute the new version's availability ledger against the source
+      //    locale — the dropped locale no longer covers it, so it falls out.
+      await this.writeVersionLocaleLedger(tx, newVersionId, sourceLocale)
+
+      return { newVersionId, previousVersionId: current.versionId }
+    })
+  }
+
+  /**
+   * setDocumentStatus
+   *
+   * Mutate the status field on an existing document version row.
+   * This is the one case where we UPDATE a version in-place — status is
+   * lifecycle metadata, not content.
+   */
+  async setDocumentStatus(params: { document_version_id: string; status: string }): Promise<void> {
+    await this.db
+      .update(documentVersions)
+      .set({
+        status: params.status,
+        updated_at: new Date(),
+      })
+      .where(eq(documentVersions.id, params.document_version_id))
+  }
+
+  /**
+   * archivePublishedVersions
+   *
+   * Set ALL versions of a document that currently have `currentStatus`
+   * (defaults to 'published') to 'archived'. Optionally exclude a specific
+   * version so the caller can protect the version it is about to publish.
+   *
+   * Returns the number of rows updated. MySQL has no `RETURNING` and drizzle's
+   * mysql2 `update()` resolves to a `[ResultSetHeader, FieldPacket[]]` tuple
+   * rather than pg's driver result object — `affectedRows` lives on the first
+   * element (confirmed live against the test database), not `.rowCount`.
+   */
+  async archivePublishedVersions(params: {
+    document_id: string
+    currentStatus?: string
+    excludeVersionId?: string
+  }): Promise<number> {
+    const targetStatus = params.currentStatus ?? 'published'
+    const conditions = [
+      eq(documentVersions.document_id, params.document_id),
+      eq(documentVersions.status, targetStatus),
+    ]
+    if (params.excludeVersionId) {
+      conditions.push(ne(documentVersions.id, params.excludeVersionId))
+    }
+    const result = await this.db
+      .update(documentVersions)
+      .set({ status: 'archived', updated_at: new Date() })
+      .where(and(...conditions))
+    return (result as unknown as [{ affectedRows: number }, unknown])[0]?.affectedRows ?? 0
+  }
+
+  /**
+   * softDeleteDocument
+   *
+   * Mark ALL versions of a document as deleted by setting `is_deleted = true`.
+   * The `current_documents` view filters these out, so the document disappears
+   * from listings without physically removing data.
+   *
+   * Returns the number of version rows marked as deleted.
+   */
+  async softDeleteDocument(params: { document_id: string }): Promise<number> {
+    return this.db.transaction(async (tx) => {
+      // Tree placement takes this same collection lock before inspecting any
+      // endpoint state. Taking it before document/version locks makes direct
+      // soft deletion serialize with placement without reversing the normal
+      // lifecycle delete's lock order.
+      const collectionId = await this.lockDocumentCollection(tx, params.document_id)
+      if (collectionId == null) return 0
+
+      const [document] = await tx
+        .select({ id: documents.id })
+        .from(documents)
+        .where(eq(documents.id, params.document_id))
+        .for('update')
+      if (document == null) return 0
+
+      const result = await tx
+        .update(documentVersions)
+        .set({
+          is_deleted: true,
+          updated_at: new Date(),
+        })
+        .where(eq(documentVersions.document_id, params.document_id))
+      return (result as unknown as [{ affectedRows: number }, unknown])[0]?.affectedRows ?? 0
+    })
+  }
+
+  /**
+   * Resolve a document's collection while locking only the collection row.
+   * `FOR UPDATE OF c` — confirmed live against a MySQL 9.7.1 server (MySQL
+   * 8.0.1+ supports the per-table lock qualifier; `::uuid` casts dropped).
+   */
+  private async lockDocumentCollection(
+    tx: TxConnection,
+    documentId: string
+  ): Promise<string | null> {
+    const locked = await tx.execute(sql`
+      SELECT c.id AS collection_id
+      FROM byline_collections c
+      JOIN byline_documents d ON d.collection_id = c.id
+      WHERE d.id = ${documentId}
+      FOR UPDATE OF c
+    `)
+    const rows = (locked as unknown as [Array<{ collection_id: string }>, unknown])[0]
+    return rows[0]?.collection_id ?? null
+  }
+  /**
+   * Write `order_key` on a single `byline_documents` row. Single-column
+   * metadata update — no new version row, no `documentVersions` touch.
+   * `updated_at` on the document row is bumped so list caches invalidate.
+   */
+  async setOrderKey(params: { document_id: string; order_key: string }): Promise<void> {
+    await this.db
+      .update(documents)
+      .set({
+        order_key: params.order_key,
+        updated_at: new Date(),
+      })
+      .where(eq(documents.id, params.document_id))
   }
 }
 

--- a/packages/db-mysql/src/modules/storage/storage-commands.ts
+++ b/packages/db-mysql/src/modules/storage/storage-commands.ts
@@ -111,7 +111,7 @@ export class CollectionCommands implements ICollectionCommands {
     // `.returning()` has no MySQL equivalent — every value here is already
     // known (app-generated id, caller-supplied config), so the row is
     // constructed in JS rather than re-`SELECT`ed. `created_at`/`updated_at`
-    // are DB defaults (`CURRENT_TIMESTAMP(3)`); approximated with the
+    // are DB defaults (`CURRENT_TIMESTAMP(6)`); approximated with the
     // request-time `Date` since no caller in this adapter's current scope
     // depends on the authoritative DB-assigned value.
     return [
@@ -681,7 +681,7 @@ export class DocumentCommands implements IDocumentCommands {
    * `id`s are minted per row (MySQL has no per-row `gen_random_uuid()`
    * usable from an `INSERT … SELECT`, and ids must be app-generated UUIDv7 —
    * see `copyForwardStoreRows` above); `created_at`/`updated_at` are left off
-   * the inserted row so the column default (`CURRENT_TIMESTAMP(3)`) supplies
+   * the inserted row so the column default (`CURRENT_TIMESTAMP(6)`) supplies
    * a fresh timestamp, matching pg's explicit `NOW(), NOW()`.
    *
    * The target version is assumed fresh (no existing rows), so — unlike

--- a/packages/db-mysql/src/modules/storage/storage-commands.ts
+++ b/packages/db-mysql/src/modules/storage/storage-commands.ts
@@ -6,7 +6,7 @@
  * Copyright (c) Infonomic Company Limited
  */
 
-import type { CollectionDefinition } from '@byline/core'
+import type { CollectionDefinition, ICollectionCommands } from '@byline/core'
 import { DbErrorCodes, flattenFieldSetData } from '@byline/core'
 import { and, eq, notInArray, sql } from 'drizzle-orm'
 import type { AnyMySqlTable } from 'drizzle-orm/mysql-core'
@@ -48,7 +48,7 @@ type TxConnection = Parameters<Parameters<DatabaseConnection['transaction']>[0]>
  * without a round trip. `update` re-`SELECT`s because `patch` is partial
  * and the caller expects the merged row back.
  */
-export class CollectionCommands {
+export class CollectionCommands implements ICollectionCommands {
   constructor(private dbManager: DBManager) {}
 
   /**
@@ -129,18 +129,21 @@ export class CollectionCommands {
 }
 
 /**
- * DocumentCommands — Task 9A partial.
+ * DocumentCommands — Task 9B, in progress.
  *
- * Only `createDocumentVersion` (and the private helpers it calls) is
- * implemented here. The rest of `IDocumentCommands` —
- * `updateDocumentPath`, `setDocumentAvailableLocales`, `setDocumentStatus`,
+ * `createDocumentVersion` (Task 9A) plus `updateDocumentPath` and
+ * `setDocumentAvailableLocales` — the standalone, non-versioned system-field
+ * writes, both second callers into the private `writeDocumentPath` /
+ * `writeDocumentAvailableLocales` helpers `createDocumentVersion` already
+ * uses. The rest of `IDocumentCommands` — `setDocumentStatus`,
  * `archivePublishedVersions`, `softDeleteDocument`, `deleteDocumentLocale`,
  * `setOrderKey`, `placeTreeNode`, `removeFromTree`,
- * `promoteChildrenAndRemoveFromTree` — is Task 9B, ported alongside the rest
- * of `packages/db-postgres/src/modules/storage/storage-commands.ts`'s
- * `DocumentCommands`. This class deliberately does not `implements
+ * `promoteChildrenAndRemoveFromTree` — lands in the rest of this task, ported
+ * alongside the rest of
+ * `packages/db-postgres/src/modules/storage/storage-commands.ts`'s
+ * `DocumentCommands`. This class deliberately does not yet `implements
  * IDocumentCommands`; `src/index.ts` composes the full interface object by
- * picking `createDocumentVersion` off an instance of this class and leaving
+ * picking the implemented members off an instance of this class and leaving
  * every other member as the existing `notImplemented(...)` stub.
  */
 export class DocumentCommands {
@@ -577,6 +580,65 @@ export class DocumentCommands {
 
     await (tx.insert(table as any).values(values) as any).onDuplicateKeyUpdate({
       set: { id: sql`id` },
+    })
+  }
+  /**
+   * updateDocumentPath
+   *
+   * Standalone, non-versioned write of a document's URL path. Backs the admin
+   * path widget's direct-write Save path: it edits `byline_document_paths`
+   * in-place (document-grain, sticky) **without** minting a new document
+   * version or touching workflow status. The path's document-grain nature means
+   * the change is immediate and applies across every version of the document.
+   *
+   * Second caller into `writeDocumentPath` (the first is `createDocumentVersion`
+   * step 2a) — see that method's docblock for the insert-then-catch-and-
+   * conditionally-update targeting it does in place of pg's
+   * `onConflictDoUpdate({ target })`.
+   *
+   * Source-locale enforcement and `ERR_PATH_CONFLICT` mapping live in the
+   * lifecycle service that calls this; the command itself only performs the
+   * upsert (and surfaces the raw `ER_DUP_ENTRY` for the service to translate
+   * via `classifyError`).
+   */
+  async updateDocumentPath(params: {
+    documentId: string
+    collectionId: string
+    locale: string
+    path: string
+  }): Promise<void> {
+    await this.db.transaction(async (tx) => {
+      await this.writeDocumentPath(tx, {
+        documentId: params.documentId,
+        locale: params.locale,
+        collectionId: params.collectionId,
+        path: params.path,
+      })
+    })
+  }
+
+  /**
+   * setDocumentAvailableLocales
+   *
+   * Standalone, non-versioned write of a document's editorial advertised-locale
+   * set. Backs the admin available-locales widget's direct-write Save path: it
+   * replaces `byline_document_available_locales` wholesale (document-grain)
+   * **without** minting a new document version or touching workflow status. The
+   * change is immediate and applies across every version of the document; the
+   * public advertised set remains the intersection with the resolved version's
+   * completeness ledger. See docs/07-internationalization/index.md.
+   */
+  async setDocumentAvailableLocales(params: {
+    documentId: string
+    collectionId: string
+    availableLocales: string[]
+  }): Promise<void> {
+    await this.db.transaction(async (tx) => {
+      await this.writeDocumentAvailableLocales(tx, {
+        documentId: params.documentId,
+        collectionId: params.collectionId,
+        availableLocales: params.availableLocales,
+      })
     })
   }
 }

--- a/packages/db-mysql/src/modules/storage/storage-commands.ts
+++ b/packages/db-mysql/src/modules/storage/storage-commands.ts
@@ -1,0 +1,589 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import type { CollectionDefinition } from '@byline/core'
+import { DbErrorCodes, flattenFieldSetData } from '@byline/core'
+import { and, eq, notInArray, sql } from 'drizzle-orm'
+import type { AnyMySqlTable } from 'drizzle-orm/mysql-core'
+import type { MySql2Database } from 'drizzle-orm/mysql2'
+import { v7 as uuidv7 } from 'uuid'
+
+import {
+  booleanStore,
+  collections,
+  datetimeStore,
+  documentAvailableLocales,
+  documentPaths,
+  documents,
+  documentVersions,
+  fileStore,
+  jsonStore,
+  metaStore,
+  numericStore,
+  relationStore,
+  textStore,
+} from '../../database/schema/index.js'
+import { classifyError } from './classify-error.js'
+import { prepareFieldInsertBuckets } from './storage-insert.js'
+import { getFirstOrThrow } from './storage-utils.js'
+import type * as schema from '../../database/schema/index.js'
+import type { DBManager } from '../../lib/db-manager.js'
+
+type DatabaseConnection = MySql2Database<typeof schema>
+/** The transaction handle passed to `this.db.transaction(async (tx) => …)`. */
+type TxConnection = Parameters<Parameters<DatabaseConnection['transaction']>[0]>[0]
+
+/**
+ * CollectionCommands
+ *
+ * Mirrors `packages/db-postgres/src/modules/storage/storage-commands.ts`'s
+ * `CollectionCommands`. MySQL has no `RETURNING` clause, so every write
+ * constructs its return value in JS instead — collection ids are
+ * app-generated UUIDv7, so `create` already knows every value it needs
+ * without a round trip. `update` re-`SELECT`s because `patch` is partial
+ * and the caller expects the merged row back.
+ */
+export class CollectionCommands {
+  constructor(private dbManager: DBManager) {}
+
+  /**
+   * The executor for this call — the ambient transaction when a
+   * `withTransaction` boundary is open, otherwise the pool. Resolved per
+   * access so every `this.db.*` below transparently joins an enclosing
+   * transaction with no call-site change. See docs/03-architecture/03-transactions.md.
+   */
+  private get db(): DatabaseConnection {
+    return this.dbManager.get()
+  }
+
+  async create(
+    path: string,
+    config: CollectionDefinition,
+    opts?: { version?: number; schemaHash?: string }
+  ) {
+    const id = uuidv7()
+    const version = opts?.version ?? 1
+    const singular = config.labels.singular || path
+    const plural = config.labels.plural || `${path}s`
+    await this.db.insert(collections).values({
+      id,
+      path,
+      singular,
+      plural,
+      config,
+      version,
+      ...(opts?.schemaHash !== undefined ? { schema_hash: opts.schemaHash } : {}),
+    })
+    // `.returning()` has no MySQL equivalent — every value here is already
+    // known (app-generated id, caller-supplied config), so the row is
+    // constructed in JS rather than re-`SELECT`ed. `created_at`/`updated_at`
+    // are DB defaults (`CURRENT_TIMESTAMP(3)`); approximated with the
+    // request-time `Date` since no caller in this adapter's current scope
+    // depends on the authoritative DB-assigned value.
+    return [
+      {
+        id,
+        path,
+        singular,
+        plural,
+        config,
+        version,
+        schema_hash: opts?.schemaHash ?? null,
+        created_at: new Date(),
+        updated_at: new Date(),
+      },
+    ]
+  }
+
+  async update(
+    id: string,
+    patch: {
+      config?: CollectionDefinition
+      version?: number
+      schemaHash?: string
+    }
+  ) {
+    const set: Record<string, unknown> = { updated_at: new Date() }
+    if (patch.config !== undefined) set.config = patch.config
+    if (patch.version !== undefined) set.version = patch.version
+    if (patch.schemaHash !== undefined) set.schema_hash = patch.schemaHash
+    await this.db.update(collections).set(set).where(eq(collections.id, id))
+    // MySQL has no `RETURNING` — re-`SELECT` the merged row since `patch` is
+    // partial and the caller expects the full row back.
+    const row = await this.db
+      .select()
+      .from(collections)
+      .where(eq(collections.id, id))
+      .then(getFirstOrThrow('Failed to load collection after update'))
+    return [row]
+  }
+
+  async delete(id: string) {
+    return await this.db.delete(collections).where(eq(collections.id, id))
+  }
+}
+
+/**
+ * DocumentCommands — Task 9A partial.
+ *
+ * Only `createDocumentVersion` (and the private helpers it calls) is
+ * implemented here. The rest of `IDocumentCommands` —
+ * `updateDocumentPath`, `setDocumentAvailableLocales`, `setDocumentStatus`,
+ * `archivePublishedVersions`, `softDeleteDocument`, `deleteDocumentLocale`,
+ * `setOrderKey`, `placeTreeNode`, `removeFromTree`,
+ * `promoteChildrenAndRemoveFromTree` — is Task 9B, ported alongside the rest
+ * of `packages/db-postgres/src/modules/storage/storage-commands.ts`'s
+ * `DocumentCommands`. This class deliberately does not `implements
+ * IDocumentCommands`; `src/index.ts` composes the full interface object by
+ * picking `createDocumentVersion` off an instance of this class and leaving
+ * every other member as the existing `notImplemented(...)` stub.
+ */
+export class DocumentCommands {
+  constructor(
+    private dbManager: DBManager,
+    private defaultContentLocale: string
+  ) {}
+
+  /**
+   * The executor for this call — the ambient transaction when a
+   * `withTransaction` boundary is open, otherwise the pool. Resolved per
+   * access so every `this.db.*` below transparently joins an enclosing
+   * transaction with no call-site change. See docs/03-architecture/03-transactions.md.
+   */
+  private get db(): DatabaseConnection {
+    return this.dbManager.get()
+  }
+
+  /**
+   * createDocumentVersion
+   *
+   * Creates a new document or a new version of an existing document. Ported
+   * from `packages/db-postgres/src/modules/storage/storage-commands.ts`'s
+   * `DocumentCommands.createDocumentVersion` — see spec §2's normative
+   * conversion table, applied at each site below:
+   *
+   *   - `.returning()` → construct-in-JS. Every id here is app-generated
+   *     UUIDv7 (minted before the insert), so the value is already known —
+   *     no re-`SELECT` is needed anywhere in this method.
+   *   - `onConflictDoUpdate` (path upsert) → NOT `.onDuplicateKeyUpdate()`
+   *     (found live: MySQL's `ON DUPLICATE KEY UPDATE` has no per-constraint
+   *     targeting the way pg's `onConflictDoUpdate({ target })` does, so it
+   *     would silently absorb a genuine cross-document path conflict instead
+   *     of erroring). `writeDocumentPath` below does the targeting itself —
+   *     see its docblock.
+   *   - `ON CONFLICT (document_version_id, field_path, locale) DO NOTHING`
+   *     (7 sites, the per-locale carry-forward) → MySQL has no per-row
+   *     `gen_random_uuid()` to call from an `INSERT … SELECT`, and ids must
+   *     be app-generated UUIDv7 — never `INSERT IGNORE`, which would swallow
+   *     unrelated errors, and never a DB-generated id. So each site becomes
+   *     a typed `SELECT` of the previous version's carry-forward rows,
+   *     followed by a JS-side UUIDv7-per-row bulk `INSERT … ON DUPLICATE KEY
+   *     UPDATE id = id` (drizzle's own documented no-op idiom for "do
+   *     nothing" on MySQL) — see `copyForwardStoreRows` below, which the 7
+   *     call sites share.
+   *   - `::uuid` casts → dropped (MySQL ids are plain `CHAR(36)`).
+   *
+   * @param params - Options for creating the document
+   * @returns The created document and the number of field values inserted
+   */
+  async createDocumentVersion(params: {
+    documentId?: string
+    collectionId: string
+    collectionVersion: number
+    collectionConfig: CollectionDefinition
+    action: string
+    documentData: any
+    path?: string
+    availableLocales?: string[]
+    locale?: string
+    status?: string
+    createdBy?: string
+    previousVersionId?: string
+    orderKey?: string
+  }) {
+    return await this.db.transaction(async (tx) => {
+      let documentId = params.documentId
+
+      // 1. Create the main document if needed, and resolve the document's
+      // `source_locale` — its per-document data anchor. A brand-new document
+      // is anchored to the configured default content locale (the locale it is
+      // authored in; `createDocument` enforces create-in-default). An existing
+      // document carries its own anchor on `byline_documents`; read it so the
+      // path row and the completeness ledger below key off *this document's*
+      // source locale rather than the mutable global default. NULL (a row not
+      // yet touched by `backfillSourceLocales`) falls back to the configured
+      // default — the value it was implicitly authored against.
+      // See docs/07-internationalization/index.md.
+      let sourceLocale: string
+      if (documentId == null) {
+        documentId = uuidv7()
+        sourceLocale = this.defaultContentLocale
+        await tx.insert(documents).values({
+          id: documentId,
+          collection_id: params.collectionId,
+          order_key: params.orderKey ?? null,
+          source_locale: sourceLocale,
+        })
+      } else {
+        const existing = await tx
+          .select({ source_locale: documents.source_locale })
+          .from(documents)
+          .where(eq(documents.id, documentId))
+          .then(getFirstOrThrow('Failed to load document for new version'))
+        sourceLocale = existing.source_locale ?? this.defaultContentLocale
+      }
+
+      // 2. Create the document version. The id is minted here (app-side
+      // UUIDv7), so the row is constructed in JS below rather than
+      // re-`SELECT`ed — MySQL has no `RETURNING`.
+      const documentVersionId = uuidv7()
+      const createdAt = new Date()
+      await tx.insert(documentVersions).values({
+        id: documentVersionId,
+        document_id: documentId,
+        collection_id: params.collectionId,
+        collection_version: params.collectionVersion,
+        event_type: params.action ?? 'create',
+        status: params.status ?? 'draft',
+        created_by: params.createdBy ?? null,
+      })
+      const documentVersion = {
+        id: documentVersionId,
+        document_id: documentId,
+        collection_id: params.collectionId,
+        collection_version: params.collectionVersion,
+        doc: null,
+        event_type: params.action ?? 'create',
+        status: params.status ?? 'draft',
+        is_deleted: false,
+        created_by: params.createdBy ?? null,
+        change_summary: null,
+        created_at: createdAt,
+        updated_at: createdAt,
+      }
+
+      // 2a. Upsert the document_paths row when a path is supplied. The path
+      // row lives under the document's `source_locale` (its data anchor),
+      // not the mutable global default — so a re-anchored document, or any
+      // document read after the global default is switched, still resolves by
+      // path. The lifecycle layer skips this param for non-source-locale
+      // (translation) saves. Unique-constraint violations on
+      // (collection_id, locale, path) bubble up as a MySQL ER_DUP_ENTRY error
+      // which the lifecycle wraps as ERR_PATH_CONFLICT (via `classifyError`).
+      if (params.path !== undefined) {
+        await this.writeDocumentPath(tx, {
+          documentId,
+          locale: sourceLocale,
+          collectionId: params.collectionId,
+          path: params.path,
+        })
+      }
+
+      // 2b. Replace the document_available_locales rows when an editorial set
+      // is supplied. Document-grain and sticky across versions: `undefined`
+      // leaves the existing set untouched (the lifecycle omits the param on
+      // saves that don't touch advertising), while an explicit array — empty
+      // included — replaces it wholesale. Deduplicated so a caller-supplied
+      // duplicate doesn't collide on the (document_id, locale) primary key.
+      if (params.availableLocales !== undefined) {
+        await this.writeDocumentAvailableLocales(tx, {
+          documentId,
+          collectionId: params.collectionId,
+          availableLocales: params.availableLocales,
+        })
+      }
+
+      // 3. Flatten the document data to field values
+      const flattenedFields = flattenFieldSetData(
+        params.collectionConfig.fields,
+        params.documentData,
+        params.locale ?? 'all'
+      )
+
+      // 4. Batch-insert all field values, grouped by store type
+      const storeBuckets = prepareFieldInsertBuckets(
+        flattenedFields,
+        documentVersion.id,
+        params.collectionId
+      )
+
+      if (storeBuckets.text.length > 0) {
+        await tx.insert(textStore).values(storeBuckets.text)
+      }
+
+      if (storeBuckets.numeric.length > 0) {
+        await tx.insert(numericStore).values(storeBuckets.numeric)
+      }
+
+      if (storeBuckets.boolean.length > 0) {
+        await tx.insert(booleanStore).values(storeBuckets.boolean)
+      }
+
+      if (storeBuckets.datetime.length > 0) {
+        await tx.insert(datetimeStore).values(storeBuckets.datetime)
+      }
+
+      if (storeBuckets.file.length > 0) {
+        await tx.insert(fileStore).values(storeBuckets.file)
+      }
+
+      if (storeBuckets.relation.length > 0) {
+        await tx.insert(relationStore).values(storeBuckets.relation)
+      }
+
+      if (storeBuckets.json.length > 0) {
+        await tx.insert(jsonStore).values(storeBuckets.json)
+      }
+
+      if (storeBuckets.meta.length > 0) {
+        await tx.insert(metaStore).values(storeBuckets.meta)
+      }
+
+      // 5. Copy field-value rows for other locales from the previous version.
+      // When saving in a specific locale (e.g. 'fr'), only rows for that locale
+      // and locale='all' are written above. Any existing rows for other locales
+      // (e.g. 'en', 'es') from the previous version must be carried forward so
+      // per-locale content is not lost under immutable versioning. Seven store
+      // tables, one `copyForwardStoreRows` call each — see the method doc for
+      // why this isn't a single `INSERT … SELECT` the way pg does it.
+      if (params.previousVersionId && params.locale && params.locale !== 'all') {
+        const prevId = params.previousVersionId
+        const newId = documentVersion.id
+        const activeLoc = params.locale
+
+        await this.copyForwardStoreRows(tx, textStore, prevId, newId, activeLoc)
+        await this.copyForwardStoreRows(tx, numericStore, prevId, newId, activeLoc)
+        await this.copyForwardStoreRows(tx, booleanStore, prevId, newId, activeLoc)
+        await this.copyForwardStoreRows(tx, datetimeStore, prevId, newId, activeLoc)
+        await this.copyForwardStoreRows(tx, jsonStore, prevId, newId, activeLoc)
+        await this.copyForwardStoreRows(tx, relationStore, prevId, newId, activeLoc)
+        await this.copyForwardStoreRows(tx, fileStore, prevId, newId, activeLoc)
+      }
+
+      // 6. Record the version's available content locales for
+      // `localeFallback: 'strict'` reads. A locale is "available" when it
+      // covers every localized field path the default content locale has
+      // (path-coverage). Derived from the *persisted* localized rows, so it
+      // accounts for the per-locale carry-forward in step 5 — not just the
+      // freshly-flattened locale. A version with no localized content at all
+      // records a single `'all'` sentinel (it renders identically in any
+      // locale). Status-blind by design — see docs/07-internationalization/index.md.
+      await this.writeVersionLocaleLedger(tx, documentVersion.id, sourceLocale)
+
+      return {
+        document: documentVersion,
+        fieldCount: flattenedFields.length,
+      }
+    })
+  }
+
+  /**
+   * writeDocumentPath
+   *
+   * Upsert the `byline_document_paths` row for a (document, locale) pair. The
+   * path row is document-grain and sticky across versions — it lives under the
+   * document's `source_locale` (its data anchor), not the mutable global
+   * default.
+   *
+   * Real dialect divergence from pg, found live (a test that should have
+   * raised a conflict silently "succeeded" instead): pg's `onConflictDoUpdate`
+   * takes an explicit `target` — the (`document_id`, `locale`) unique index —
+   * so a collision on the *other* unique index
+   * (`idx_document_paths_collection_locale_path`, a genuine path conflict
+   * from a different document) is deliberately left untargeted and bubbles up
+   * as `23505`. MySQL's `ON DUPLICATE KEY UPDATE` has no per-constraint
+   * targeting — it fires for a collision on *any* unique/primary key on the
+   * table, so a naive `.onDuplicateKeyUpdate()` would silently rewrite
+   * whichever existing row the *other* document's path collided with instead
+   * of raising `ER_DUP_ENTRY`. So this does the targeting itself: try the
+   * `INSERT` first; if it fails on the *own-document* unique index
+   * (`unique_document_paths_document_locale`, the ordinary "this document is
+   * resaving its already-anchored path" case — detected via `classifyError`,
+   * the same cause-chain-walking classifier the lifecycle layer uses, since
+   * mysql2/Drizzle wraps the duplicate-key error rather than throwing it
+   * bare), fall through to an explicit `UPDATE` instead. Any other
+   * duplicate-key error — in particular the collection-scoped
+   * path-uniqueness index — is rethrown unchanged, so it still surfaces as
+   * `ER_DUP_ENTRY` for the lifecycle layer's own `classifyError`-based
+   * `ERR_PATH_CONFLICT` mapping.
+   */
+  private async writeDocumentPath(
+    tx: TxConnection,
+    args: { documentId: string; locale: string; collectionId: string; path: string }
+  ): Promise<void> {
+    try {
+      await tx.insert(documentPaths).values({
+        document_id: args.documentId,
+        locale: args.locale,
+        collection_id: args.collectionId,
+        path: args.path,
+      })
+    } catch (err) {
+      const classification = classifyError(err)
+      const isOwnDocumentLocaleConflict =
+        classification.code === DbErrorCodes.UNIQUE_VIOLATION &&
+        classification.constraint === 'unique_document_paths_document_locale'
+      if (!isOwnDocumentLocaleConflict) {
+        throw err
+      }
+      await tx
+        .update(documentPaths)
+        .set({
+          path: args.path,
+          collection_id: args.collectionId,
+          updated_at: new Date(),
+        })
+        .where(
+          and(eq(documentPaths.document_id, args.documentId), eq(documentPaths.locale, args.locale))
+        )
+    }
+  }
+
+  /**
+   * writeDocumentAvailableLocales
+   *
+   * Replace a document's `byline_document_available_locales` rows wholesale —
+   * the editorial advertised-locale set. Document-grain and sticky across
+   * versions: `delete`-then-`insert`, deduplicated so a caller-supplied
+   * duplicate doesn't collide on the `(document_id, locale)` primary key. An
+   * empty array clears the set (advertise nothing).
+   */
+  private async writeDocumentAvailableLocales(
+    tx: TxConnection,
+    args: { documentId: string; collectionId: string; availableLocales: string[] }
+  ): Promise<void> {
+    await tx
+      .delete(documentAvailableLocales)
+      .where(eq(documentAvailableLocales.document_id, args.documentId))
+    const locales = [...new Set(args.availableLocales)]
+    if (locales.length > 0) {
+      await tx.insert(documentAvailableLocales).values(
+        locales.map((locale) => ({
+          document_id: args.documentId,
+          locale,
+          collection_id: args.collectionId,
+        }))
+      )
+    }
+  }
+
+  /**
+   * writeVersionLocaleLedger
+   *
+   * Compute and insert a version's `byline_document_version_locales` rows: a
+   * locale is recorded when it covers every localized field path the version's
+   * `sourceLocale` has (path-coverage), and a version with no localized content
+   * records a single `'all'` sentinel. Reads the version's persisted store rows,
+   * so callers must have written them first. `::uuid` casts are dropped
+   * (MySQL ids are plain `CHAR(36)`); the WITH/UNION/HAVING NOT EXISTS logic is
+   * otherwise unchanged MySQL 8+ syntax — but the WITH clause's *position* is a
+   * real dialect difference, found live (a syntax error, not assumed): Postgres
+   * accepts `WITH … INSERT INTO … SELECT …`, whereas MySQL requires the WITH
+   * clause *after* `INSERT INTO <table>` and immediately before the `SELECT`
+   * it modifies (confirmed against a live MySQL 9.7.1 server) — so the two
+   * clauses are transposed relative to the pg original. See
+   * docs/07-internationalization/index.md.
+   */
+  private async writeVersionLocaleLedger(
+    tx: TxConnection,
+    versionId: string,
+    sourceLocale: string
+  ): Promise<void> {
+    await tx.execute(sql`
+      INSERT INTO byline_document_version_locales (document_version_id, locale)
+      WITH loc AS (
+        SELECT field_path, locale FROM byline_store_text     WHERE document_version_id = ${versionId} AND locale <> 'all'
+        UNION SELECT field_path, locale FROM byline_store_numeric  WHERE document_version_id = ${versionId} AND locale <> 'all'
+        UNION SELECT field_path, locale FROM byline_store_boolean  WHERE document_version_id = ${versionId} AND locale <> 'all'
+        UNION SELECT field_path, locale FROM byline_store_datetime WHERE document_version_id = ${versionId} AND locale <> 'all'
+        UNION SELECT field_path, locale FROM byline_store_file     WHERE document_version_id = ${versionId} AND locale <> 'all'
+        UNION SELECT field_path, locale FROM byline_store_relation WHERE document_version_id = ${versionId} AND locale <> 'all'
+        UNION SELECT field_path, locale FROM byline_store_json     WHERE document_version_id = ${versionId} AND locale <> 'all'
+      ),
+      canonical AS (
+        SELECT field_path FROM loc WHERE locale = ${sourceLocale}
+      ),
+      covering AS (
+        SELECT l.locale
+        FROM loc l
+        GROUP BY l.locale
+        HAVING NOT EXISTS (
+          SELECT 1 FROM canonical c
+          WHERE NOT EXISTS (
+            SELECT 1 FROM loc l2 WHERE l2.locale = l.locale AND l2.field_path = c.field_path
+          )
+        )
+      )
+      SELECT ${versionId}, locale FROM covering
+      UNION ALL
+      SELECT ${versionId}, 'all' WHERE NOT EXISTS (SELECT 1 FROM loc)
+    `)
+  }
+
+  /**
+   * copyForwardStoreRows
+   *
+   * Carry forward one store table's rows for every locale except `'all'` and
+   * the version's active write locale, from `prevVersionId` to `newVersionId`.
+   * The MySQL counterpart of pg's `INSERT … SELECT gen_random_uuid(), … ON
+   * CONFLICT (document_version_id, field_path, locale) DO NOTHING`: MySQL has
+   * no per-row id generator usable from an `INSERT … SELECT`, and ids must be
+   * app-generated UUIDv7 (never DB-generated, never `INSERT IGNORE` — see the
+   * method doc on `createDocumentVersion`) — so this reads the candidate rows
+   * with a typed `SELECT`, mints a fresh UUIDv7 per row in JS, and bulk-inserts
+   * with `.onDuplicateKeyUpdate({ set: { id: sql\`id\` } })`, drizzle's own
+   * documented no-op idiom for "do nothing on conflict" on MySQL. One generic
+   * helper shared by all 7 call sites (pg keeps 7 near-identical raw-SQL
+   * blocks because it doesn't need this per-row JS step; MySQL does, so
+   * factoring it once here avoids seven copies of the same shape).
+   *
+   * `table` is threaded through as `AnyMySqlTable` and cast internally —
+   * the 7 store tables share the same `(id, document_version_id, …, locale,
+   * created_at, updated_at)` column shape (`baseStoreColumns` in the schema),
+   * but Drizzle's query builder generics don't unify cleanly across a union
+   * of distinct table types for `.from()` / `.insert()`, so the cast is
+   * confined to this one private helper rather than leaking into the 7 call
+   * sites, which stay fully typed.
+   */
+  private async copyForwardStoreRows(
+    tx: TxConnection,
+    table: AnyMySqlTable,
+    prevVersionId: string,
+    newVersionId: string,
+    activeLocale: string
+  ): Promise<void> {
+    const t = table as unknown as {
+      document_version_id: any
+      locale: any
+    }
+    const rows = (await tx
+      .select()
+      .from(table as any)
+      .where(
+        and(eq(t.document_version_id, prevVersionId), notInArray(t.locale, ['all', activeLocale]))
+      )) as unknown as Record<string, unknown>[]
+
+    if (rows.length === 0) return
+
+    const values = rows.map((row) => {
+      const { id: _id, created_at: _createdAt, updated_at: _updatedAt, ...rest } = row
+      return { ...rest, id: uuidv7(), document_version_id: newVersionId }
+    })
+
+    await (tx.insert(table as any).values(values) as any).onDuplicateKeyUpdate({
+      set: { id: sql`id` },
+    })
+  }
+}
+
+export function createCommandBuilders(dbManager: DBManager, defaultContentLocale: string) {
+  return {
+    collections: new CollectionCommands(dbManager),
+    documents: new DocumentCommands(dbManager, defaultContentLocale),
+  }
+}

--- a/packages/db-mysql/src/modules/storage/storage-insert.ts
+++ b/packages/db-mysql/src/modules/storage/storage-insert.ts
@@ -1,0 +1,198 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import { ERR_DATABASE, type FlattenedFieldValue, getLogger } from '@byline/core'
+import { v7 as uuidv7 } from 'uuid'
+
+import type {
+  booleanStore,
+  datetimeStore,
+  fileStore,
+  jsonStore,
+  metaStore,
+  numericStore,
+  relationStore,
+  textStore,
+} from '@/database/schema/index.js'
+
+// ------------------------------------------------------------------------------
+// Insert-bucket preparation: take flattened field values and bucket them by
+// target store table, producing Drizzle-typed rows ready for a bulk insert.
+// Mirrors `packages/db-postgres/src/modules/storage/storage-insert.ts` —
+// dialect-independent apart from the date/timestamp coercion notes below.
+// ------------------------------------------------------------------------------
+
+type FieldInsertBuckets = {
+  text: (typeof textStore.$inferInsert)[]
+  numeric: (typeof numericStore.$inferInsert)[]
+  boolean: (typeof booleanStore.$inferInsert)[]
+  datetime: (typeof datetimeStore.$inferInsert)[]
+  file: (typeof fileStore.$inferInsert)[]
+  relation: (typeof relationStore.$inferInsert)[]
+  json: (typeof jsonStore.$inferInsert)[]
+  meta: (typeof metaStore.$inferInsert)[]
+}
+
+export const prepareFieldInsertBuckets = (
+  flattenedFields: FlattenedFieldValue[],
+  document_version_id: string,
+  collection_id: string
+): FieldInsertBuckets => {
+  const buckets: FieldInsertBuckets = {
+    text: [],
+    numeric: [],
+    boolean: [],
+    datetime: [],
+    file: [],
+    relation: [],
+    json: [],
+    meta: [],
+  }
+
+  for (const field of flattenedFields) {
+    const { field_type, field_path, locale } = field
+
+    if (field_type === 'meta') {
+      buckets.meta.push({
+        id: uuidv7(),
+        document_version_id,
+        collection_id,
+        type: field.type,
+        path: field_path.join('.'),
+        item_id: field.item_id,
+      })
+      continue
+    }
+
+    const base = {
+      id: uuidv7(),
+      document_version_id,
+      collection_id,
+      field_path: field_path.join('.'),
+      field_name: field_path[field_path.length - 1] ?? '',
+      locale,
+      parent_path: field_path.length > 1 ? field_path.slice(0, -1).join('.') : undefined,
+    }
+
+    switch (field_type) {
+      case 'text':
+        buckets.text.push({ ...base, value: field.value })
+        continue
+
+      case 'numeric':
+        buckets.numeric.push({
+          ...base,
+          number_type: field.number_type,
+          value_float: field.value_float,
+          value_integer: field.value_integer,
+          value_decimal: field.value_decimal,
+        })
+        continue
+
+      case 'boolean':
+        buckets.boolean.push({
+          ...base,
+          value: field.value,
+        })
+        continue
+
+      case 'datetime':
+        buckets.datetime.push({
+          ...base,
+          date_type: field.date_type,
+          // Real dialect divergence from pg, found via typecheck rather than
+          // assumed: `drizzle-orm/pg-core`'s `date()` defaults to *string*
+          // mode (`PgDateStringBuilder`) unless `{ mode: 'date' }` is passed;
+          // `drizzle-orm/mysql-core`'s `date()` defaults the other way — to
+          // *`Date`* mode (`MySqlDateBuilder`) unless `{ mode: 'string' }` is
+          // passed. The schema's `value_date: date('value_date')`
+          // (`src/database/schema/index.ts`, unchanged from Task 8/PR 1) is
+          // therefore `Date`-typed on insert here, the mirror image of pg's
+          // `toDateOnlyString` — so this coerces to `Date` instead of a
+          // 'YYYY-MM-DD' string. `mapToDriverValue` is identity (unverified
+          // by an override in the mysql-core source), so mysql2 receives the
+          // `Date` object directly and formats it per the pool's `timezone:
+          // 'Z'` option.
+          value_date: toDate(field.value_date),
+          value_time: field.value_time,
+          // `value_timestamp_tz` arrives as a `Date` from form widgets but
+          // as a string from `getAllFieldValues` — the UNION ALL declares
+          // the column as MySQL `datetime(3)` (no TZ; UTC by connection-level
+          // convention, see `src/index.ts`'s `timezone: 'Z'` pool option),
+          // and mysql2 maps a `datetime` column to a string on read.
+          // Drizzle's own `mapToDriverValue` for the (default, non-'string')
+          // `datetime()` builder calls `.toISOString()` unguarded on insert
+          // — confirmed against the drizzle-orm/mysql-core source — so we
+          // coerce here, exactly like pg's `toDate`.
+          value_timestamp_tz: toDate(field.value_timestamp_tz),
+        })
+        continue
+
+      case 'file':
+        buckets.file.push({
+          ...base,
+          file_id: field.file_id,
+          filename: field.filename,
+          original_filename: field.original_filename,
+          mime_type: field.mime_type,
+          file_size: field.file_size,
+          storage_provider: field.storage_provider,
+          storage_path: field.storage_path,
+          storage_url: field.storage_url,
+          file_hash: field.file_hash,
+          image_width: field.image_width,
+          image_height: field.image_height,
+          image_format: field.image_format,
+          processing_status: field.processing_status || 'pending', // TODO: Is 'pending' the appropriate default status?
+          thumbnail_generated: field.thumbnail_generated || false,
+          variants: field.variants,
+        })
+        continue
+
+      case 'relation':
+        buckets.relation.push({
+          ...base,
+          target_document_id: field.target_document_id,
+          target_collection_id: field.target_collection_id,
+          relationship_type: field.relationship_type || 'reference', // TODO: Is this the appropriate place to set this?
+          cascade_delete: field.cascade_delete || false, // TODO: Same question?
+        })
+        continue
+
+      case 'json':
+        buckets.json.push({
+          ...base,
+          value: field.value,
+        })
+        continue
+
+      default:
+        throw ERR_DATABASE({
+          message: `unexpected field type: ${field_type}`,
+          details: { fieldType: field_type },
+        }).log(getLogger())
+    }
+  }
+
+  return buckets
+}
+
+/**
+ * Coerce a date/timestamp field value to a `Date` instance — both the
+ * MySQL `date` and (default-mode) `datetime` column builders require one on
+ * insert, per the dialect-divergence notes above. Accepts:
+ *   - `Date`   → passed through
+ *   - string   → parsed via `new Date(...)` (ISO, MySQL `date`, or MySQL
+ *     `datetime` shape — all parse correctly through the `Date` constructor)
+ *   - null / undefined → undefined (no insert)
+ */
+function toDate(value: Date | string | null | undefined): Date | undefined {
+  if (value == null) return undefined
+  if (value instanceof Date) return value
+  return new Date(value)
+}

--- a/packages/db-mysql/src/modules/storage/storage-insert.ts
+++ b/packages/db-mysql/src/modules/storage/storage-insert.ts
@@ -122,7 +122,7 @@ export const prepareFieldInsertBuckets = (
           value_time: field.value_time,
           // `value_timestamp_tz` arrives as a `Date` from form widgets but
           // as a string from `getAllFieldValues` — the UNION ALL declares
-          // the column as MySQL `datetime(3)` (no TZ; UTC by connection-level
+          // the column as MySQL `DATETIME(6)` (no TZ; UTC by connection-level
           // convention, see `src/index.ts`'s `timezone: 'Z'` pool option),
           // and mysql2 maps a `datetime` column to a string on read.
           // Drizzle's own `mapToDriverValue` for the (default, non-'string')

--- a/packages/db-mysql/src/modules/storage/storage-queries.ts
+++ b/packages/db-mysql/src/modules/storage/storage-queries.ts
@@ -1551,22 +1551,53 @@ export class DocumentQueries implements IDocumentQueries {
    * current-documents view, so an unpublished node and its whole subtree
    * drop out in `published` mode.
    *
-   * Two divergences from pg, both found live (not assumed from docs):
+   * Three divergences from pg, all found (or, for the third, reproduced)
+   * live — not assumed from docs:
    *
    *   - `s.path || '/' || r.order_key` (pg's `||` string concat) is MySQL
    *     boolean OR unless `PIPES_AS_CONCAT` is in `sql_mode` — confirmed
    *     against this database's `@@sql_mode` (it isn't set), and confirmed
    *     `SELECT 'a' || 'b'` returns `0`, not `'ab'`. `CONCAT(s.path, '/',
    *     r.order_key)` is the portable form.
-   *   - pg's `r.order_key::text AS path` cast and the closing `ORDER BY path
-   *     COLLATE "C"` both drop: `order_key` (and therefore the CONCAT'd
-   *     `path` column) is already `ascii_bin` — byte-comparable — end to
-   *     end (`varcharByteSorted`, `database/schema/common.ts`), confirmed
-   *     live that `CONCAT()` over two `ascii_bin` columns plus a `'/'`
-   *     literal stays `ascii_bin` rather than falling back to the
-   *     connection's `utf8mb4_0900_ai_ci` default (which would reorder
-   *     mixed-case keys incorrectly, the same class of bug `varcharByteSorted`
-   *     exists to prevent on the base columns).
+   *   - `ORDER BY path COLLATE "C"` drops the explicit collation: `order_key`
+   *     (and therefore the CONCAT'd `path` column, once the width fix below
+   *     is in place) is already `ascii_bin` — byte-comparable — end to end
+   *     (`varcharByteSorted`, `database/schema/common.ts`), confirmed live
+   *     that `CONCAT()` over two `ascii_bin` operands plus a `'/'` literal
+   *     stays `ascii_bin` rather than falling back to the connection's
+   *     `utf8mb4_0900_ai_ci` default (which would reorder mixed-case keys
+   *     incorrectly, the same class of bug `varcharByteSorted` exists to
+   *     prevent on the base columns).
+   *   - pg's `r.order_key::text AS path` cast does **two** jobs, not one —
+   *     an earlier version of this docblock dropped the cast on collation
+   *     grounds alone and missed the second job. In Postgres, `::text`
+   *     also makes the anchor column **unbounded** (`text` has no length
+   *     cap), which an accumulating concatenation needs. MySQL infers a
+   *     recursive CTE's column types from the *non-recursive* (anchor) leg
+   *     only — a bare `r.order_key` reference in the anchor makes `path`
+   *     inherit `order_key`'s declared `varchar(128)` width
+   *     (`varcharByteSorted`, `database/schema/index.ts:299`), so every
+   *     recursive iteration's `CONCAT` is silently constrained to 128
+   *     bytes regardless of how the SELECT list is written. Reproduced
+   *     live against this server (`STRICT_TRANS_TABLES` is in `sql_mode`,
+   *     so it's a hard `ER_DATA_TOO_LONG`, not silent truncation):
+   *     `WITH RECURSIVE t AS (SELECT CAST('ab' AS CHAR(128) CHARACTER SET
+   *     ascii) AS p, 1 AS n UNION ALL SELECT CONCAT(p,'/','abc…xyz'), n+1
+   *     FROM t WHERE n<6) …` → `ERROR 1406 (22001): Data too long for
+   *     column 'p' at row 1`. The threshold — `Σ len(order_key) + depth − 1
+   *     > 128` — is far more reachable than the `cte_max_recursion_depth`
+   *     ceiling this method's own docblock elsewhere flags: roughly 11–40
+   *     tree levels for typical fractional-index keys, lower once keys
+   *     have grown through repeated same-position reordering. Fix: widen
+   *     the anchor's `path` column explicitly —
+   *     `CAST(r.order_key AS CHAR(4096) CHARACTER SET ascii) COLLATE
+   *     ascii_bin` — doing both jobs the pg cast did: width (4096 bytes,
+   *     generous headroom over the reachable-depth threshold above) *and*
+   *     collation (`CHARACTER SET ascii` alone resolves to
+   *     `ascii_general_ci`, not `ascii_bin` — confirmed live that a bare
+   *     `CAST(… AS CHAR(4096))` with no `CHARACTER SET`/`COLLATE` at all
+   *     reverts to the *connection's* default collation, not the source
+   *     column's, so both clauses are required, not just one).
    */
   async getTreeSubtree({
     collectionId,
@@ -1612,7 +1643,8 @@ export class DocumentQueries implements IDocumentQueries {
     const query = sql`
       WITH RECURSIVE subtree AS (
         SELECT r.child_document_id, r.parent_document_id, r.order_key,
-               0 AS depth, r.order_key AS path
+               0 AS depth,
+               CAST(r.order_key AS CHAR(4096) CHARACTER SET ascii) COLLATE ascii_bin AS path
         FROM byline_document_relationships r
         JOIN byline_documents d ON d.id = r.child_document_id
         WHERE d.collection_id = ${collectionId}

--- a/packages/db-mysql/src/modules/storage/storage-queries.ts
+++ b/packages/db-mysql/src/modules/storage/storage-queries.ts
@@ -1,0 +1,1278 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ *
+ * Task 10A — the MySQL storage read path. Ported from
+ * `packages/db-postgres/src/modules/storage/storage-queries.ts`, scoped per
+ * the Task 10A controller amendments: the UNION ALL reconstruction path
+ * (`getDocumentById`, `getDocumentByVersion`, `getDocumentHistory`) and
+ * `findDocuments` far enough to serve the `versioning` + `field-types`
+ * `@byline/db-conformance` suites, including selective field loading
+ * (`resolveStoreTypes`).
+ *
+ * Deliberately NOT ported here (Task 10B): the `filters` (`DocumentFilter[]`
+ * — `$and`/`$or` combinators, relation hops, document-column filters)
+ * predicate compiler, `findDocuments`' `pathFilter`/`query` (LIKE search)/
+ * `sort` (`LEFT JOIN LATERAL` field sort), `getDocumentByPath`,
+ * `getDocumentsByVersionIds`, `getDocumentsByDocumentIds`,
+ * `getPublishedVersion`, `getPublishedDocumentIds`,
+ * `getDocumentCountsByStatus`, order-key / tree reads, `getCurrentPath`, and
+ * `getDocumentSystemFieldsForUpdate`. `DocumentQueries` therefore does NOT
+ * declare `implements IDocumentQueries` — that compile-time check only
+ * becomes meaningful once every member lands. `src/index.ts` wires each
+ * implemented member individually, exactly as `storage-commands.ts` did
+ * through Tasks 9A/9B.
+ */
+
+import type {
+  CollectionDefinition,
+  DocumentFilter,
+  FieldFilterOperator,
+  FieldSort,
+  FlattenedFieldValue,
+  FlattenedStore,
+  ICollectionQueries,
+  MissingLocalePolicy,
+  ReadMode,
+  UnifiedFieldValue,
+} from '@byline/core'
+import {
+  ERR_DATABASE,
+  ERR_NOT_FOUND,
+  extractFlattenedFieldValue,
+  getLogger,
+  orderByContentLocale,
+  resolveStoreTypes,
+  restoreFieldSetData,
+} from '@byline/core'
+import { and, eq, inArray, type SQL, sql } from 'drizzle-orm'
+import type { MySql2Database } from 'drizzle-orm/mysql2'
+
+import {
+  collections,
+  currentDocumentsView,
+  currentPublishedDocumentsView,
+  documentAvailableLocales,
+  documentPaths,
+  documentVersionLocales,
+  documentVersions,
+  metaStore,
+} from '../../database/schema/index.js'
+import type * as schema from '../../database/schema/index.js'
+import type { DBManager } from '../../lib/db-manager.js'
+
+type DatabaseConnection = MySql2Database<typeof schema>
+// `path` was dropped from documentVersions in favour of byline_document_paths;
+// SELECT projections re-attach it via a locale-aware subquery (see
+// `pathProjection`), so the in-memory Document shape continues to carry it.
+// `source_locale` (the per-document content-locale anchor) rides alongside so
+// the locale-aware read paths re-base the fallback floor onto it rather than
+// the mutable global default. See docs/07-internationalization/index.md.
+// Mirrors `packages/db-postgres/src/modules/storage/storage-queries.ts`.
+type Document = Omit<typeof documentVersions.$inferSelect, 'doc'> & {
+  path: string | null
+  source_locale: string | null
+}
+
+import { normalizeRow } from './normalize-row.js'
+import {
+  allStoreTypes,
+  type StoreType,
+  storeSelectList,
+  storeTableNames,
+} from './storage-store-manifest.js'
+
+interface MetaRow {
+  type: string
+  path: string
+  item_id: string
+  meta: Record<string, any> | null
+}
+
+/**
+ * CollectionQueries
+ *
+ * Identical to pg's — a plain query-builder read against `byline_collections`,
+ * with no dialect-specific SQL anywhere.
+ */
+export class CollectionQueries implements ICollectionQueries {
+  constructor(private db: DatabaseConnection) {}
+
+  async getAllCollections() {
+    return await this.db.select().from(collections)
+  }
+
+  async getCollectionByPath(path: string) {
+    return this.db.query.collections.findFirst({ where: eq(collections.path, path) })
+  }
+
+  async getCollectionById(id: string) {
+    return this.db.query.collections.findFirst({ where: eq(collections.id, id) })
+  }
+}
+
+/**
+ * DocumentQueries — Task 10A scope only. See the module docblock for what's
+ * deliberately not ported yet.
+ */
+export class DocumentQueries {
+  private db: DatabaseConnection
+  // Not read by any Task 10A method (none of getDocumentById/ByVersion/
+  // History/findDocuments needs a locked, ambient-transaction-aware read) —
+  // kept for constructor-signature parity with pg's DocumentQueries and
+  // because a locked read (getDocumentSystemFieldsForUpdate) is exactly the
+  // kind of member Task 10B adds.
+  // biome-ignore lint/correctness/noUnusedPrivateClassMembers: forward scaffolding for Task 10B, see comment above
+  private transactionDb: DBManager
+  private collections: readonly CollectionDefinition[]
+  private defaultContentLocale: string
+  private collectionPathCache = new Map<string, string>()
+
+  constructor(
+    db: DatabaseConnection,
+    collections: readonly CollectionDefinition[],
+    defaultContentLocale: string,
+    transactionDb: DBManager = { get: () => db }
+  ) {
+    this.db = db
+    this.transactionDb = transactionDb
+    this.collections = collections
+    this.defaultContentLocale = defaultContentLocale
+  }
+
+  /**
+   * Guard for the four Task 10B-owned query features
+   * (`filters`/`pathFilter`/`query`/`sort`). Fails loudly rather than
+   * silently ignoring a `beforeRead`-hook predicate or a search/sort
+   * request — a caller relying on row-scoping getting an unscoped result
+   * back would be a silent security regression, not a missing feature.
+   */
+  private assertUnsupported(condition: boolean, method: string, feature: string): void {
+    if (!condition) return
+    throw ERR_DATABASE({
+      message: `${method}: '${feature}' is not implemented on @byline/db-mysql yet (Task 10B)`,
+      details: { method, feature },
+    }).log(getLogger())
+  }
+
+  /**
+   * Resolve a collection UUID to its CollectionDefinition by looking up the
+   * collection's path in the DB and matching it against the injected array.
+   */
+  private async getDefinitionForCollection(collectionId: string): Promise<CollectionDefinition> {
+    let path = this.collectionPathCache.get(collectionId)
+    if (!path) {
+      const row = await this.db.query.collections.findFirst({
+        where: eq(collections.id, collectionId),
+      })
+      if (!row) {
+        throw ERR_NOT_FOUND({
+          message: `collection not found in database: ${collectionId}`,
+          details: { collectionId },
+        }).log(getLogger())
+      }
+      path = row.path
+      this.collectionPathCache.set(collectionId, path)
+    }
+
+    const definition = this.collections.find((c) => c.path === path)
+    if (!definition) {
+      throw ERR_NOT_FOUND({
+        message: `no CollectionDefinition found for path: ${path}`,
+        details: { collectionPath: path },
+      }).log(getLogger())
+    }
+    return definition
+  }
+
+  /**
+   * Pick the Drizzle view reference to read from based on `readMode`.
+   *
+   *   - `'any'` (default) → `current_documents` — the latest version of
+   *     each logical document, regardless of status.
+   *   - `'published'`     → `current_published_documents` — the latest
+   *     version whose status is `'published'`, falling back past newer
+   *     drafts so public readers keep seeing previously-published
+   *     content while editors work on an unpublished draft.
+   *
+   * Both views share the same row shape, so the returned reference is
+   * drop-in substitutable at every select/where site.
+   */
+  private pickCurrentView(
+    readMode: ReadMode | undefined
+  ): typeof currentDocumentsView | typeof currentPublishedDocumentsView {
+    return readMode === 'published' ? currentPublishedDocumentsView : currentDocumentsView
+  }
+
+  /**
+   * Build the locale priority chain for fallback resolution:
+   * `[requested, floor]`, deduplicated when both are the same. The floor is
+   * the document's own `source_locale` anchor when known (so a re-anchored
+   * document, or any document read after the global default is switched, falls
+   * back to the locale it was actually authored in) — otherwise the configured
+   * global default, which is correct for not-yet-anchored rows. See
+   * docs/07-internationalization/index.md.
+   */
+  private buildLocaleChain(
+    requestedLocale: string | undefined,
+    sourceLocale?: string | null
+  ): string[] {
+    const floor = sourceLocale ?? this.defaultContentLocale
+    const requested = requestedLocale ?? floor
+    return requested === floor ? [requested] : [requested, floor]
+  }
+
+  /**
+   * Build the `onMissingLocale: 'omit'` availability gate — an EXISTS against
+   * the version-locale ledger (`byline_document_version_locales`) that keeps
+   * only documents available in the requested locale. The `'all'` sentinel row
+   * covers locale-agnostic documents (no localized content). Returns `null`
+   * when the gate does not apply — a non-`'omit'` policy (`'empty'` /
+   * `'fallback'` / unset), or the admin sentinel `'all'` read — so callers can
+   * conditionally push it into a WHERE. No dialect-specific SQL — ports
+   * unchanged from pg.
+   */
+  private localeAvailabilityExists(
+    versionId: SQL,
+    locale: string,
+    onMissingLocale: MissingLocalePolicy | undefined
+  ): SQL | null {
+    if (onMissingLocale !== 'omit' || locale === 'all') return null
+    return sql`EXISTS (
+      SELECT 1 FROM byline_document_version_locales dvl
+      WHERE dvl.document_version_id = ${versionId}
+        AND (dvl.locale = ${locale} OR dvl.locale = 'all')
+    )`
+  }
+
+  /**
+   * Batch-fetch the version-locale availability sets from the
+   * `byline_document_version_locales` ledger. For each version returns the
+   * concrete locales its content is complete in (`availableLocales`, in
+   * configured content-locale order), or `localeAgnostic: true` when the
+   * version carries only the `'all'` sentinel. Drives the
+   * `_availableVersionLocales` read metadata. One indexed query per call.
+   * Plain query-builder code — ports unchanged from pg.
+   */
+  private async getAvailableLocalesByVersion(
+    versionIds: string[]
+  ): Promise<Map<string, { availableLocales: string[]; localeAgnostic: boolean }>> {
+    const result = new Map<string, { availableLocales: string[]; localeAgnostic: boolean }>()
+    if (versionIds.length === 0) return result
+
+    const rows = await this.db
+      .select({
+        vid: documentVersionLocales.document_version_id,
+        locale: documentVersionLocales.locale,
+      })
+      .from(documentVersionLocales)
+      .where(inArray(documentVersionLocales.document_version_id, versionIds))
+
+    for (const row of rows) {
+      let entry = result.get(row.vid)
+      if (entry == null) {
+        entry = { availableLocales: [], localeAgnostic: false }
+        result.set(row.vid, entry)
+      }
+      if (row.locale === 'all') entry.localeAgnostic = true
+      else entry.availableLocales.push(row.locale)
+    }
+    for (const entry of result.values()) {
+      entry.availableLocales = orderByContentLocale(entry.availableLocales)
+    }
+    return result
+  }
+
+  /**
+   * Batch-fetch the editorial advertised-locale sets from
+   * `byline_document_available_locales` (document-grain). For each logical
+   * document returns the set of locales the editor has elected to advertise,
+   * in configured content-locale order. Surfaced on reads as
+   * `availableLocales`. One indexed query per call. Plain query-builder
+   * code — ports unchanged from pg.
+   */
+  private async getAdvertisedLocalesByDocument(
+    documentIds: string[]
+  ): Promise<Map<string, string[]>> {
+    const result = new Map<string, string[]>()
+    if (documentIds.length === 0) return result
+
+    const rows = await this.db
+      .select({
+        did: documentAvailableLocales.document_id,
+        locale: documentAvailableLocales.locale,
+      })
+      .from(documentAvailableLocales)
+      .where(inArray(documentAvailableLocales.document_id, documentIds))
+
+    for (const row of rows) {
+      let arr = result.get(row.did)
+      if (arr == null) {
+        arr = []
+        result.set(row.did, arr)
+      }
+      arr.push(row.locale)
+    }
+    for (const [did, arr] of result) result.set(did, orderByContentLocale(arr))
+    return result
+  }
+
+  /**
+   * Emit a SQL fragment that resolves the path string for a document via
+   * the locale priority chain. Used as a projected column expression
+   * inside `SELECT` lists.
+   *
+   * Postgres:
+   * ```sql
+   * (SELECT path FROM byline_document_paths
+   *  WHERE document_id = <docIdSql> AND locale = ANY(<chain>)
+   *  ORDER BY array_position(<chain>, locale) LIMIT 1)
+   * ```
+   * MySQL has no `ANY(ARRAY[...])` or `array_position` — the locale-chain
+   * conversion (design spec §2): `IN (…)` for the membership test, and
+   * `ORDER BY FIELD(locale, …)` for the priority order. `FIELD()` returns
+   * the 1-based position of the first argument within the remaining
+   * argument list (0 if absent); since the `WHERE … IN (chain)` clause
+   * already restricts every candidate row to a locale that's a member of
+   * the chain, `FIELD()` can never actually return 0 here — every row that
+   * reaches the `ORDER BY` has a genuine position, and ascending order
+   * therefore picks the earliest (highest-priority, i.e. most-requested)
+   * chain entry first, exactly matching `array_position`'s semantics.
+   * Verified live against MySQL 9.7.1 (see the Task 10A report) and pinned
+   * by `storage-queries.test.ts`'s locale-chain-ordering test.
+   */
+  private pathProjection(
+    documentIdCol: SQL,
+    requestedLocale?: string,
+    sourceLocaleCol?: SQL
+  ): SQL<string | null> {
+    const floorSql: SQL = sourceLocaleCol
+      ? sql`COALESCE(${sourceLocaleCol}, ${this.defaultContentLocale})`
+      : sql`${this.defaultContentLocale}`
+    const requestedSql: SQL = requestedLocale != null ? sql`${requestedLocale}` : floorSql
+    const chainSql = sql.join([requestedSql, floorSql], sql`, `)
+    return sql<string | null>`(
+      SELECT ${documentPaths.path} FROM ${documentPaths}
+      WHERE ${documentPaths.document_id} = ${documentIdCol}
+        AND ${documentPaths.locale} IN (${chainSql})
+      ORDER BY FIELD(${documentPaths.locale}, ${chainSql})
+      LIMIT 1
+    )`
+  }
+
+  /**
+   * Project list for `current_documents` / `current_published_documents`
+   * reads, with `path` resolved through the locale priority chain. Used
+   * everywhere a read previously did `.select()` (which auto-pulls every
+   * view column) — `path` is no longer projected by the views, so call
+   * sites must list the projection explicitly.
+   */
+  private viewProjection(
+    view: typeof currentDocumentsView | typeof currentPublishedDocumentsView,
+    requestedLocale: string | undefined
+  ) {
+    return {
+      id: view.id,
+      document_id: view.document_id,
+      collection_id: view.collection_id,
+      collection_version: view.collection_version,
+      event_type: view.event_type,
+      status: view.status,
+      is_deleted: view.is_deleted,
+      created_at: view.created_at,
+      updated_at: view.updated_at,
+      created_by: view.created_by,
+      change_summary: view.change_summary,
+      source_locale: view.source_locale,
+      path: this.pathProjection(
+        sql`${view.document_id}`,
+        requestedLocale,
+        sql`${view.source_locale}`
+      ),
+    }
+  }
+
+  /**
+   * Project list for direct `byline_document_versions` reads (history,
+   * version-by-id lookups). Mirrors `viewProjection` but against the
+   * underlying table — `path` is sourced from `byline_document_paths` via
+   * the locale priority chain, since it no longer lives on the version row.
+   */
+  private documentVersionsProjection(requestedLocale: string | undefined) {
+    const sourceLocaleSql = sql<
+      string | null
+    >`(SELECT source_locale FROM byline_documents WHERE id = ${documentVersions.document_id})`
+    return {
+      id: documentVersions.id,
+      document_id: documentVersions.document_id,
+      collection_id: documentVersions.collection_id,
+      collection_version: documentVersions.collection_version,
+      event_type: documentVersions.event_type,
+      status: documentVersions.status,
+      is_deleted: documentVersions.is_deleted,
+      created_at: documentVersions.created_at,
+      updated_at: documentVersions.updated_at,
+      created_by: documentVersions.created_by,
+      change_summary: documentVersions.change_summary,
+      source_locale: sourceLocaleSql,
+      path: this.pathProjection(
+        sql`${documentVersions.document_id}`,
+        requestedLocale,
+        sourceLocaleSql
+      ),
+    }
+  }
+
+  /**
+   * Resolve the single effective content locale a version should be restored
+   * in, walking the fallback chain (`[requested, default]`) and returning the
+   * first locale the version is *available* in. Pure JS/data-structure code
+   * — no SQL — ports unchanged from pg. See pg's docblock for the full
+   * phase-1 availability rule.
+   */
+  private resolveEffectiveLocale(flattenedData: FlattenedFieldValue[], chain: string[]): string {
+    // biome-ignore lint/style/noNonNullAssertion: chain is non-empty by construction
+    const defaultLocale = chain[chain.length - 1]!
+
+    const pathsByLocale = new Map<string, Set<string>>()
+    for (const row of flattenedData) {
+      if (row.locale === 'all' || row.field_type === 'meta') continue
+      let set = pathsByLocale.get(row.locale)
+      if (set == null) {
+        set = new Set<string>()
+        pathsByLocale.set(row.locale, set)
+      }
+      set.add(row.field_path.join('.'))
+    }
+
+    const canonical = pathsByLocale.get(defaultLocale) ?? new Set<string>()
+
+    for (const candidate of chain) {
+      if (candidate === defaultLocale) break
+      if (canonical.size === 0) return candidate
+      const covered = pathsByLocale.get(candidate)
+      if (covered != null && isSuperset(covered, canonical)) return candidate
+    }
+
+    return defaultLocale
+  }
+
+  /**
+   * Reconstruct document fields from unified row values using schema-aware
+   * restoration. Meta rows (from store_meta) are converted to
+   * FlattenedFieldValue entries so that restoreFieldSetData can inject
+   * _id and _type for blocks and array items inline. Pure JS/core-delegate
+   * code — ports unchanged from pg.
+   */
+  private reconstructFromUnifiedRows(
+    unifiedFieldValues: UnifiedFieldValue[],
+    definition: CollectionDefinition,
+    locale: string,
+    metaRows?: MetaRow[],
+    lenient = false,
+    onMissingLocale?: MissingLocalePolicy,
+    sourceLocale?: string | null
+  ): { fields: any; warnings: string[] } {
+    const flattenedData: FlattenedFieldValue[] = unifiedFieldValues.map((row) =>
+      extractFlattenedFieldValue(row)
+    )
+
+    if (metaRows) {
+      for (const meta of metaRows) {
+        flattenedData.push({
+          locale: 'all',
+          field_path: meta.path.split('.'),
+          field_type: 'meta',
+          type: meta.type as 'group' | 'array_item',
+          item_id: meta.item_id,
+        })
+      }
+    }
+
+    const resolveLocale =
+      locale === 'all'
+        ? undefined
+        : onMissingLocale === 'fallback'
+          ? this.resolveEffectiveLocale(flattenedData, this.buildLocaleChain(locale, sourceLocale))
+          : locale
+    const { data, warnings } = restoreFieldSetData(definition.fields, flattenedData, resolveLocale)
+
+    if (!lenient && warnings.length > 0) {
+      throw ERR_DATABASE({
+        message: `document reconstruction failed with ${warnings.length} warnings`,
+        details: { warnings },
+      }).log(getLogger())
+    }
+
+    return { fields: data, warnings }
+  }
+
+  /**
+   * getDocumentById — gets the current version of a document by its logical document ID.
+   *
+   * When `lenient` is true, schema-mismatch warnings emitted during
+   * reconstruction are surfaced on the returned object as `restoreWarnings`
+   * rather than thrown. This is the admin edit path's "best-effort load"
+   * mode for documents written under a previous collection schema.
+   *
+   * `filters` (the `beforeRead`-hook predicate) is accepted for interface
+   * parity but not yet compiled — see `assertUnsupported`. Task 10B.
+   */
+  async getDocumentById({
+    collection_id,
+    document_id,
+    locale = 'en',
+    reconstruct = true,
+    readMode,
+    filters,
+    lenient = false,
+    onMissingLocale,
+  }: {
+    collection_id: string
+    document_id: string
+    locale?: string
+    reconstruct?: boolean
+    readMode?: ReadMode
+    filters?: DocumentFilter[]
+    lenient?: boolean
+    onMissingLocale?: MissingLocalePolicy
+  }) {
+    this.assertUnsupported(!!filters?.length, 'getDocumentById', 'filters')
+
+    const view = this.pickCurrentView(readMode)
+    const baseConditions: SQL[] = [
+      eq(view.collection_id, collection_id),
+      eq(view.document_id, document_id),
+    ]
+    const strictGate = this.localeAvailabilityExists(sql`${view.id}`, locale, onMissingLocale)
+    if (strictGate) {
+      baseConditions.push(strictGate)
+    }
+    const [document] = await this.db
+      .select(this.viewProjection(view, locale))
+      .from(view)
+      .where(and(...baseConditions))
+
+    if (document == null) {
+      return null
+    }
+
+    const unifiedFieldValues = await this.getAllFieldValues(
+      document.id,
+      locale,
+      document.source_locale
+    )
+
+    if (reconstruct === true) {
+      const definition = await this.getDefinitionForCollection(collection_id)
+
+      const metaRows = await this.db
+        .select({
+          type: metaStore.type,
+          path: metaStore.path,
+          item_id: metaStore.item_id,
+          meta: metaStore.meta,
+        })
+        .from(metaStore)
+        .where(eq(metaStore.document_version_id, document.id))
+
+      const { fields, warnings } = this.reconstructFromUnifiedRows(
+        unifiedFieldValues,
+        definition,
+        locale,
+        metaRows as MetaRow[],
+        lenient,
+        onMissingLocale,
+        document.source_locale
+      )
+
+      const availability = (await this.getAvailableLocalesByVersion([document.id])).get(document.id)
+      const advertised = (await this.getAdvertisedLocalesByDocument([document.document_id])).get(
+        document.document_id
+      )
+
+      return {
+        document_version_id: document.id,
+        document_id: document.document_id,
+        path: document.path ?? '',
+        source_locale: document.source_locale ?? null,
+        status: document.status,
+        event_type: document.event_type,
+        created_at: document.created_at,
+        updated_at: document.updated_at,
+        created_by: document.created_by ?? null,
+        fields,
+        availableLocales: advertised ?? [],
+        _availableVersionLocales: availability?.availableLocales ?? [],
+        _localeAgnostic: availability?.localeAgnostic ?? false,
+        ...(lenient && warnings.length > 0 ? { restoreWarnings: warnings } : {}),
+      }
+    }
+    const fieldValues = this.convertUnionRowToFlattenedStores(unifiedFieldValues)
+    return {
+      document_version_id: document.id,
+      document_id: document.document_id,
+      path: document.path ?? '',
+      source_locale: document.source_locale ?? null,
+      status: document.status,
+      event_type: document.event_type,
+      created_at: document.created_at,
+      updated_at: document.updated_at,
+      created_by: document.created_by ?? null,
+      fields: fieldValues,
+    }
+  }
+
+  /**
+   * getDocumentByVersion — fetches a specific version and reconstructs its fields.
+   *
+   * `filters` accepted for interface parity, not yet compiled. Task 10B.
+   */
+  async getDocumentByVersion({
+    document_version_id,
+    locale = 'all',
+    collection_id,
+    filters,
+  }: {
+    document_version_id: string
+    locale?: string
+    collection_id?: string
+    filters?: DocumentFilter[]
+  }): Promise<any | null> {
+    this.assertUnsupported(!!filters?.length, 'getDocumentByVersion', 'filters')
+
+    const projectionLocale = locale === 'all' ? undefined : locale
+    const conditions: SQL[] = [eq(documentVersions.id, document_version_id)]
+    if (collection_id) conditions.push(eq(documentVersions.collection_id, collection_id))
+
+    const [document] = await this.db
+      .select(this.documentVersionsProjection(projectionLocale))
+      .from(documentVersions)
+      .where(and(...conditions))
+
+    if (document == null) return null
+
+    const unifiedFieldValues = await this.getAllFieldValues(
+      document.id,
+      locale,
+      document.source_locale
+    )
+    const definition = await this.getDefinitionForCollection(document.collection_id)
+
+    const metaRows = await this.db
+      .select({
+        type: metaStore.type,
+        path: metaStore.path,
+        item_id: metaStore.item_id,
+        meta: metaStore.meta,
+      })
+      .from(metaStore)
+      .where(eq(metaStore.document_version_id, document.id))
+
+    const { fields } = this.reconstructFromUnifiedRows(
+      unifiedFieldValues,
+      definition,
+      locale,
+      metaRows as MetaRow[],
+      false,
+      undefined,
+      document.source_locale
+    )
+
+    return {
+      document_version_id: document.id,
+      document_id: document.document_id,
+      path: document.path ?? '',
+      source_locale: document.source_locale ?? null,
+      status: document.status,
+      created_at: document.created_at,
+      updated_at: document.updated_at,
+      fields,
+    }
+  }
+
+  /**
+   * getDocumentHistory — paginated version history for a logical document.
+   *
+   * `filters` accepted for interface parity, not yet compiled. Task 10B.
+   */
+  async getDocumentHistory({
+    collection_id,
+    document_id,
+    locale = 'all',
+    page = 1,
+    page_size = 20,
+    order = 'updated_at',
+    desc: descending = true,
+    filters,
+  }: {
+    collection_id: string
+    document_id: string
+    locale?: string
+    page?: number
+    page_size?: number
+    order?: string
+    desc?: boolean
+    query?: string
+    filters?: DocumentFilter[]
+  }): Promise<{
+    documents: any[]
+    meta: {
+      total: number
+      page: number
+      page_size: number
+      total_pages: number
+      order: string
+      desc: boolean
+    }
+  }> {
+    this.assertUnsupported(!!filters?.length, 'getDocumentHistory', 'filters')
+
+    const collection = await this.db.query.collections.findFirst({
+      where: eq(collections.id, collection_id),
+    })
+
+    if (collection == null || collection.config == null) {
+      throw ERR_NOT_FOUND({
+        message: `collection not found or missing config: ${collection_id}`,
+        details: { collectionId: collection_id },
+      }).log(getLogger())
+    }
+
+    const conditions: SQL[] = [
+      eq(documentVersions.collection_id, collection_id),
+      eq(documentVersions.document_id, document_id),
+    ]
+
+    // `count(*)::int` (pg) → `CAST(COUNT(*) AS SIGNED)` (design spec §2),
+    // with the `Number()` normalisation at the result edge kept as a belt.
+    const totalResult: { count: number }[] = await this.db
+      .select({ count: sql<number>`CAST(COUNT(*) AS SIGNED)` })
+      .from(documentVersions)
+      .where(and(...conditions))
+
+    const total = Number(totalResult[0]?.count) || 0
+    const total_pages = Math.ceil(total / page_size)
+    const offset = (page - 1) * page_size
+    // History is per-document; path is sticky so every version row has the
+    // same value. `order === 'path'` is degenerate and was removed when
+    // path moved to byline_document_paths — fall back to created_at.
+    const orderColumn = documentVersions.created_at
+    const orderFunc = descending === true ? sql`DESC` : sql`ASC`
+
+    const projectionLocale = locale === 'all' ? undefined : locale
+    const result: Document[] = await this.db
+      .select(this.documentVersionsProjection(projectionLocale))
+      .from(documentVersions)
+      .where(and(...conditions))
+      .orderBy(sql`${orderColumn} ${orderFunc}`)
+      .limit(page_size)
+      .offset(offset)
+
+    const history = await this.reconstructDocuments({ documents: result, locale })
+
+    return {
+      documents: history,
+      meta: { total, page, page_size, total_pages, order, desc: descending },
+    }
+  }
+
+  /**
+   * Reconstruct a batch of already-fetched `Document` rows into full
+   * documents, applying selective field loading when `fields` is supplied.
+   * Pure JS/core-delegate orchestration around `getAllFieldValuesForMultipleVersions`
+   * — ports unchanged from pg (the dialect-specific work is one level down).
+   */
+  private async reconstructDocuments({
+    documents,
+    locale = 'all',
+    fields: requestedFields,
+    onMissingLocale,
+  }: {
+    documents: Document[]
+    locale?: string
+    fields?: string[]
+    onMissingLocale?: MissingLocalePolicy
+  }): Promise<any[]> {
+    if (documents.length === 0) return []
+    const versionIds = documents.map((v) => v.id)
+
+    // Resolve definition once for the batch (safe — early return above guarantees length > 0)
+    const firstDoc = documents[0]!
+    const definition = await this.getDefinitionForCollection(firstDoc.collection_id)
+
+    // When specific fields are requested, resolve which store tables we need
+    // and query only those — skipping irrelevant tables entirely.
+    const storeTypes = requestedFields?.length
+      ? resolveStoreTypes(definition.fields, requestedFields)
+      : undefined
+
+    // The distinct fallback floors for the batch — each document's own
+    // `source_locale` anchor — so the field fetch pulls every locale a row in
+    // this page might fall back to, not just the global default.
+    const floorLocales = [
+      ...new Set(documents.map((d) => d.source_locale).filter((l): l is string => l != null)),
+    ]
+
+    const allFieldValues = await this.getAllFieldValuesForMultipleVersions(
+      versionIds,
+      locale,
+      storeTypes,
+      floorLocales
+    )
+
+    const fieldValuesByVersion = new Map<string, UnifiedFieldValue[]>()
+    for (const fieldValue of allFieldValues) {
+      if (!fieldValuesByVersion.has(fieldValue.document_version_id)) {
+        fieldValuesByVersion.set(fieldValue.document_version_id, [])
+      }
+      fieldValuesByVersion.get(fieldValue.document_version_id)?.push(fieldValue)
+    }
+
+    const allMetaRows = await this.db
+      .select({
+        document_version_id: metaStore.document_version_id,
+        type: metaStore.type,
+        path: metaStore.path,
+        item_id: metaStore.item_id,
+        meta: metaStore.meta,
+      })
+      .from(metaStore)
+      .where(inArray(metaStore.document_version_id, versionIds))
+
+    const metaByVersion = new Map<string, MetaRow[]>()
+    for (const row of allMetaRows) {
+      const list = metaByVersion.get(row.document_version_id) ?? []
+      list.push({
+        type: row.type,
+        path: row.path,
+        item_id: row.item_id,
+        meta: row.meta as Record<string, any> | null,
+      })
+      if (!metaByVersion.has(row.document_version_id)) {
+        metaByVersion.set(row.document_version_id, list)
+      }
+    }
+
+    const result: any[] = []
+    for (const doc of documents) {
+      const versionFieldValues = fieldValuesByVersion.get(doc.id) || []
+      const docMetaRows = (metaByVersion.get(doc.id) ?? []) as MetaRow[]
+      const { fields } = this.reconstructFromUnifiedRows(
+        versionFieldValues,
+        definition,
+        locale,
+        docMetaRows,
+        false,
+        onMissingLocale,
+        doc.source_locale
+      )
+
+      // When specific fields were requested, trim the reconstructed object
+      // to only those fields. Store-level filtering avoids querying unused
+      // tables, but fields sharing a store (e.g. price + views in numeric)
+      // still appear — this final pass removes them.
+      const trimmedFields = requestedFields?.length
+        ? Object.fromEntries(Object.entries(fields).filter(([k]) => requestedFields.includes(k)))
+        : fields
+
+      result.push({
+        document_version_id: doc.id,
+        document_id: doc.document_id,
+        path: doc.path ?? '',
+        source_locale: doc.source_locale ?? null,
+        status: doc.status,
+        event_type: doc.event_type,
+        created_at: doc.created_at,
+        updated_at: doc.updated_at,
+        created_by: doc.created_by ?? null,
+        fields: trimmedFields,
+      })
+    }
+
+    return result
+  }
+
+  /**
+   * Gets all field values for a single document version.
+   * Delegates to the multi-version dynamic UNION ALL builder.
+   */
+  private async getAllFieldValues(
+    documentVersionId: string,
+    locale = 'all',
+    sourceLocale?: string | null
+  ): Promise<UnifiedFieldValue[]> {
+    return this.getAllFieldValuesForMultipleVersions(
+      [documentVersionId],
+      locale,
+      undefined,
+      sourceLocale ? [sourceLocale] : undefined
+    )
+  }
+
+  /**
+   * Gets field values for multiple versions in a single query — the UNION
+   * ALL that is the whole point of this task.
+   *
+   * When `storeTypes` is provided, only those store tables are included in
+   * the UNION ALL — this is the selective field loading optimisation for
+   * list views that only need a subset of fields.
+   *
+   * Locale-chain conversion (design spec §2, the store-row locale
+   * condition): pg's `locale = ANY(ARRAY[...]) ` → MySQL `locale IN (...)`.
+   * No `ORDER BY`/`FIELD()` needed here — this is a membership filter, not a
+   * priority pick (unlike `pathProjection`, every matching locale row is
+   * kept; `resolveEffectiveLocale`/`restoreFieldSetData` pick the effective
+   * one in JS afterwards).
+   *
+   * `db.execute()` on the mysql2 driver returns a `[rows, fields]` tuple
+   * (unlike pg's `{ rows }` result object) — see `storage-commands.ts` for
+   * the established pattern this mirrors.
+   */
+  private async getAllFieldValuesForMultipleVersions(
+    documentVersionIds: string[],
+    locale = 'all',
+    storeTypes?: Set<StoreType>,
+    floorLocales?: string[]
+  ): Promise<UnifiedFieldValue[]> {
+    if (documentVersionIds.length === 0) return []
+
+    let localeCondition = sql``
+    if (locale !== 'all') {
+      const floors = floorLocales?.length ? floorLocales : [this.defaultContentLocale]
+      const chain = [...new Set([locale, ...floors])]
+      const chainSql = sql.join(
+        chain.map((l) => sql`${l}`),
+        sql`, `
+      )
+      localeCondition = sql`AND (locale IN (${chainSql}) OR locale = 'all')`
+    }
+
+    const documentCondition = sql`document_version_id IN (${sql.join(
+      documentVersionIds.map((id) => sql`${id}`),
+      sql`, `
+    )})`
+
+    const typesToQuery = storeTypes ?? new Set(allStoreTypes)
+
+    const fragments: SQL[] = []
+    for (const st of allStoreTypes) {
+      if (!typesToQuery.has(st)) continue
+      fragments.push(
+        sql`SELECT ${storeSelectList(st)} FROM ${sql.raw(storeTableNames[st])} WHERE ${documentCondition} ${localeCondition}`
+      )
+    }
+
+    if (fragments.length === 0) return []
+
+    let unionQuery = fragments[0]!
+    for (let i = 1; i < fragments.length; i++) {
+      unionQuery = sql`${unionQuery} UNION ALL ${fragments[i]}`
+    }
+
+    const query = sql`${unionQuery} ORDER BY document_version_id, field_path, locale`
+
+    const result = (await this.db.execute(query)) as unknown as [
+      Array<Record<string, unknown>>,
+      unknown,
+    ]
+    // Canonicalise the raw UNION ALL driver rows at the ingestion boundary —
+    // see normalizeRow's docstring for what the mysql2 driver leaves in a
+    // shape core's reconstruction can't consume as-is (TINYINT(1)-as-number,
+    // DECIMAL-as-string with decimalNumbers: false, DATETIME(3)-as-Date).
+    return result[0].map(normalizeRow)
+  }
+
+  /**
+   * findDocuments — Task 10A scope: `collection_id` + optional exact-match
+   * `status` + `locale` + basic document-level pagination/ordering +
+   * selective field loading (`fields`) + `readMode`/`onMissingLocale`. This
+   * is enough to serve the `field-types` conformance suite's two calls
+   * (with and without `fields`).
+   *
+   * Deliberately NOT implemented (Task 10B, per the controller amendments):
+   * `filters` (`DocumentFilter[]` — `$and`/`$or` combinators, relation-hop
+   * EXISTS, document-column filters), `pathFilter`, `query` (admin
+   * quick-search LIKE), `sort` (field-level `LEFT JOIN LATERAL` sort). Any
+   * of these being passed throws rather than silently ignoring the request
+   * — a caller expecting row-scoping or a specific sort order getting an
+   * unscoped/default-ordered result back would be a silent correctness bug.
+   */
+  async findDocuments({
+    collection_id,
+    filters = [],
+    status,
+    pathFilter,
+    query,
+    sort,
+    orderBy = 'created_at',
+    orderDirection = 'desc',
+    locale = 'en',
+    page = 1,
+    pageSize = 20,
+    fields: requestedFields,
+    readMode,
+    onMissingLocale,
+  }: {
+    collection_id: string
+    filters?: DocumentFilter[]
+    status?: string
+    pathFilter?: { operator: FieldFilterOperator; value: string }
+    query?: string
+    sort?: FieldSort
+    orderBy?: string
+    orderDirection?: 'asc' | 'desc'
+    locale?: string
+    page?: number
+    pageSize?: number
+    fields?: string[]
+    readMode?: ReadMode
+    onMissingLocale?: MissingLocalePolicy
+  }): Promise<{ documents: any[]; total: number }> {
+    this.assertUnsupported(filters.length > 0, 'findDocuments', 'filters')
+    this.assertUnsupported(!!pathFilter, 'findDocuments', 'pathFilter')
+    this.assertUnsupported(!!query, 'findDocuments', 'query')
+    this.assertUnsupported(!!sort, 'findDocuments', 'sort')
+
+    const offset = (page - 1) * pageSize
+    const sourceTable =
+      readMode === 'published'
+        ? sql.raw('byline_current_published_documents')
+        : sql.raw('byline_current_documents')
+
+    const conditions: SQL[] = [sql`d.collection_id = ${collection_id}`]
+
+    if (status) {
+      conditions.push(sql`d.status = ${status}`)
+    }
+
+    const strictGate = this.localeAvailabilityExists(sql`d.id`, locale, onMissingLocale)
+    if (strictGate) {
+      conditions.push(strictGate)
+    }
+
+    const whereClause = sql.join(conditions, sql` AND `)
+    const orderClause = this.buildDocumentOrderClause(orderBy, orderDirection)
+
+    // `count(*)::int` → `CAST(COUNT(*) AS SIGNED)` (design spec §2).
+    const countQuery = sql`
+      SELECT CAST(COUNT(*) AS SIGNED) AS total
+      FROM ${sourceTable} d
+      WHERE ${whereClause}
+    `
+    const countResult = (await this.db.execute(countQuery)) as unknown as [
+      Array<{ total: number }>,
+      unknown,
+    ]
+    const total = Number(countResult[0][0]?.total) || 0
+
+    if (total === 0) {
+      return { documents: [], total: 0 }
+    }
+
+    const pathProjectionSql = this.pathProjection(sql`d.document_id`, locale, sql`d.source_locale`)
+    const mainQuery = sql`
+      SELECT d.*, ${pathProjectionSql} AS path
+      FROM ${sourceTable} d
+      WHERE ${whereClause}
+      ORDER BY ${orderClause}
+      LIMIT ${pageSize}
+      OFFSET ${offset}
+    `
+    const mainResult = (await this.db.execute(mainQuery)) as unknown as [
+      Array<Record<string, unknown>>,
+      unknown,
+    ]
+
+    const currentDocuments: Document[] = mainResult[0].map((row) => ({
+      id: row.id as string,
+      document_id: row.document_id as string,
+      collection_id: row.collection_id as string,
+      collection_version: row.collection_version as number,
+      path: (row.path as string | null) ?? null,
+      event_type: row.event_type as string,
+      status: row.status as string,
+      // Raw driver row (not the schema-typed query builder) — TINYINT(1)
+      // arrives as a JS number here, same as normalizeRow's boolean_value
+      // columns. `current_documents`'s own CTE already filters
+      // `is_deleted = false`, so this is always falsy in practice; coerced
+      // properly regardless.
+      is_deleted: Boolean(row.is_deleted),
+      created_at: row.created_at as Date,
+      updated_at: row.updated_at as Date,
+      created_by: row.created_by as string,
+      change_summary: row.change_summary as string,
+      source_locale: (row.source_locale as string | null) ?? null,
+    }))
+
+    const documents = await this.reconstructDocuments({
+      documents: currentDocuments,
+      locale,
+      fields: requestedFields,
+      onMissingLocale,
+    })
+
+    const availability = await this.getAvailableLocalesByVersion(
+      documents.map((d) => d.document_version_id)
+    )
+    const advertised = await this.getAdvertisedLocalesByDocument(
+      documents.map((d) => d.document_id)
+    )
+    for (const doc of documents) {
+      const a = availability.get(doc.document_version_id)
+      doc.availableLocales = advertised.get(doc.document_id) ?? []
+      doc._availableVersionLocales = a?.availableLocales ?? []
+      doc._localeAgnostic = a?.localeAgnostic ?? false
+    }
+
+    return { documents, total }
+  }
+
+  /**
+   * Build an ORDER BY clause for a document-level column. `path` is
+   * intentionally not sortable here — see pg's docblock.
+   *
+   * Divergence from pg (found by reasoning, confirmed live — see the Task
+   * 10A report): MySQL has no `NULLS LAST`. For `DESC`, MySQL already sorts
+   * NULL last by default (confirmed against the live container), so
+   * `d.order_key DESC` needs no help. For `ASC`, MySQL's default sorts NULL
+   * *first* — the opposite of pg's `NULLS LAST` — so the emulation idiom
+   * `ORDER BY (col IS NULL), col ASC` is required to match pg's behaviour
+   * (`(col IS NULL)` evaluates 0/1; ascending puts real values, which
+   * evaluate to 0, before NULLs, which evaluate to 1).
+   */
+  private buildDocumentOrderClause(orderBy: string, direction: 'asc' | 'desc'): SQL {
+    if (orderBy === 'order_key') {
+      return direction === 'desc'
+        ? sql`d.order_key DESC, d.created_at DESC`
+        : sql`(d.order_key IS NULL) ASC, d.order_key ASC, d.created_at DESC`
+    }
+    const columnMap: Record<string, string> = {
+      created_at: 'd.created_at',
+      updated_at: 'd.updated_at',
+    }
+    const col = columnMap[orderBy] ?? 'd.created_at'
+    return direction === 'desc' ? sql`${sql.raw(col)} DESC` : sql`${sql.raw(col)} ASC`
+  }
+
+  /**
+   * Converts a union field row back into an array of FlattenedStore that
+   * the reconstruction utilities expect. Pure JS mapping — ports unchanged
+   * from pg.
+   */
+  private convertUnionRowToFlattenedStores(unionRowValues: UnifiedFieldValue[]): FlattenedStore[] {
+    return unionRowValues.map((row) => {
+      const baseValue = {
+        field_path: row.field_path,
+        field_name: row.field_name,
+        locale: row.locale,
+        parent_path: row.parent_path ?? undefined,
+      }
+
+      switch (row.field_type) {
+        case 'text':
+          return {
+            ...baseValue,
+            field_type: 'text' as const,
+            value: row.text_value,
+          }
+
+        case 'richText':
+          return {
+            ...baseValue,
+            field_type: 'richText' as const,
+            value: row.json_value,
+          }
+
+        case 'numeric':
+          return {
+            ...baseValue,
+            field_type: row.number_type as 'float' | 'integer' | 'decimal',
+            number_type: row.number_type,
+            value_integer: row.value_integer,
+            value_decimal: row.value_decimal,
+            value_float: row.value_float,
+          }
+
+        case 'boolean':
+          return {
+            ...baseValue,
+            field_type: 'boolean' as const,
+            value: row.boolean_value,
+          }
+
+        case 'time':
+        case 'date':
+        case 'datetime':
+          return {
+            ...baseValue,
+            field_type: row.date_type as 'time' | 'date' | 'datetime',
+            date_type: row.date_type,
+            value_time: row.value_time,
+            value_date: row.value_date,
+            value_timestamp_tz: row.value_timestamp_tz,
+          }
+
+        case 'image':
+        case 'file':
+          return {
+            ...baseValue,
+            field_type: row.field_type as 'image' | 'file',
+            file_id: row.file_id,
+            filename: row.filename,
+            original_filename: row.original_filename,
+            mime_type: row.mime_type,
+            file_size: row.file_size,
+            storage_provider: row.storage_provider,
+            storage_path: row.storage_path,
+            storage_url: row.storage_url,
+            file_hash: row.file_hash,
+            image_width: row.image_width,
+            image_height: row.image_height,
+            image_format: row.image_format,
+            processing_status: row.processing_status,
+            thumbnail_generated: row.thumbnail_generated,
+          }
+
+        case 'relation':
+          return {
+            ...baseValue,
+            field_type: 'relation' as const,
+            target_document_id: row.target_document_id,
+            target_collection_id: row.target_collection_id,
+            relationship_type: row.relationship_type,
+            cascade_delete: row.cascade_delete,
+          }
+
+        default:
+          throw ERR_DATABASE({
+            message: `unknown field type: ${row.field_type}`,
+            details: { fieldType: row.field_type },
+          }).log(getLogger())
+      }
+    }) as FlattenedStore[]
+  }
+}
+
+/** True when `a` contains every member of `b`. */
+function isSuperset<T>(a: Set<T>, b: Set<T>): boolean {
+  for (const item of b) {
+    if (!a.has(item)) return false
+  }
+  return true
+}
+
+export function createQueryBuilders(
+  db: DatabaseConnection,
+  collections: readonly CollectionDefinition[],
+  defaultContentLocale: string,
+  transactionDb?: DBManager
+) {
+  return {
+    collections: new CollectionQueries(db),
+    documents: new DocumentQueries(db, collections, defaultContentLocale, transactionDb),
+  }
+}

--- a/packages/db-mysql/src/modules/storage/storage-queries.ts
+++ b/packages/db-mysql/src/modules/storage/storage-queries.ts
@@ -5,38 +5,39 @@
  *
  * Copyright (c) Infonomic Company Limited
  *
- * Task 10A — the MySQL storage read path. Ported from
- * `packages/db-postgres/src/modules/storage/storage-queries.ts`, scoped per
- * the Task 10A controller amendments: the UNION ALL reconstruction path
- * (`getDocumentById`, `getDocumentByVersion`, `getDocumentHistory`) and
- * `findDocuments` far enough to serve the `versioning` + `field-types`
- * `@byline/db-conformance` suites, including selective field loading
- * (`resolveStoreTypes`).
+ * The MySQL storage read path. Ported from
+ * `packages/db-postgres/src/modules/storage/storage-queries.ts`.
  *
- * Deliberately NOT ported here (Task 10B): the `filters` (`DocumentFilter[]`
- * — `$and`/`$or` combinators, relation hops, document-column filters)
- * predicate compiler, `findDocuments`' `pathFilter`/`query` (LIKE search)/
- * `sort` (`LEFT JOIN LATERAL` field sort), `getDocumentByPath`,
+ * Task 10A landed the UNION ALL reconstruction path (`getDocumentById`,
+ * `getDocumentByVersion`, `getDocumentHistory`) and a `findDocuments` scoped
+ * to what the `versioning` + `field-types` conformance suites needed.
+ *
+ * Task 10B (this port) completes the surface: the `DocumentFilter[]`
+ * predicate compiler (`$and`/`$or` combinators, relation hops,
+ * document-column filters), `findDocuments`' `pathFilter`/`query` (LIKE
+ * search)/`sort` (`LEFT JOIN LATERAL` field sort), `getDocumentByPath`,
  * `getDocumentsByVersionIds`, `getDocumentsByDocumentIds`,
  * `getPublishedVersion`, `getPublishedDocumentIds`,
  * `getDocumentCountsByStatus`, order-key / tree reads, `getCurrentPath`, and
- * `getDocumentSystemFieldsForUpdate`. `DocumentQueries` therefore does NOT
- * declare `implements IDocumentQueries` — that compile-time check only
- * becomes meaningful once every member lands. `src/index.ts` wires each
- * implemented member individually, exactly as `storage-commands.ts` did
- * through Tasks 9A/9B.
+ * `getDocumentSystemFieldsForUpdate`. `DocumentQueries` now declares
+ * `implements IDocumentQueries`.
  */
 
 import type {
   CollectionDefinition,
+  CombinatorFilter,
+  DocumentColumnFilter,
   DocumentFilter,
+  FieldFilter,
   FieldFilterOperator,
   FieldSort,
   FlattenedFieldValue,
   FlattenedStore,
   ICollectionQueries,
+  IDocumentQueries,
   MissingLocalePolicy,
   ReadMode,
+  RelationFilter,
   UnifiedFieldValue,
 } from '@byline/core'
 import {
@@ -45,10 +46,11 @@ import {
   extractFlattenedFieldValue,
   getLogger,
   orderByContentLocale,
+  resolveIdentityField,
   resolveStoreTypes,
   restoreFieldSetData,
 } from '@byline/core'
-import { and, eq, inArray, type SQL, sql } from 'drizzle-orm'
+import { and, desc, eq, inArray, isNotNull, isNull, type SQL, sql } from 'drizzle-orm'
 import type { MySql2Database } from 'drizzle-orm/mysql2'
 
 import {
@@ -57,6 +59,8 @@ import {
   currentPublishedDocumentsView,
   documentAvailableLocales,
   documentPaths,
+  documentRelationships,
+  documents,
   documentVersionLocales,
   documentVersions,
   metaStore,
@@ -93,6 +97,33 @@ interface MetaRow {
 }
 
 /**
+ * SQL references to the columns the predicate compiler may need from the
+ * enclosing scope. `docVersionId` is consumed by every EXISTS subquery as
+ * the correlation key; `status` / `path` / `documentId` are referenced by
+ * `DocumentColumnFilter` (the inside-a-combinator form of the top-level
+ * reserved keys for `status` / `path`, plus the all-scope form for `id`).
+ *
+ * Note: `documentId` is the *logical* document id (`document_id` on the
+ * current-documents view), not `docVersionId` (the version row id) —
+ * matches what callers writing `where: { id }` expect. Ports unchanged from
+ * pg — dialect-agnostic shape.
+ */
+interface OuterScope {
+  docVersionId: SQL
+  documentId: SQL
+  status: SQL
+  path: SQL
+}
+
+/** True when `a` contains every member of `b`. */
+function isSuperset<T>(a: Set<T>, b: Set<T>): boolean {
+  for (const item of b) {
+    if (!a.has(item)) return false
+  }
+  return true
+}
+
+/**
  * CollectionQueries
  *
  * Identical to pg's — a plain query-builder read against `byline_collections`,
@@ -115,17 +146,10 @@ export class CollectionQueries implements ICollectionQueries {
 }
 
 /**
- * DocumentQueries — Task 10A scope only. See the module docblock for what's
- * deliberately not ported yet.
+ * DocumentQueries
  */
-export class DocumentQueries {
+export class DocumentQueries implements IDocumentQueries {
   private db: DatabaseConnection
-  // Not read by any Task 10A method (none of getDocumentById/ByVersion/
-  // History/findDocuments needs a locked, ambient-transaction-aware read) —
-  // kept for constructor-signature parity with pg's DocumentQueries and
-  // because a locked read (getDocumentSystemFieldsForUpdate) is exactly the
-  // kind of member Task 10B adds.
-  // biome-ignore lint/correctness/noUnusedPrivateClassMembers: forward scaffolding for Task 10B, see comment above
   private transactionDb: DBManager
   private collections: readonly CollectionDefinition[]
   private defaultContentLocale: string
@@ -135,7 +159,7 @@ export class DocumentQueries {
     db: DatabaseConnection,
     collections: readonly CollectionDefinition[],
     defaultContentLocale: string,
-    transactionDb: DBManager = { get: () => db }
+    transactionDb: DBManager
   ) {
     this.db = db
     this.transactionDb = transactionDb
@@ -144,18 +168,65 @@ export class DocumentQueries {
   }
 
   /**
-   * Guard for the four Task 10B-owned query features
-   * (`filters`/`pathFilter`/`query`/`sort`). Fails loudly rather than
-   * silently ignoring a `beforeRead`-hook predicate or a search/sort
-   * request — a caller relying on row-scoping getting an unscoped result
-   * back would be a silent security regression, not a missing feature.
+   * Lock the logical document row before reading its document-grain system
+   * fields. Every audited system-field writer takes this same parent-row lock,
+   * so path and advertised-locale snapshots serialize without locking a
+   * variable set of child rows.
+   *
+   * Runs on `this.transactionDb.get()` — the ambient `withTransaction`
+   * executor when one is open, else the pool — so `FOR UPDATE` (unchanged
+   * syntax from pg) actually takes its lock inside the caller's transaction.
+   * A lock taken on a bare pool connection would release at the end of its
+   * own implicit transaction and serialise nothing; see the §H ruling in the
+   * Task 10B report for why `transactionDb` is a required constructor
+   * parameter rather than a silently-defaulted one.
    */
-  private assertUnsupported(condition: boolean, method: string, feature: string): void {
-    if (!condition) return
-    throw ERR_DATABASE({
-      message: `${method}: '${feature}' is not implemented on @byline/db-mysql yet (Task 10B)`,
-      details: { method, feature },
-    }).log(getLogger())
+  async getDocumentSystemFieldsForUpdate({
+    collection_id,
+    document_id,
+  }: {
+    collection_id: string
+    document_id: string
+  }): Promise<{
+    source_locale: string
+    path: string | null
+    availableLocales: string[]
+  } | null> {
+    const executor = this.transactionDb.get()
+    const [document] = await executor
+      .select({ source_locale: documents.source_locale })
+      .from(documents)
+      .where(and(eq(documents.collection_id, collection_id), eq(documents.id, document_id)))
+      .for('update')
+
+    if (document == null) return null
+
+    const [pathRow] = await executor
+      .select({ path: documentPaths.path })
+      .from(documentPaths)
+      .where(
+        and(
+          eq(documentPaths.collection_id, collection_id),
+          eq(documentPaths.document_id, document_id),
+          eq(documentPaths.locale, document.source_locale)
+        )
+      )
+      .limit(1)
+    const localeRows = await executor
+      .select({ locale: documentAvailableLocales.locale })
+      .from(documentAvailableLocales)
+      .where(
+        and(
+          eq(documentAvailableLocales.collection_id, collection_id),
+          eq(documentAvailableLocales.document_id, document_id)
+        )
+      )
+
+    return {
+      source_locale: document.source_locale,
+      path: pathRow?.path ?? null,
+      availableLocales: localeRows.map((row) => row.locale).sort(),
+    }
   }
 
   /**
@@ -213,8 +284,8 @@ export class DocumentQueries {
    * the document's own `source_locale` anchor when known (so a re-anchored
    * document, or any document read after the global default is switched, falls
    * back to the locale it was actually authored in) — otherwise the configured
-   * global default, which is correct for not-yet-anchored rows. See
-   * docs/07-internationalization/index.md.
+   * global default, which is correct for not-yet-anchored rows and for
+   * row-less lookups (findByPath). See docs/07-internationalization/index.md.
    */
   private buildLocaleChain(
     requestedLocale: string | undefined,
@@ -357,6 +428,34 @@ export class DocumentQueries {
     return sql<string | null>`(
       SELECT ${documentPaths.path} FROM ${documentPaths}
       WHERE ${documentPaths.document_id} = ${documentIdCol}
+        AND ${documentPaths.locale} IN (${chainSql})
+      ORDER BY FIELD(${documentPaths.locale}, ${chainSql})
+      LIMIT 1
+    )`
+  }
+
+  /**
+   * Emit a SQL fragment that resolves a `(collection_id, path)` tuple to a
+   * `document_id` via the locale priority chain. Used inside `WHERE` clauses
+   * for findByPath-style lookups. Same `IN (…)` / `FIELD()` locale-chain
+   * conversion as `pathProjection` — see that method's docblock. Returns
+   * NULL when no row matches in any locale, which makes the outer `=`
+   * predicate fail cleanly (no document found).
+   */
+  private resolveDocumentIdByPath(
+    collection_id: string,
+    path: string,
+    requestedLocale?: string
+  ): SQL {
+    const chain = this.buildLocaleChain(requestedLocale)
+    const chainSql = sql.join(
+      chain.map((l) => sql`${l}`),
+      sql`, `
+    )
+    return sql`(
+      SELECT ${documentPaths.document_id} FROM ${documentPaths}
+      WHERE ${documentPaths.collection_id} = ${collection_id}
+        AND ${documentPaths.path} = ${path}
         AND ${documentPaths.locale} IN (${chainSql})
       ORDER BY FIELD(${documentPaths.locale}, ${chainSql})
       LIMIT 1
@@ -511,15 +610,101 @@ export class DocumentQueries {
   }
 
   /**
+   * getCurrentVersionMetadata — narrow metadata fetch for the current version.
+   *
+   * Hits `current_documents` only; no field reconstruction, no meta fetch,
+   * no path subquery. Used by lifecycle operations (status changes,
+   * restore, delete checks) that only need `document_version_id` /
+   * `status` / timestamps before mutating.
+   */
+  async getCurrentVersionMetadata({
+    collection_id,
+    document_id,
+  }: {
+    collection_id: string
+    document_id: string
+  }): Promise<{
+    document_version_id: string
+    document_id: string
+    collection_id: string
+    status: string
+    created_at: Date
+    updated_at: Date
+  } | null> {
+    const [row] = await this.db
+      .select({
+        document_version_id: currentDocumentsView.id,
+        document_id: currentDocumentsView.document_id,
+        collection_id: currentDocumentsView.collection_id,
+        status: currentDocumentsView.status,
+        created_at: currentDocumentsView.created_at,
+        updated_at: currentDocumentsView.updated_at,
+      })
+      .from(currentDocumentsView)
+      .where(
+        and(
+          eq(currentDocumentsView.collection_id, collection_id),
+          eq(currentDocumentsView.document_id, document_id)
+        )
+      )
+      .limit(1)
+
+    if (!row) return null
+
+    return {
+      document_version_id: row.document_version_id,
+      document_id: row.document_id,
+      collection_id: row.collection_id ?? '',
+      status: row.status ?? 'draft',
+      created_at: row.created_at ?? new Date(),
+      updated_at: row.updated_at ?? new Date(),
+    }
+  }
+
+  /**
+   * getCurrentPath — resolve a document's canonical (source-locale) path.
+   *
+   * Reuses `pathProjection` against `current_documents`, passing
+   * `requestedLocale: undefined` so the projection's fallback floor — the
+   * document's own `source_locale` (COALESCE-guarded to the default content
+   * locale for not-yet-anchored rows) — supplies the canonical path. Used by
+   * the lifecycle to populate `path` on the status-change / unpublish hook
+   * contexts. Returns `null` when no path row (or document) exists.
+   */
+  async getCurrentPath({
+    collection_id,
+    document_id,
+  }: {
+    collection_id: string
+    document_id: string
+  }): Promise<string | null> {
+    const [row] = await this.db
+      .select({
+        path: this.pathProjection(
+          sql`${currentDocumentsView.document_id}`,
+          undefined,
+          sql`${currentDocumentsView.source_locale}`
+        ),
+      })
+      .from(currentDocumentsView)
+      .where(
+        and(
+          eq(currentDocumentsView.collection_id, collection_id),
+          eq(currentDocumentsView.document_id, document_id)
+        )
+      )
+      .limit(1)
+
+    return row?.path ?? null
+  }
+
+  /**
    * getDocumentById — gets the current version of a document by its logical document ID.
    *
    * When `lenient` is true, schema-mismatch warnings emitted during
    * reconstruction are surfaced on the returned object as `restoreWarnings`
    * rather than thrown. This is the admin edit path's "best-effort load"
    * mode for documents written under a previous collection schema.
-   *
-   * `filters` (the `beforeRead`-hook predicate) is accepted for interface
-   * parity but not yet compiled — see `assertUnsupported`. Task 10B.
    */
   async getDocumentById({
     collection_id,
@@ -540,13 +725,22 @@ export class DocumentQueries {
     lenient?: boolean
     onMissingLocale?: MissingLocalePolicy
   }) {
-    this.assertUnsupported(!!filters?.length, 'getDocumentById', 'filters')
-
     const view = this.pickCurrentView(readMode)
     const baseConditions: SQL[] = [
       eq(view.collection_id, collection_id),
       eq(view.document_id, document_id),
     ]
+    if (filters?.length) {
+      const outerScope: OuterScope = {
+        docVersionId: sql`${view.id}`,
+        documentId: sql`${view.document_id}`,
+        status: sql`${view.status}`,
+        path: this.pathProjection(sql`${view.document_id}`, locale, sql`${view.source_locale}`),
+      }
+      for (const f of filters) {
+        baseConditions.push(this.buildFilterExists(f, locale, outerScope, readMode, 0))
+      }
+    }
     const strictGate = this.localeAvailabilityExists(sql`${view.id}`, locale, onMissingLocale)
     if (strictGate) {
       baseConditions.push(strictGate)
@@ -627,9 +821,124 @@ export class DocumentQueries {
   }
 
   /**
+   * getDocumentByPath — resolves `(collection_id, path)` through the locale
+   * priority chain to a document_id, then reads and reconstructs its
+   * current version. See `resolveDocumentIdByPath` for the locale-chain
+   * SQL.
+   */
+  async getDocumentByPath({
+    collection_id,
+    path,
+    locale = 'en',
+    reconstruct = true,
+    readMode,
+    filters,
+    onMissingLocale,
+  }: {
+    collection_id: string
+    path: string
+    locale?: string
+    reconstruct: boolean
+    readMode?: ReadMode
+    filters?: DocumentFilter[]
+    onMissingLocale?: MissingLocalePolicy
+  }) {
+    const view = this.pickCurrentView(readMode)
+    const baseConditions: SQL[] = [
+      eq(view.collection_id, collection_id),
+      sql`${view.document_id} = ${this.resolveDocumentIdByPath(collection_id, path, locale)}`,
+    ]
+    if (filters?.length) {
+      const outerScope: OuterScope = {
+        docVersionId: sql`${view.id}`,
+        documentId: sql`${view.document_id}`,
+        status: sql`${view.status}`,
+        path: this.pathProjection(sql`${view.document_id}`, locale, sql`${view.source_locale}`),
+      }
+      for (const f of filters) {
+        baseConditions.push(this.buildFilterExists(f, locale, outerScope, readMode, 0))
+      }
+    }
+    const strictGate = this.localeAvailabilityExists(sql`${view.id}`, locale, onMissingLocale)
+    if (strictGate) {
+      baseConditions.push(strictGate)
+    }
+    const [document] = await this.db
+      .select(this.viewProjection(view, locale))
+      .from(view)
+      .where(and(...baseConditions))
+
+    if (document == null) {
+      return null
+    }
+
+    const unifiedFieldValues = await this.getAllFieldValues(
+      document.id,
+      locale,
+      document.source_locale
+    )
+
+    if (reconstruct === true) {
+      const definition = await this.getDefinitionForCollection(collection_id)
+
+      const metaRows = await this.db
+        .select({
+          type: metaStore.type,
+          path: metaStore.path,
+          item_id: metaStore.item_id,
+          meta: metaStore.meta,
+        })
+        .from(metaStore)
+        .where(eq(metaStore.document_version_id, document.id))
+
+      const { fields } = this.reconstructFromUnifiedRows(
+        unifiedFieldValues,
+        definition,
+        locale,
+        metaRows as MetaRow[],
+        false,
+        onMissingLocale,
+        document.source_locale
+      )
+
+      const availability = (await this.getAvailableLocalesByVersion([document.id])).get(document.id)
+      const advertised = (await this.getAdvertisedLocalesByDocument([document.document_id])).get(
+        document.document_id
+      )
+
+      return {
+        document_version_id: document.id,
+        document_id: document.document_id,
+        path: document.path ?? '',
+        source_locale: document.source_locale ?? null,
+        status: document.status,
+        event_type: document.event_type,
+        created_at: document.created_at,
+        updated_at: document.updated_at,
+        created_by: document.created_by ?? null,
+        fields,
+        availableLocales: advertised ?? [],
+        _availableVersionLocales: availability?.availableLocales ?? [],
+        _localeAgnostic: availability?.localeAgnostic ?? false,
+      }
+    }
+    const fieldValues = this.convertUnionRowToFlattenedStores(unifiedFieldValues)
+    return {
+      document_version_id: document.id,
+      document_id: document.document_id,
+      path: document.path ?? '',
+      source_locale: document.source_locale ?? null,
+      status: document.status,
+      event_type: document.event_type,
+      created_at: document.created_at,
+      updated_at: document.updated_at,
+      created_by: document.created_by ?? null,
+      fields: fieldValues,
+    }
+  }
+
+  /**
    * getDocumentByVersion — fetches a specific version and reconstructs its fields.
-   *
-   * `filters` accepted for interface parity, not yet compiled. Task 10B.
    */
   async getDocumentByVersion({
     document_version_id,
@@ -642,12 +951,21 @@ export class DocumentQueries {
     collection_id?: string
     filters?: DocumentFilter[]
   }): Promise<any | null> {
-    this.assertUnsupported(!!filters?.length, 'getDocumentByVersion', 'filters')
-
     const projectionLocale = locale === 'all' ? undefined : locale
+    const filterLocale = projectionLocale ?? this.defaultContentLocale
     const conditions: SQL[] = [eq(documentVersions.id, document_version_id)]
     if (collection_id) conditions.push(eq(documentVersions.collection_id, collection_id))
-
+    if (filters?.length) {
+      const scope: OuterScope = {
+        docVersionId: sql`${documentVersions.id}`,
+        documentId: sql`${documentVersions.document_id}`,
+        status: sql`${documentVersions.status}`,
+        path: this.pathProjection(sql`${documentVersions.document_id}`, filterLocale),
+      }
+      for (const filter of filters) {
+        conditions.push(this.buildFilterExists(filter, filterLocale, scope, 'any', 0))
+      }
+    }
     const [document] = await this.db
       .select(this.documentVersionsProjection(projectionLocale))
       .from(documentVersions)
@@ -695,9 +1013,102 @@ export class DocumentQueries {
   }
 
   /**
-   * getDocumentHistory — paginated version history for a logical document.
+   * getDocumentsByVersionIds — fetches and reconstructs multiple documents by
+   * version ID. Used for batch loading a known set of versions (e.g.
+   * migration scripts, tests).
+   */
+  async getDocumentsByVersionIds({
+    document_version_ids,
+    locale = 'all',
+  }: {
+    document_version_ids: string[]
+    locale?: string
+  }): Promise<any[]> {
+    if (document_version_ids.length === 0) return []
+
+    const docs = await this.db
+      .select(this.documentVersionsProjection(locale === 'all' ? undefined : locale))
+      .from(documentVersions)
+      .where(inArray(documentVersions.id, document_version_ids))
+
+    return this.reconstructDocuments({ documents: docs as Document[], locale })
+  }
+
+  /**
+   * getDocumentsByDocumentIds — batch-fetch current versions for a list of
+   * logical document IDs, with optional selective field loading.
    *
-   * `filters` accepted for interface parity, not yet compiled. Task 10B.
+   * Resolves each document_id to its current version via the
+   * `current_documents` view (soft-deleted documents are excluded by the
+   * view definition), then delegates to `reconstructDocuments` for the
+   * shared field + meta reconstruction path.
+   *
+   * Primary consumer is the client API's relationship populate pass —
+   * `store_relation` rows carry `target_document_id` (not version ID), so
+   * populate collects those IDs and resolves them here in one round trip.
+   */
+  async getDocumentsByDocumentIds({
+    collection_id,
+    document_ids,
+    locale = 'all',
+    fields,
+    readMode,
+    filters,
+  }: {
+    collection_id: string
+    document_ids: string[]
+    locale?: string
+    fields?: string[]
+    readMode?: ReadMode
+    filters?: DocumentFilter[]
+  }): Promise<any[]> {
+    if (document_ids.length === 0) return []
+
+    const view = this.pickCurrentView(readMode)
+    // The locale used to compile filter EXISTS subqueries should resolve
+    // values from a real locale, even when the surrounding read uses the
+    // sentinel `'all'` (populate batches that span every locale do this).
+    // Falling back to the installation default here matches the default
+    // used by the single-doc lookup methods.
+    const filterLocale = locale === 'all' ? this.defaultContentLocale : locale
+    const baseConditions: SQL[] = [
+      eq(view.collection_id, collection_id),
+      inArray(view.document_id, document_ids),
+    ]
+    if (filters?.length) {
+      const outerScope: OuterScope = {
+        docVersionId: sql`${view.id}`,
+        documentId: sql`${view.document_id}`,
+        status: sql`${view.status}`,
+        path: this.pathProjection(
+          sql`${view.document_id}`,
+          filterLocale,
+          sql`${view.source_locale}`
+        ),
+      }
+      for (const f of filters) {
+        baseConditions.push(this.buildFilterExists(f, filterLocale, outerScope, readMode, 0))
+      }
+    }
+    const docs = await this.db
+      .select(this.viewProjection(view, filterLocale))
+      .from(view)
+      .where(and(...baseConditions))
+
+    // Populated relation targets always fall back through the locale chain so
+    // a populated tree never has holes — independent of the outer read's
+    // `onMissingLocale`. (A no-op when `locale === 'all'`, which keeps the map.)
+    return this.reconstructDocuments({
+      documents: docs as Document[],
+      locale,
+      fields,
+      onMissingLocale: 'fallback',
+    })
+  }
+
+  /**
+   * getDocumentHistory — paginated version history for a document,
+   * including soft-deleted versions.
    */
   async getDocumentHistory({
     collection_id,
@@ -729,8 +1140,6 @@ export class DocumentQueries {
       desc: boolean
     }
   }> {
-    this.assertUnsupported(!!filters?.length, 'getDocumentHistory', 'filters')
-
     const collection = await this.db.query.collections.findFirst({
       where: eq(collections.id, collection_id),
     })
@@ -742,10 +1151,22 @@ export class DocumentQueries {
       }).log(getLogger())
     }
 
+    const filterLocale = locale === 'all' ? this.defaultContentLocale : locale
     const conditions: SQL[] = [
       eq(documentVersions.collection_id, collection_id),
       eq(documentVersions.document_id, document_id),
     ]
+    if (filters?.length) {
+      const scope: OuterScope = {
+        docVersionId: sql`${documentVersions.id}`,
+        documentId: sql`${documentVersions.document_id}`,
+        status: sql`${documentVersions.status}`,
+        path: this.pathProjection(sql`${documentVersions.document_id}`, filterLocale),
+      }
+      for (const filter of filters) {
+        conditions.push(this.buildFilterExists(filter, filterLocale, scope, 'any', 0))
+      }
+    }
 
     // `count(*)::int` (pg) → `CAST(COUNT(*) AS SIGNED)` (design spec §2),
     // with the `Number()` normalisation at the result edge kept as a belt.
@@ -781,13 +1202,508 @@ export class DocumentQueries {
   }
 
   /**
-   * Reconstruct a batch of already-fetched `Document` rows into full
-   * documents, applying selective field loading when `fields` is supplied.
-   * Pure JS/core-delegate orchestration around `getAllFieldValuesForMultipleVersions`
-   * — ports unchanged from pg (the dialect-specific work is one level down).
+   * getPublishedVersion
+   *
+   * Find the latest version of a document that has a specific status
+   * (defaults to 'published'). Queries `document_versions` directly so it
+   * can find a published version even when a newer draft exists.
+   *
+   * Returns minimal version metadata (not reconstructed content), or null
+   * if no version with the requested status exists.
+   */
+  async getPublishedVersion({
+    collection_id,
+    document_id,
+    status = 'published',
+  }: {
+    collection_id: string
+    document_id: string
+    status?: string
+  }): Promise<{
+    document_version_id: string
+    document_id: string
+    status: string
+    created_at: Date
+    updated_at: Date
+  } | null> {
+    const [row] = await this.db
+      .select({
+        document_version_id: documentVersions.id,
+        document_id: documentVersions.document_id,
+        status: documentVersions.status,
+        created_at: documentVersions.created_at,
+        updated_at: documentVersions.updated_at,
+      })
+      .from(documentVersions)
+      .where(
+        and(
+          eq(documentVersions.collection_id, collection_id),
+          eq(documentVersions.document_id, document_id),
+          eq(documentVersions.status, status),
+          eq(documentVersions.is_deleted, false)
+        )
+      )
+      .orderBy(sql`${documentVersions.id} DESC`)
+      .limit(1)
+
+    if (!row) return null
+
+    return {
+      document_version_id: row.document_version_id,
+      document_id: row.document_id,
+      status: row.status ?? 'draft',
+      created_at: row.created_at ?? new Date(),
+      updated_at: row.updated_at ?? new Date(),
+    }
+  }
+
+  /**
+   * getPublishedDocumentIds
+   *
+   * Given a list of document IDs, return the subset that have at least one
+   * version with the requested status (defaults to 'published'). Uses a
+   * single batch query instead of per-document lookups.
+   */
+  async getPublishedDocumentIds({
+    collection_id,
+    document_ids,
+    status = 'published',
+  }: {
+    collection_id: string
+    document_ids: string[]
+    status?: string
+  }): Promise<Set<string>> {
+    if (document_ids.length === 0) return new Set()
+
+    const rows = await this.db
+      .select({ document_id: documentVersions.document_id })
+      .from(documentVersions)
+      .where(
+        and(
+          inArray(documentVersions.document_id, document_ids),
+          eq(documentVersions.collection_id, collection_id),
+          eq(documentVersions.status, status),
+          eq(documentVersions.is_deleted, false)
+        )
+      )
+      .groupBy(documentVersions.document_id)
+
+    return new Set(rows.map((r) => r.document_id))
+  }
+
+  /**
+   * getLastOrderKey
+   *
+   * Largest `order_key` currently in use for the given collection. Used
+   * at create-time on `orderable: true` collections to append the new
+   * row at the end. Returns `null` when no keyed rows exist yet.
+   */
+  async getLastOrderKey({ collection_id }: { collection_id: string }): Promise<string | null> {
+    const rows = await this.db
+      .select({ order_key: documents.order_key })
+      .from(documents)
+      .where(and(eq(documents.collection_id, collection_id), isNotNull(documents.order_key)))
+      .orderBy(desc(documents.order_key))
+      .limit(1)
+    return rows[0]?.order_key ?? null
+  }
+
+  /**
+   * getNeighborOrderKeys
+   *
+   * Resolve the `order_key` values bracketing a target gap in one query.
+   * `before_document_id` is the doc the moved row should land *after*;
+   * `after_document_id` is the doc it should land *before*. Either or
+   * both may be null (append / prepend / empty collection).
+   *
+   * Resolves both keys in a single round trip to keep the read consistent
+   * with the next-key computation that follows in the caller.
+   */
+  async getNeighborOrderKeys({
+    collection_id,
+    before_document_id,
+    after_document_id,
+  }: {
+    collection_id: string
+    before_document_id: string | null
+    after_document_id: string | null
+  }): Promise<{ left: string | null; right: string | null }> {
+    const ids: string[] = []
+    if (before_document_id) ids.push(before_document_id)
+    if (after_document_id) ids.push(after_document_id)
+    if (ids.length === 0) {
+      return { left: null, right: null }
+    }
+    const rows = await this.db
+      .select({ id: documents.id, order_key: documents.order_key })
+      .from(documents)
+      .where(and(eq(documents.collection_id, collection_id), inArray(documents.id, ids)))
+    const byId = new Map(rows.map((r) => [r.id, r.order_key]))
+    return {
+      left: before_document_id ? (byId.get(before_document_id) ?? null) : null,
+      right: after_document_id ? (byId.get(after_document_id) ?? null) : null,
+    }
+  }
+
+  /**
+   * getCanonicalDocumentOrder
+   *
+   * Returns every document in the collection in its canonical list-view
+   * order: `order_key ASC NULLS LAST, created_at DESC`. Used by the reorder
+   * server fn for backfill and recovery from key corruption.
+   *
+   * Divergence from pg: MySQL has no `NULLS LAST`. MySQL's own `ASC`
+   * default sorts NULL *first* (the opposite of pg's `NULLS LAST`), so the
+   * `(col IS NULL) ASC, col ASC` emulation idiom — the same one
+   * `buildDocumentOrderClause` uses — is required here too.
+   */
+  async getCanonicalDocumentOrder({
+    collection_id,
+  }: {
+    collection_id: string
+  }): Promise<Array<{ id: string; order_key: string | null }>> {
+    const rows = await this.db
+      .select({ id: documents.id, order_key: documents.order_key })
+      .from(documents)
+      .where(eq(documents.collection_id, collection_id))
+      .orderBy(
+        sql`(${documents.order_key} IS NULL) ASC, ${documents.order_key} ASC`,
+        desc(documents.created_at)
+      )
+    return rows
+  }
+
+  /**
+   * getTreeAncestors — see {@link IDocumentQueries.getTreeAncestors}.
+   *
+   * Recursive CTE walking `parent_document_id` upward from the given node.
+   * Returns ancestors root-first (`ORDER BY depth DESC`), each with a 1-based
+   * depth (1 = immediate parent). Empty for a root or unplaced node.
+   *
+   * Status-at-edge: in `published` mode each hop must resolve in
+   * `byline_current_published_documents`, so the walk stops at the first
+   * unpublished ancestor rather than skipping it (a truncated spine the splat
+   * handler turns into a 404). `any` mode walks the raw edges unchanged.
+   *
+   * `WITH RECURSIVE` syntax is unchanged from pg (the 8.0.14 engine floor
+   * guarantees support); the `::uuid` cast on `document_id` is dropped —
+   * MySQL has no cast syntax for a UUID-shaped `CHAR(36)` column, and the
+   * driver already binds the plain string correctly.
+   */
+  async getTreeAncestors({
+    document_id,
+    maxDepth = 10_000,
+    readMode = 'any',
+    locale = this.defaultContentLocale,
+    filters,
+  }: {
+    document_id: string
+    maxDepth?: number
+    readMode?: ReadMode
+    locale?: string
+    filters?: DocumentFilter[]
+  }): Promise<Array<{ document_id: string; depth: number }>> {
+    const childGate = this.buildTreeVisibility(
+      sql`child_document_id`,
+      filters,
+      locale,
+      readMode,
+      'cv0'
+    )
+    const anchorParentGate = this.buildTreeVisibility(
+      sql`parent_document_id`,
+      filters,
+      locale,
+      readMode,
+      'pv0'
+    )
+    const recursiveParentGate = this.buildTreeVisibility(
+      sql`r.parent_document_id`,
+      filters,
+      locale,
+      readMode,
+      'pv1'
+    )
+
+    const query = sql`
+      WITH RECURSIVE ancestors AS (
+        SELECT parent_document_id AS ancestor_id, child_document_id AS node_id, 1 AS depth
+        FROM byline_document_relationships
+        WHERE child_document_id = ${document_id} AND parent_document_id IS NOT NULL
+          AND ${childGate}
+          AND ${anchorParentGate}
+        UNION ALL
+        SELECT r.parent_document_id, r.child_document_id, a.depth + 1
+        FROM byline_document_relationships r
+        JOIN ancestors a ON r.child_document_id = a.ancestor_id
+        WHERE r.parent_document_id IS NOT NULL AND a.depth < ${maxDepth}
+          AND ${recursiveParentGate}
+      )
+      SELECT ancestor_id AS document_id, depth FROM ancestors ORDER BY depth DESC
+    `
+    const result = (await this.db.execute(query)) as unknown as [
+      Array<{ document_id: string; depth: number }>,
+      unknown,
+    ]
+    return result[0].map((r) => ({
+      document_id: r.document_id as string,
+      depth: Number(r.depth),
+    }))
+  }
+
+  /**
+   * getTreeChildren — see {@link IDocumentQueries.getTreeChildren}.
+   *
+   * Immediate children of a node ordered by the per-parent `order_key`.
+   * `parentDocumentId: null` returns the collection's root nodes; the join to
+   * `byline_documents` scopes roots to the collection (they have no parent to
+   * scope by). Plain query-builder code — ports unchanged from pg.
+   */
+  async getTreeChildren({
+    collectionId,
+    parentDocumentId,
+  }: {
+    collectionId: string
+    parentDocumentId: string | null
+  }): Promise<Array<{ document_id: string; order_key: string }>> {
+    const rows = await this.db
+      .select({
+        document_id: documentRelationships.child_document_id,
+        order_key: documentRelationships.order_key,
+      })
+      .from(documentRelationships)
+      .innerJoin(documents, eq(documents.id, documentRelationships.child_document_id))
+      .where(
+        and(
+          eq(documents.collection_id, collectionId),
+          parentDocumentId == null
+            ? isNull(documentRelationships.parent_document_id)
+            : eq(documentRelationships.parent_document_id, parentDocumentId)
+        )
+      )
+      .orderBy(documentRelationships.order_key)
+    return rows
+  }
+
+  /**
+   * getTreeParent — see {@link IDocumentQueries.getTreeParent}.
+   *
+   * Single indexed lookup on the edge table by `child_document_id` (unique).
+   * No row → *unplaced*; a row with a null parent → *root*; a row with a parent
+   * → *child*. Distinguishes the unplaced/root states that `getTreeAncestors`
+   * (which returns `[]` for both) conflates. `::uuid` cast dropped, same as
+   * `getTreeAncestors`.
+   */
+  async getTreeParent({
+    document_id,
+    readMode = 'any',
+    locale = this.defaultContentLocale,
+    filters,
+  }: {
+    document_id: string
+    readMode?: ReadMode
+    locale?: string
+    filters?: DocumentFilter[]
+  }): Promise<{ placed: boolean; parentDocumentId: string | null; parentRedacted?: true }> {
+    const childGate = this.buildTreeVisibility(
+      sql`r.child_document_id`,
+      filters,
+      locale,
+      readMode,
+      'cv0'
+    )
+    const parentGate = this.buildTreeVisibility(
+      sql`r.parent_document_id`,
+      filters,
+      locale,
+      readMode,
+      'pv0'
+    )
+    const query = sql`
+      SELECT r.parent_document_id,
+             CASE WHEN r.parent_document_id IS NULL THEN TRUE ELSE ${parentGate} END AS parent_visible
+      FROM byline_document_relationships r
+      WHERE r.child_document_id = ${document_id}
+        AND ${childGate}
+      LIMIT 1
+    `
+    const result = (await this.db.execute(query)) as unknown as [
+      Array<{ parent_document_id: string | null; parent_visible: number | boolean }>,
+      unknown,
+    ]
+    const row = result[0][0]
+    if (row == null) return { placed: false, parentDocumentId: null }
+    if (!row.parent_visible) {
+      return { placed: true, parentDocumentId: null, parentRedacted: true }
+    }
+    return { placed: true, parentDocumentId: row.parent_document_id ?? null }
+  }
+
+  /**
+   * getTreeSubtree — see {@link IDocumentQueries.getTreeSubtree}.
+   *
+   * Recursive CTE descending from the requested root (or the collection's
+   * roots when `rootDocumentId` is null). Each row carries a `/`-joined path
+   * of ancestor `order_key`s; ordering by that path yields a pre-order
+   * depth-first walk (a parent's path is a prefix of its children's, and `/`
+   * (0x2F) sorts below every key character in an ascii_bin comparison).
+   * Status-at-edge: every node — anchor included — must exist in the chosen
+   * current-documents view, so an unpublished node and its whole subtree
+   * drop out in `published` mode.
+   *
+   * Two divergences from pg, both found live (not assumed from docs):
+   *
+   *   - `s.path || '/' || r.order_key` (pg's `||` string concat) is MySQL
+   *     boolean OR unless `PIPES_AS_CONCAT` is in `sql_mode` — confirmed
+   *     against this database's `@@sql_mode` (it isn't set), and confirmed
+   *     `SELECT 'a' || 'b'` returns `0`, not `'ab'`. `CONCAT(s.path, '/',
+   *     r.order_key)` is the portable form.
+   *   - pg's `r.order_key::text AS path` cast and the closing `ORDER BY path
+   *     COLLATE "C"` both drop: `order_key` (and therefore the CONCAT'd
+   *     `path` column) is already `ascii_bin` — byte-comparable — end to
+   *     end (`varcharByteSorted`, `database/schema/common.ts`), confirmed
+   *     live that `CONCAT()` over two `ascii_bin` columns plus a `'/'`
+   *     literal stays `ascii_bin` rather than falling back to the
+   *     connection's `utf8mb4_0900_ai_ci` default (which would reorder
+   *     mixed-case keys incorrectly, the same class of bug `varcharByteSorted`
+   *     exists to prevent on the base columns).
+   */
+  async getTreeSubtree({
+    collectionId,
+    rootDocumentId = null,
+    maxDepth = 10_000,
+    readMode = 'any',
+    locale = this.defaultContentLocale,
+    filters,
+  }: {
+    collectionId: string
+    rootDocumentId?: string | null
+    maxDepth?: number
+    readMode?: ReadMode
+    locale?: string
+    filters?: DocumentFilter[]
+  }): Promise<
+    Array<{
+      document_id: string
+      parent_document_id: string | null
+      depth: number
+      order_key: string
+    }>
+  > {
+    const rootCondition =
+      rootDocumentId == null
+        ? sql`r.parent_document_id IS NULL`
+        : sql`r.child_document_id = ${rootDocumentId}`
+    const anchorGate = this.buildTreeVisibility(
+      sql`r.child_document_id`,
+      filters,
+      locale,
+      readMode,
+      'sv0'
+    )
+    const childGate = this.buildTreeVisibility(
+      sql`r.child_document_id`,
+      filters,
+      locale,
+      readMode,
+      'sv1'
+    )
+
+    const query = sql`
+      WITH RECURSIVE subtree AS (
+        SELECT r.child_document_id, r.parent_document_id, r.order_key,
+               0 AS depth, r.order_key AS path
+        FROM byline_document_relationships r
+        JOIN byline_documents d ON d.id = r.child_document_id
+        WHERE d.collection_id = ${collectionId}
+          AND ${rootCondition}
+          AND ${anchorGate}
+        UNION ALL
+        SELECT r.child_document_id, r.parent_document_id, r.order_key,
+               s.depth + 1, CONCAT(s.path, '/', r.order_key)
+        FROM byline_document_relationships r
+        JOIN subtree s ON r.parent_document_id = s.child_document_id
+        WHERE s.depth + 1 <= ${maxDepth}
+          AND ${childGate}
+      )
+      SELECT child_document_id AS document_id,
+             CASE WHEN depth = 0 THEN NULL ELSE parent_document_id END AS parent_document_id,
+             depth, order_key
+      FROM subtree
+      ORDER BY path
+    `
+    const result = (await this.db.execute(query)) as unknown as [
+      Array<{
+        document_id: string
+        parent_document_id: string | null
+        depth: number
+        order_key: string
+      }>,
+      unknown,
+    ]
+    return result[0].map((r) => ({
+      document_id: r.document_id as string,
+      parent_document_id: (r.parent_document_id as string | null) ?? null,
+      depth: Number(r.depth),
+      order_key: r.order_key as string,
+    }))
+  }
+
+  /**
+   * getDocumentCountsByStatus
+   *
+   * Returns a count of current documents grouped by workflow status for a
+   * given collection. Uses the `current_documents` view so each logical
+   * document is counted once (at its latest/current version).
+   */
+  async getDocumentCountsByStatus({
+    collection_id,
+    filters,
+  }: {
+    collection_id: string
+    filters?: DocumentFilter[]
+  }): Promise<Array<{ status: string; count: number }>> {
+    const conditions: SQL[] = [eq(currentDocumentsView.collection_id, collection_id)]
+    if (filters?.length) {
+      const outerScope: OuterScope = {
+        docVersionId: sql`${currentDocumentsView.id}`,
+        documentId: sql`${currentDocumentsView.document_id}`,
+        status: sql`${currentDocumentsView.status}`,
+        path: this.pathProjection(
+          sql`${currentDocumentsView.document_id}`,
+          this.defaultContentLocale
+        ),
+      }
+      for (const f of filters) {
+        conditions.push(
+          this.buildFilterExists(f, this.defaultContentLocale, outerScope, undefined, 0)
+        )
+      }
+    }
+    const rows = await this.db
+      .select({
+        status: currentDocumentsView.status,
+        count: sql<number>`CAST(COUNT(*) AS SIGNED)`,
+      })
+      .from(currentDocumentsView)
+      .where(and(...conditions))
+      .groupBy(currentDocumentsView.status)
+
+    return rows.map((r) => ({
+      status: r.status ?? 'unknown',
+      count: Number(r.count),
+    }))
+  }
+
+  /**
+   * reconstructDocuments — retrieve field values and reconstruct multiple documents.
+   * Supports selective field loading via the `fields` parameter. Pure
+   * JS/core-delegate orchestration — ports unchanged from pg (the
+   * dialect-specific work is one level down, in
+   * `getAllFieldValuesForMultipleVersions`).
    */
   private async reconstructDocuments({
-    documents,
+    documents: docs,
     locale = 'all',
     fields: requestedFields,
     onMissingLocale,
@@ -797,11 +1713,11 @@ export class DocumentQueries {
     fields?: string[]
     onMissingLocale?: MissingLocalePolicy
   }): Promise<any[]> {
-    if (documents.length === 0) return []
-    const versionIds = documents.map((v) => v.id)
+    if (docs.length === 0) return []
+    const versionIds = docs.map((v) => v.id)
 
     // Resolve definition once for the batch (safe — early return above guarantees length > 0)
-    const firstDoc = documents[0]!
+    const firstDoc = docs[0]!
     const definition = await this.getDefinitionForCollection(firstDoc.collection_id)
 
     // When specific fields are requested, resolve which store tables we need
@@ -814,9 +1730,10 @@ export class DocumentQueries {
     // `source_locale` anchor — so the field fetch pulls every locale a row in
     // this page might fall back to, not just the global default.
     const floorLocales = [
-      ...new Set(documents.map((d) => d.source_locale).filter((l): l is string => l != null)),
+      ...new Set(docs.map((d) => d.source_locale).filter((l): l is string => l != null)),
     ]
 
+    // Get field values for all versions in one query
     const allFieldValues = await this.getAllFieldValuesForMultipleVersions(
       versionIds,
       locale,
@@ -824,6 +1741,7 @@ export class DocumentQueries {
       floorLocales
     )
 
+    // Group field values by document version
     const fieldValuesByVersion = new Map<string, UnifiedFieldValue[]>()
     for (const fieldValue of allFieldValues) {
       if (!fieldValuesByVersion.has(fieldValue.document_version_id)) {
@@ -832,6 +1750,7 @@ export class DocumentQueries {
       fieldValuesByVersion.get(fieldValue.document_version_id)?.push(fieldValue)
     }
 
+    // Fetch meta rows for all versions in one query
     const allMetaRows = await this.db
       .select({
         document_version_id: metaStore.document_version_id,
@@ -857,8 +1776,9 @@ export class DocumentQueries {
       }
     }
 
+    // Reconstruct each document with document data at root level
     const result: any[] = []
-    for (const doc of documents) {
+    for (const doc of docs) {
       const versionFieldValues = fieldValuesByVersion.get(doc.id) || []
       const docMetaRows = (metaByVersion.get(doc.id) ?? []) as MetaRow[]
       const { fields } = this.reconstructFromUnifiedRows(
@@ -879,7 +1799,7 @@ export class DocumentQueries {
         ? Object.fromEntries(Object.entries(fields).filter(([k]) => requestedFields.includes(k)))
         : fields
 
-      result.push({
+      const documentWithFields = {
         document_version_id: doc.id,
         document_id: doc.document_id,
         path: doc.path ?? '',
@@ -890,7 +1810,9 @@ export class DocumentQueries {
         updated_at: doc.updated_at,
         created_by: doc.created_by ?? null,
         fields: trimmedFields,
-      })
+      }
+
+      result.push(documentWithFields)
     }
 
     return result
@@ -987,19 +1909,18 @@ export class DocumentQueries {
   }
 
   /**
-   * findDocuments — Task 10A scope: `collection_id` + optional exact-match
-   * `status` + `locale` + basic document-level pagination/ordering +
-   * selective field loading (`fields`) + `readMode`/`onMissingLocale`. This
-   * is enough to serve the `field-types` conformance suite's two calls
-   * (with and without `fields`).
+   * findDocuments — field-level filtered, sorted, paginated query.
    *
-   * Deliberately NOT implemented (Task 10B, per the controller amendments):
-   * `filters` (`DocumentFilter[]` — `$and`/`$or` combinators, relation-hop
-   * EXISTS, document-column filters), `pathFilter`, `query` (admin
-   * quick-search LIKE), `sort` (field-level `LEFT JOIN LATERAL` sort). Any
-   * of these being passed throws rather than silently ignoring the request
-   * — a caller expecting row-scoping or a specific sort order getting an
-   * unscoped/default-ordered result back would be a silent correctness bug.
+   * Each `FieldFilter` becomes an EXISTS subquery against the appropriate EAV
+   * store table. A `RelationFilter` becomes a nested EXISTS that joins
+   * `store_relation` to the target collection's current-documents view
+   * (selected by `readMode` so draft leaks can't happen through filter
+   * predicates) and recurses into its own `nested` filters. A `FieldSort`
+   * becomes a LEFT JOIN LATERAL to pull the sort value into the outer query
+   * — unchanged syntax from pg (the 8.0.14 engine floor guarantees LATERAL
+   * support), confirmed live against this container. Document-level
+   * conditions (status, path) are applied directly on the current_documents
+   * view.
    */
   async findDocuments({
     collection_id,
@@ -1032,35 +1953,121 @@ export class DocumentQueries {
     readMode?: ReadMode
     onMissingLocale?: MissingLocalePolicy
   }): Promise<{ documents: any[]; total: number }> {
-    this.assertUnsupported(filters.length > 0, 'findDocuments', 'filters')
-    this.assertUnsupported(!!pathFilter, 'findDocuments', 'pathFilter')
-    this.assertUnsupported(!!query, 'findDocuments', 'query')
-    this.assertUnsupported(!!sort, 'findDocuments', 'sort')
-
     const offset = (page - 1) * pageSize
     const sourceTable =
       readMode === 'published'
         ? sql.raw('byline_current_published_documents')
         : sql.raw('byline_current_documents')
 
+    // -- Build WHERE conditions -----------------------------------------------
     const conditions: SQL[] = [sql`d.collection_id = ${collection_id}`]
 
     if (status) {
       conditions.push(sql`d.status = ${status}`)
     }
 
+    // `onMissingLocale: 'omit'` — exclude documents not available in the
+    // requested locale (filtered at the SQL layer so pagination stays correct).
     const strictGate = this.localeAvailabilityExists(sql`d.id`, locale, onMissingLocale)
     if (strictGate) {
       conditions.push(strictGate)
     }
 
-    const whereClause = sql.join(conditions, sql` AND `)
-    const orderClause = this.buildDocumentOrderClause(orderBy, orderDirection)
+    if (pathFilter) {
+      conditions.push(
+        this.buildFilterCondition(
+          this.pathProjection(sql`d.document_id`, locale, sql`d.source_locale`),
+          pathFilter.operator,
+          pathFilter.value
+        )
+      )
+    }
 
+    // Admin list-view quick search via EXISTS on store_text. MySQL has no
+    // `ILIKE` — the elected divergence (design spec §2, not "fixed"): plain
+    // `LIKE` against `byline_store_text.value`, which keeps the schema's
+    // database-default `utf8mb4_0900_ai_ci` collation, so this search is
+    // already case- AND accent-insensitive (pg's `ILIKE` is case-insensitive
+    // only). See `buildFilterCondition`'s `$contains` branch for the same
+    // divergence on the field-filter path.
+    if (query) {
+      const definition = await this.getDefinitionForCollection(collection_id)
+      const searchFields =
+        definition.listSearch != null && definition.listSearch.length > 0
+          ? definition.listSearch
+          : [resolveIdentityField(definition) ?? 'title']
+      const searchConditions = searchFields.map(
+        (fieldName) => sql`(field_name = ${fieldName} AND value LIKE ${`%${query}%`})`
+      )
+      conditions.push(sql`EXISTS (
+        SELECT 1 FROM byline_store_text
+        WHERE document_version_id = d.id
+          AND (locale = ${locale} OR locale = 'all')
+          AND (${sql.join(searchConditions, sql` OR `)})
+      )`)
+    }
+
+    // Field-level / relation-level EXISTS subqueries. Each relation hop
+    // introduces its own alias scope (`r${depth}`, `td${depth}`) so nested
+    // EXISTS clauses don't shadow their outer relation's aliases.
+    for (const filter of filters) {
+      conditions.push(
+        this.buildFilterExists(
+          filter,
+          locale,
+          {
+            docVersionId: sql`d.id`,
+            documentId: sql`d.document_id`,
+            status: sql`d.status`,
+            path: this.pathProjection(sql`d.document_id`, locale, sql`d.source_locale`),
+          },
+          readMode,
+          0
+        )
+      )
+    }
+
+    const whereClause = sql.join(conditions, sql` AND `)
+
+    // -- Build ORDER BY -------------------------------------------------------
+    let orderClause: SQL
+    let sortJoin: SQL = sql``
+
+    if (sort) {
+      // Field-level sort via LEFT JOIN LATERAL
+      const storeTable = storeTableNames[sort.storeType as StoreType]
+      if (storeTable) {
+        sortJoin = sql`LEFT JOIN LATERAL (
+          SELECT ${sql.raw(sort.valueColumn)} AS _sort_value
+          FROM ${sql.raw(storeTable)}
+          WHERE document_version_id = d.id
+            AND field_name = ${sort.fieldName}
+            AND (locale = ${locale} OR locale = 'all')
+          LIMIT 1
+        ) _sort ON true`
+        // MySQL has no `NULLS LAST`. `DESC` already sorts NULL last by
+        // default (confirmed live), so `_sort_value DESC` needs no help;
+        // `ASC` sorts NULL first by default (the opposite of pg's `NULLS
+        // LAST`), so the `(col IS NULL) ASC, col ASC` emulation idiom is
+        // required — same idiom as `buildDocumentOrderClause`.
+        orderClause =
+          sort.direction === 'desc'
+            ? sql`_sort._sort_value DESC`
+            : sql`(_sort._sort_value IS NULL) ASC, _sort._sort_value ASC`
+      } else {
+        // Unrecognised store type — fall back to document-level sort
+        orderClause = this.buildDocumentOrderClause(orderBy, orderDirection)
+      }
+    } else {
+      orderClause = this.buildDocumentOrderClause(orderBy, orderDirection)
+    }
+
+    // -- Count query ----------------------------------------------------------
     // `count(*)::int` → `CAST(COUNT(*) AS SIGNED)` (design spec §2).
     const countQuery = sql`
       SELECT CAST(COUNT(*) AS SIGNED) AS total
       FROM ${sourceTable} d
+      ${sortJoin}
       WHERE ${whereClause}
     `
     const countResult = (await this.db.execute(countQuery)) as unknown as [
@@ -1073,10 +2080,17 @@ export class DocumentQueries {
       return { documents: [], total: 0 }
     }
 
+    // -- Main query -----------------------------------------------------------
+    //
+    // `d.*` no longer includes `path` (it lives in byline_document_paths
+    // keyed by document_id + locale). Project it via the locale-aware
+    // subquery so the result rows still carry `path` for the in-memory
+    // Document shape.
     const pathProjectionSql = this.pathProjection(sql`d.document_id`, locale, sql`d.source_locale`)
     const mainQuery = sql`
       SELECT d.*, ${pathProjectionSql} AS path
       FROM ${sourceTable} d
+      ${sortJoin}
       WHERE ${whereClause}
       ORDER BY ${orderClause}
       LIMIT ${pageSize}
@@ -1115,6 +2129,9 @@ export class DocumentQueries {
       onMissingLocale,
     })
 
+    // Attach the version-locale availability metadata per row (one batched
+    // indexed query for the whole page) so list consumers can render
+    // language affordances / hreflang without a follow-up fetch.
     const availability = await this.getAvailableLocalesByVersion(
       documents.map((d) => d.document_version_id)
     )
@@ -1132,17 +2149,298 @@ export class DocumentQueries {
   }
 
   /**
+   * Compile status and `beforeRead` visibility for one tree edge endpoint.
+   * Ports unchanged from pg — the `EXISTS` shape has no dialect-specific
+   * SQL of its own (its nested `buildFilterExists` calls carry the
+   * dialect-specific bits).
+   */
+  private buildTreeVisibility(
+    documentId: SQL,
+    filters: DocumentFilter[] | undefined,
+    locale: string,
+    readMode: ReadMode,
+    aliasName: string
+  ): SQL {
+    const view =
+      readMode === 'published'
+        ? sql.raw('byline_current_published_documents')
+        : sql.raw('byline_current_documents')
+    const alias = sql.raw(aliasName)
+    const scope: OuterScope = {
+      docVersionId: sql`${alias}.id`,
+      documentId: sql`${alias}.document_id`,
+      status: sql`${alias}.status`,
+      path: this.pathProjection(sql`${alias}.document_id`, locale, sql`${alias}.source_locale`),
+    }
+    const filterSql = (filters ?? []).map((filter) =>
+      this.buildFilterExists(filter, locale, scope, readMode, 0)
+    )
+    const filterClause = filterSql.length > 0 ? sql` AND ${sql.join(filterSql, sql` AND `)}` : sql``
+    return sql`EXISTS (
+      SELECT 1 FROM ${view} ${alias}
+      WHERE ${alias}.document_id = ${documentId}${filterClause}
+    )`
+  }
+
+  /**
+   * Build an EXISTS subquery for a single DocumentFilter. Dispatches on
+   * `kind` — field filters emit a direct EXISTS against the field's EAV
+   * store; relation filters emit a nested EXISTS that joins through
+   * `store_relation` to the target collection's current-documents view
+   * and recurses against the target's own stores; combinator filters
+   * emit a parenthesised AND/OR group; document-column filters emit a
+   * direct comparison on the outer scope's status/path column. Ports
+   * unchanged from pg — the dispatch itself has no dialect-specific SQL.
+   */
+  private buildFilterExists(
+    filter: DocumentFilter,
+    locale: string,
+    outerScope: OuterScope,
+    readMode: ReadMode | undefined,
+    depth: number
+  ): SQL {
+    switch (filter.kind) {
+      case 'field':
+        return this.buildFieldExists(filter, locale, outerScope.docVersionId)
+      case 'relation':
+        return this.buildRelationExists(filter, locale, outerScope, readMode, depth)
+      case 'and':
+      case 'or':
+        return this.buildCombinatorGroup(filter, locale, outerScope, readMode, depth)
+      case 'docColumn':
+        return this.buildDocColumnFilter(filter, outerScope)
+    }
+  }
+
+  /**
+   * Build a parenthesised AND/OR group from a CombinatorFilter. Each child
+   * compiles through `buildFilterExists` recursively, so combinators nest
+   * freely and inherit the outer scope. Ports unchanged from pg.
+   */
+  private buildCombinatorGroup(
+    filter: CombinatorFilter,
+    locale: string,
+    outerScope: OuterScope,
+    readMode: ReadMode | undefined,
+    depth: number
+  ): SQL {
+    const childSql = filter.children.map((child) =>
+      this.buildFilterExists(child, locale, outerScope, readMode, depth)
+    )
+    const joiner = filter.kind === 'or' ? sql` OR ` : sql` AND `
+    return sql`(${sql.join(childSql, joiner)})`
+  }
+
+  /**
+   * Compile a `DocumentColumnFilter` against the outer scope's `status`,
+   * `path`, or `id` column. Plain comparison — no EXISTS — because the
+   * column lives directly on the outer relation (current-documents view),
+   * not in the EAV stores. Ports unchanged from pg.
+   */
+  private buildDocColumnFilter(filter: DocumentColumnFilter, outerScope: OuterScope): SQL {
+    const column =
+      filter.column === 'status'
+        ? outerScope.status
+        : filter.column === 'path'
+          ? outerScope.path
+          : outerScope.documentId
+    return this.buildFilterCondition(column, filter.operator, filter.value)
+  }
+
+  /**
+   * Build an EXISTS subquery for a single field-level filter. Ports
+   * unchanged from pg (aside from `buildFilterCondition`'s `ILIKE` → `LIKE`
+   * one level down).
+   */
+  private buildFieldExists(filter: FieldFilter, locale: string, outerDocVersionId: SQL): SQL {
+    const storeTable = storeTableNames[filter.storeType as StoreType]
+    if (!storeTable) {
+      throw ERR_DATABASE({
+        message: `unknown store type: ${filter.storeType}`,
+        details: { storeType: filter.storeType },
+      }).log(getLogger())
+    }
+
+    const valueCol = sql.raw(filter.valueColumn)
+    const condition = this.buildFilterCondition(valueCol, filter.operator, filter.value)
+
+    return sql`EXISTS (
+      SELECT 1 FROM ${sql.raw(storeTable)}
+      WHERE document_version_id = ${outerDocVersionId}
+        AND field_name = ${filter.fieldName}
+        AND (locale = ${locale} OR locale = 'all')
+        AND ${condition}
+    )`
+  }
+
+  /**
+   * Build a nested EXISTS subquery for a cross-collection relation filter.
+   *
+   * Joins `store_relation` to the target collection's current-documents
+   * view (`current_published_documents` under `readMode: 'published'`,
+   * `current_documents` otherwise — so a draft target doesn't leak when
+   * the outer read is in published mode), then recurses each nested
+   * filter against the target version's own `td.id`.
+   *
+   * `hasMany` relations store one row per item at an indexed field name
+   * (`<field>.0`, `<field>.1`, …), so the field match switches to a prefix
+   * match; single relations match the exact name.
+   *
+   * The `quantifier` selects the set semantics over the relation's
+   * (resolving) targets — see pg's docblock for the full 'some'/'none'/
+   * 'every' semantics; this method ports the SQL shape unchanged.
+   */
+  private buildRelationExists(
+    filter: RelationFilter,
+    locale: string,
+    outerScope: OuterScope,
+    readMode: ReadMode | undefined,
+    depth: number
+  ): SQL {
+    const targetView =
+      readMode === 'published'
+        ? sql.raw('byline_current_published_documents')
+        : sql.raw('byline_current_documents')
+
+    // Use depth-scoped aliases so nested relations don't shadow their
+    // outer scope. e.g. outer relation gets `r0`/`td0`; a relation filter
+    // nested inside that gets `r1`/`td1`.
+    const rAlias = sql.raw(`r${depth}`)
+    const tdAlias = sql.raw(`td${depth}`)
+    const innerScope: OuterScope = {
+      docVersionId: sql.raw(`td${depth}.id`),
+      documentId: sql.raw(`td${depth}.document_id`),
+      status: sql.raw(`td${depth}.status`),
+      // `td${depth}.path` no longer exists on the view; resolve via the
+      // locale priority chain against byline_document_paths instead, anchored
+      // to the target document's own `source_locale`.
+      path: this.pathProjection(
+        sql.raw(`td${depth}.document_id`),
+        locale,
+        sql.raw(`td${depth}.source_locale`)
+      ),
+    }
+
+    const nestedConditions: SQL[] = filter.nested.map((nested) =>
+      this.buildFilterExists(nested, locale, innerScope, readMode, depth + 1)
+    )
+
+    const quantifier = filter.quantifier ?? 'some'
+
+    // `every` with nothing to fail is vacuously true for every document —
+    // short-circuit rather than emitting `NOT (TRUE)` noise.
+    if (quantifier === 'every' && nestedConditions.length === 0) {
+      return sql`TRUE`
+    }
+
+    // 'some'/'none' assert the nested conjunction on a matching row;
+    // 'every' asserts the *negated* conjunction (a failing row) and wraps
+    // the whole scan in NOT.
+    const nestedAnd =
+      nestedConditions.length === 0
+        ? sql``
+        : quantifier === 'every'
+          ? sql` AND NOT (${sql.join(nestedConditions, sql` AND `)})`
+          : sql` AND ${sql.join(nestedConditions, sql` AND `)}`
+
+    // hasMany rows are stored at indexed paths (`gallery.0`, `gallery.1`, …)
+    // where `field_name` is the *index segment* ('0', '1', …) and
+    // `parent_path` is the field name — so multi-target rows match on
+    // `parent_path` exactly, single-target rows on `field_name`. (A where
+    // clause only addresses top-level fields, so `parent_path` needs no
+    // prefix handling.)
+    const fieldMatch = filter.hasMany
+      ? sql`${rAlias}.parent_path = ${filter.fieldName}`
+      : sql`${rAlias}.field_name = ${filter.fieldName}`
+
+    const existsSql = sql`EXISTS (
+      SELECT 1 FROM byline_store_relation ${rAlias}
+      JOIN ${targetView} ${tdAlias}
+        ON ${tdAlias}.document_id = ${rAlias}.target_document_id
+       AND ${tdAlias}.collection_id = ${rAlias}.target_collection_id
+      WHERE ${rAlias}.document_version_id = ${outerScope.docVersionId}
+        AND ${fieldMatch}
+        AND ${rAlias}.target_collection_id = ${filter.targetCollectionId}
+        AND (${rAlias}.locale = ${locale} OR ${rAlias}.locale = 'all')${nestedAnd}
+    )`
+
+    return quantifier === 'some' ? existsSql : sql`NOT ${existsSql}`
+  }
+
+  /**
+   * Build a comparison condition for a filter operator.
+   *
+   * `$contains` divergence (design spec §2, elected — not "fixed"): pg's
+   * `ILIKE` has no MySQL equivalent, so this compiles to plain `LIKE`. The
+   * store `value` columns keep the schema's default `utf8mb4_0900_ai_ci`
+   * collation, which is case- *and* accent-insensitive — a strictly wider
+   * match than pg's case-insensitive-only `ILIKE`. `byline_document_paths
+   * .path` is the one column this operator also reaches (via
+   * `buildDocColumnFilter`'s `path` branch) that is NOT `ai_ci` — it's
+   * `utf8mb4_bin` (`varcharCaseSensitive`, `database/schema/common.ts`), so
+   * a `$contains` against `path` stays byte-exact and matches pg exactly.
+   * Both behaviours fall out of the column's own collation; nothing here
+   * special-cases `path` vs a store value.
+   */
+  private buildFilterCondition(
+    column: SQL,
+    operator: string,
+    value: string | number | boolean | null | Array<string | number>
+  ): SQL {
+    switch (operator) {
+      case '$eq':
+        return value === null ? sql`${column} IS NULL` : sql`${column} = ${value}`
+      case '$ne':
+        return value === null ? sql`${column} IS NOT NULL` : sql`${column} != ${value}`
+      case '$gt':
+        return sql`${column} > ${value}`
+      case '$gte':
+        return sql`${column} >= ${value}`
+      case '$lt':
+        return sql`${column} < ${value}`
+      case '$lte':
+        return sql`${column} <= ${value}`
+      case '$contains':
+        return sql`${column} LIKE ${`%${String(value)}%`}`
+      case '$in': {
+        const arr = value as Array<string | number>
+        // Empty `$in` matches nothing — explicit FALSE avoids generating
+        // an invalid empty `IN ()` clause.
+        if (arr.length === 0) return sql`FALSE`
+        const items = sql.join(
+          arr.map((v) => sql`${v}`),
+          sql`, `
+        )
+        return sql`${column} IN (${items})`
+      }
+      case '$nin': {
+        const arr = value as Array<string | number>
+        if (arr.length === 0) return sql`TRUE`
+        const items = sql.join(
+          arr.map((v) => sql`${v}`),
+          sql`, `
+        )
+        return sql`${column} NOT IN (${items})`
+      }
+      default:
+        throw ERR_DATABASE({
+          message: `unsupported filter operator: ${operator}`,
+          details: { operator },
+        }).log(getLogger())
+    }
+  }
+
+  /**
    * Build an ORDER BY clause for a document-level column. `path` is
    * intentionally not sortable here — see pg's docblock.
    *
-   * Divergence from pg (found by reasoning, confirmed live — see the Task
-   * 10A report): MySQL has no `NULLS LAST`. For `DESC`, MySQL already sorts
-   * NULL last by default (confirmed against the live container), so
-   * `d.order_key DESC` needs no help. For `ASC`, MySQL's default sorts NULL
-   * *first* — the opposite of pg's `NULLS LAST` — so the emulation idiom
-   * `ORDER BY (col IS NULL), col ASC` is required to match pg's behaviour
-   * (`(col IS NULL)` evaluates 0/1; ascending puts real values, which
-   * evaluate to 0, before NULLs, which evaluate to 1).
+   * Divergence from pg (found by reasoning, confirmed live against this
+   * container): MySQL has no `NULLS LAST`. For `DESC`, MySQL already sorts
+   * NULL last by default, so `d.order_key DESC` needs no help. For `ASC`,
+   * MySQL's default sorts NULL *first* — the opposite of pg's `NULLS LAST`
+   * — so the emulation idiom `ORDER BY (col IS NULL), col ASC` is required
+   * to match pg's behaviour (`(col IS NULL)` evaluates 0/1; ascending puts
+   * real values, which evaluate to 0, before NULLs, which evaluate to 1).
    */
   private buildDocumentOrderClause(orderBy: string, direction: 'asc' | 'desc'): SQL {
     if (orderBy === 'order_key') {
@@ -1257,19 +2555,11 @@ export class DocumentQueries {
   }
 }
 
-/** True when `a` contains every member of `b`. */
-function isSuperset<T>(a: Set<T>, b: Set<T>): boolean {
-  for (const item of b) {
-    if (!a.has(item)) return false
-  }
-  return true
-}
-
 export function createQueryBuilders(
   db: DatabaseConnection,
   collections: readonly CollectionDefinition[],
   defaultContentLocale: string,
-  transactionDb?: DBManager
+  transactionDb: DBManager
 ) {
   return {
     collections: new CollectionQueries(db),

--- a/packages/db-mysql/src/modules/storage/storage-queries.ts
+++ b/packages/db-mysql/src/modules/storage/storage-queries.ts
@@ -1937,7 +1937,9 @@ export class DocumentQueries implements IDocumentQueries {
     // Canonicalise the raw UNION ALL driver rows at the ingestion boundary —
     // see normalizeRow's docstring for what the mysql2 driver leaves in a
     // shape core's reconstruction can't consume as-is (TINYINT(1)-as-number,
-    // DECIMAL-as-string with decimalNumbers: false, DATETIME(3)-as-Date).
+    // DECIMAL-as-string with decimalNumbers: false, and — the opposite of
+    // what an earlier version of this comment claimed — DATETIME/DATE-as-
+    // string, coerced to Date by normalizeRow, not already a Date).
     return result[0].map(normalizeRow)
   }
 

--- a/packages/db-mysql/src/modules/storage/storage-queries.ts
+++ b/packages/db-mysql/src/modules/storage/storage-queries.ts
@@ -88,6 +88,7 @@ import {
   storeSelectList,
   storeTableNames,
 } from './storage-store-manifest.js'
+import { toDate } from './storage-utils.js'
 
 interface MetaRow {
   type: string
@@ -2147,8 +2148,12 @@ export class DocumentQueries implements IDocumentQueries {
       // `is_deleted = false`, so this is always falsy in practice; coerced
       // properly regardless.
       is_deleted: Boolean(row.is_deleted),
-      created_at: row.created_at as Date,
-      updated_at: row.updated_at as Date,
+      // Raw driver row on this `db.execute(sql\`...\`)` path — drizzle's
+      // mysql2 driver hands DATETIME columns back as strings here, not
+      // `Date` (see `toDate`'s docstring, `storage-utils.ts`), confirmed
+      // live: an un-coerced `as Date` cast was lying at the type level.
+      created_at: toDate(row.created_at as string) as Date,
+      updated_at: toDate(row.updated_at as string) as Date,
       created_by: row.created_by as string,
       change_summary: row.change_summary as string,
       source_locale: (row.source_locale as string | null) ?? null,

--- a/packages/db-mysql/src/modules/storage/storage-store-manifest.ts
+++ b/packages/db-mysql/src/modules/storage/storage-store-manifest.ts
@@ -68,12 +68,18 @@ const fieldTypeLiterals: Record<StoreType, string> = {
  * branch selecting a real, populated column of the corresponding store type
  * and confirming the driver returns the real value unmodified (no
  * truncation, no precision loss) — see the Task 10A report for the
- * transcript. Precision-bearing casts (`TIME(3)`, `DATETIME(3)`,
+ * transcript. Precision-bearing casts (`TIME(3)`, `DATETIME(6)`,
  * `DECIMAL(10,2)`) mirror the schema's own column precision
  * (`packages/db-mysql/src/database/schema/index.ts`) exactly, rather than
  * relying on MySQL's default (whole-second time, `DECIMAL(10,0)`), so a
  * NULL-cast branch can never be the one that silently narrows the unified
- * column's type.
+ * column's type. `DATETIME(6)` here specifically must track
+ * `value_timestamp_tz`'s own `fsp` (Task 11 moved it from 3 to 6, matching
+ * pg's microsecond precision — see `common.ts`'s `auditTimestamp` docblock)
+ * — re-verified live post-move via `storage-queries.test.ts`'s
+ * `datetime`-field round-trip test, which exercises exactly this branch
+ * (a text-typed sibling row's UNION leg lands on this `CAST`) and confirmed
+ * full microsecond fidelity survives.
  */
 export function mysqlNullCast(nullCast: string): string {
   switch (nullCast) {
@@ -83,9 +89,10 @@ export function mysqlNullCast(nullCast: string): string {
       return 'CAST(NULL AS SIGNED)'
     case 'timestamp':
       // The manifest's abstract name for the `timestamptz`-shaped column
-      // (`value_timestamp_tz`); MySQL's storage-side type is `DATETIME(3)`
-      // (spec §2 — UTC by convention), not a MySQL `TIMESTAMP` column.
-      return 'CAST(NULL AS DATETIME(3))'
+      // (`value_timestamp_tz`); MySQL's storage-side type is `DATETIME(6)`
+      // (matching pg's microsecond precision — see `common.ts`'s
+      // `auditTimestamp` docblock), not a MySQL `TIMESTAMP` column.
+      return 'CAST(NULL AS DATETIME(6))'
     case 'date':
       return 'CAST(NULL AS DATE)'
     case 'time':

--- a/packages/db-mysql/src/modules/storage/storage-store-manifest.ts
+++ b/packages/db-mysql/src/modules/storage/storage-store-manifest.ts
@@ -1,0 +1,180 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ *
+ * Generated UNION ALL column projections for the EAV store tables.
+ *
+ * Instead of maintaining 7 hand-synchronized SQL fragments with 41
+ * positional columns each, we generate the SELECT list for each store
+ * table from a single column manifest. Adding a column or a new store
+ * table is a one-line change in the manifest.
+ *
+ * The manifest data (`storeColumnManifest`, `storeTableNames`) is dialect
+ * independent and lives in `@byline/core` — the same manifest
+ * `@byline/db-postgres` consumes. This module owns everything
+ * MySQL-specific: the generated `SQL` fragments, and `mysqlNullCast()`,
+ * which renders the manifest's abstract `nullCast` type names (`'uuid'`,
+ * `'boolean'`, …) as MySQL `CAST(NULL AS <type>)` expressions — MySQL has
+ * no `NULL::<type>` shorthand.
+ *
+ * The adapter-agnostic pieces (`StoreType`, `ALL_STORE_TYPES`,
+ * `fieldTypeToStore`, `fieldTypeToStoreType`) also live in `@byline/core`
+ * so `@byline/client` can consume the same mapping without taking a
+ * dependency on either adapter. Mirrors
+ * `packages/db-postgres/src/modules/storage/storage-store-manifest.ts`.
+ */
+
+import { ALL_STORE_TYPES, type StoreType, storeColumnManifest } from '@byline/core'
+import { type SQL, sql } from 'drizzle-orm'
+
+// Re-export for adapter-internal consumers.
+export {
+  ALL_STORE_TYPES,
+  fieldTypeToStore,
+  fieldTypeToStoreType,
+  type StoreType,
+  storeTableNames,
+} from '@byline/core'
+
+/** Short-form alias used by adapter-internal call sites. */
+export const allStoreTypes = ALL_STORE_TYPES
+
+// ---------------------------------------------------------------------------
+// SQL generation
+// ---------------------------------------------------------------------------
+
+/** The field_type literal emitted for each store table in the UNION ALL. */
+const fieldTypeLiterals: Record<StoreType, string> = {
+  text: 'text',
+  numeric: 'numeric',
+  boolean: 'boolean',
+  datetime: 'datetime',
+  json: 'richText',
+  relation: 'relation',
+  file: 'file',
+}
+
+/**
+ * Map the manifest's abstract `nullCast` type name to its MySQL `CAST(NULL
+ * AS <type>)` expression. MySQL has no `NULL::<type>` shorthand (that's
+ * Postgres-only syntax), so every branch of the UNION ALL that doesn't
+ * provide a given column emits an explicit `CAST`.
+ *
+ * Each mapping was verified against the live MySQL 9.7.1 container (not
+ * just read from the docs) by UNIONing a `CAST(NULL AS …)` branch against a
+ * branch selecting a real, populated column of the corresponding store type
+ * and confirming the driver returns the real value unmodified (no
+ * truncation, no precision loss) — see the Task 10A report for the
+ * transcript. Precision-bearing casts (`TIME(3)`, `DATETIME(3)`,
+ * `DECIMAL(10,2)`) mirror the schema's own column precision
+ * (`packages/db-mysql/src/database/schema/index.ts`) exactly, rather than
+ * relying on MySQL's default (whole-second time, `DECIMAL(10,0)`), so a
+ * NULL-cast branch can never be the one that silently narrows the unified
+ * column's type.
+ */
+export function mysqlNullCast(nullCast: string): string {
+  switch (nullCast) {
+    case 'uuid':
+      return 'CAST(NULL AS CHAR(36))'
+    case 'boolean':
+      return 'CAST(NULL AS SIGNED)'
+    case 'timestamp':
+      // The manifest's abstract name for the `timestamptz`-shaped column
+      // (`value_timestamp_tz`); MySQL's storage-side type is `DATETIME(3)`
+      // (spec §2 — UTC by convention), not a MySQL `TIMESTAMP` column.
+      return 'CAST(NULL AS DATETIME(3))'
+    case 'date':
+      return 'CAST(NULL AS DATE)'
+    case 'time':
+      return 'CAST(NULL AS TIME(3))'
+    case 'jsonb':
+      return 'CAST(NULL AS JSON)'
+    case 'text':
+    case 'varchar':
+      return 'CAST(NULL AS CHAR)'
+    case 'bigint':
+    case 'integer':
+      return 'CAST(NULL AS SIGNED)'
+    case 'decimal':
+      return 'CAST(NULL AS DECIMAL(10,2))'
+    case 'real':
+      return 'CAST(NULL AS FLOAT)'
+    case 'text[]':
+      // No MySQL array type — `object_keys` is stored as a JSON array of
+      // strings on this adapter (see the manifest's own comment at its
+      // `object_keys` entry), so the null cast matches that column's real
+      // MySQL type.
+      return 'CAST(NULL AS JSON)'
+    default:
+      throw new Error(`mysqlNullCast: unrecognised nullCast type '${nullCast}'`)
+  }
+}
+
+/** Number of columns in the unified output (base + field_type + type-specific). */
+export const UNIFIED_COLUMN_COUNT = storeColumnManifest.length + 1 // +1 for field_type
+
+/**
+ * Build the SELECT column list for a given store table type.
+ *
+ * Base columns (id, document_version_id, etc.) are passed through directly.
+ * The `field_type` column is emitted as a string literal.
+ * Type-specific columns are either mapped to the source expression or
+ * emitted as a typed NULL.
+ */
+function buildSelectList(storeType: StoreType): string {
+  const parts: string[] = []
+
+  for (const col of storeColumnManifest) {
+    // Base columns (no sources) are always passed through from the table.
+    if (!col.sources) {
+      parts.push(col.name)
+      continue
+    }
+
+    const sourceExpr = col.sources[storeType]
+    if (sourceExpr) {
+      // This store provides this column — use the source expression.
+      // If the source column name differs from the output alias, add AS.
+      if (sourceExpr === col.name) {
+        parts.push(col.name)
+      } else {
+        parts.push(`${sourceExpr} as \`${col.name}\``)
+      }
+    } else {
+      // This store doesn't provide this column — emit typed NULL.
+      parts.push(`${mysqlNullCast(col.nullCast)} as \`${col.name}\``)
+    }
+  }
+
+  // Insert field_type after the base columns. The base columns are the first
+  // 7 entries (id through parent_path). field_type goes at position 3
+  // (after collection_id, before field_path) to match the original layout.
+  const fieldTypeLiteral = `'${fieldTypeLiterals[storeType]}' as \`field_type\``
+  parts.splice(3, 0, fieldTypeLiteral)
+
+  return parts.join(',\n  ')
+}
+
+// Pre-generate SQL fragments for each store type.
+const selectListCache = new Map<StoreType, SQL>()
+
+/**
+ * Get the Drizzle SQL fragment for a store type's SELECT list.
+ * Results are cached — the generation runs once at module load.
+ */
+export function storeSelectList(storeType: StoreType): SQL {
+  let cached = selectListCache.get(storeType)
+  if (!cached) {
+    cached = sql.raw(buildSelectList(storeType))
+    selectListCache.set(storeType, cached)
+  }
+  return cached
+}
+
+// ---------------------------------------------------------------------------
+// Exported for testing
+// ---------------------------------------------------------------------------
+export { buildSelectList, fieldTypeLiterals }

--- a/packages/db-mysql/src/modules/storage/storage-utils.ts
+++ b/packages/db-mysql/src/modules/storage/storage-utils.ts
@@ -26,3 +26,25 @@ export const getFirstOrThrow =
     }
     return value
   }
+
+/**
+ * Coerce a raw driver `DATETIME`/`TIMESTAMP` value from a `db.execute(sql\`...\`)`
+ * call to a real `Date`. `drizzle-orm`'s mysql2 driver installs its own
+ * `typeCast` on every raw-execute call that has no schema-typed `fields`
+ * mapper — which every hand-written SQL read in this adapter is — that
+ * unconditionally returns those column types as **strings**
+ * (`'YYYY-MM-DD HH:MM:SS.ffffff'`, space-separated, no timezone marker),
+ * regardless of the pool's own `timezone` option. Confirmed live across
+ * three independent call sites in this adapter (Task 11's audit-log UNION,
+ * `normalizeRow`'s `value_timestamp_tz`, and `findDocuments`' main query —
+ * see the Task 11 report). Every `DATETIME`/`TIMESTAMP` column in this
+ * schema is UTC by convention, so appending `Z` after normalising the
+ * separator is the correct interpretation, not an assumed one. Tolerant of
+ * `null`/`undefined` and of the value already being a `Date` (defensive —
+ * not expected on this path, but cheap to allow and keeps callers simple).
+ */
+export function toDate(value: string | Date | null | undefined): Date | null {
+  if (value == null) return null
+  if (value instanceof Date) return value
+  return new Date(`${value.replace(' ', 'T')}Z`)
+}

--- a/packages/db-mysql/src/modules/storage/storage-utils.ts
+++ b/packages/db-mysql/src/modules/storage/storage-utils.ts
@@ -1,0 +1,28 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import { ERR_DATABASE, getLogger } from '@byline/core'
+
+// ------------------------------------------------------------------------------
+// Misc
+//
+// `resolveStoreTypes` lives in `@byline/core` (`packages/core/src/storage/
+// storage-utils.ts`) — it is dialect-independent. `getFirstOrThrow` stays
+// here: it's a result helper tied to this adapter. Mirrors
+// `packages/db-postgres/src/modules/storage/storage-utils.ts`.
+// ------------------------------------------------------------------------------
+
+export const getFirstOrThrow =
+  <T>(message: string) =>
+  (values: T[]): T => {
+    const value = values[0]
+    if (value == null) {
+      throw ERR_DATABASE({ message }).log(getLogger())
+    }
+    return value
+  }

--- a/packages/db-mysql/src/modules/storage/storage-utils.ts
+++ b/packages/db-mysql/src/modules/storage/storage-utils.ts
@@ -48,3 +48,19 @@ export function toDate(value: string | Date | null | undefined): Date | null {
   if (value instanceof Date) return value
   return new Date(`${value.replace(' ', 'T')}Z`)
 }
+
+/**
+ * Read the affected-row count off a drizzle mysql2 `update()`/`delete()`
+ * result. MySQL has no `RETURNING`, so every guarded write in this adapter
+ * (optimistic-concurrency `UPDATE`/`DELETE` gates, bulk-mutation counts)
+ * uses this as its accept/reject or count signal instead. mysql2 resolves
+ * these to a `[ResultSetHeader, FieldPacket[]]` tuple — `affectedRows`
+ * lives on the first element, not `.rowCount` the way pg's driver shapes
+ * it (confirmed live against the test database; see
+ * `storage-commands.ts`'s `archivePublishedVersions` docblock for the
+ * original finding). Centralised here so the admin repositories (`../admin/
+ * *.ts`) share one cast instead of repeating it inline at every call site.
+ */
+export function affectedRowCount(result: unknown): number {
+  return (result as [{ affectedRows: number }, unknown])[0]?.affectedRows ?? 0
+}

--- a/packages/db-mysql/src/modules/storage/tests/storage-commands.test.ts
+++ b/packages/db-mysql/src/modules/storage/tests/storage-commands.test.ts
@@ -263,8 +263,12 @@ describe('storage-commands (mysql, live database)', () => {
       )
       expect(featuredRow.value).toBe(1)
 
-      // byline_store_datetime — DATETIME(3) round-trips as a Date with the
-      // pool's `timezone: 'Z'` option, millisecond precision intact.
+      // byline_store_datetime — DATETIME(6) round-trips as a Date with the
+      // pool's `timezone: 'Z'` option (this query goes through the raw pool,
+      // not drizzle's typeCast-overridden `db.execute()` — see
+      // `storage-utils.ts`'s `toDate` docblock for why that distinction
+      // matters), millisecond precision intact for this millisecond-only
+      // source value.
       const publishedRow = await queryOne(
         rawPool,
         "SELECT value_timestamp_tz FROM byline_store_datetime WHERE document_version_id = ? AND field_name = 'publishedOn'",

--- a/packages/db-mysql/src/modules/storage/tests/storage-commands.test.ts
+++ b/packages/db-mysql/src/modules/storage/tests/storage-commands.test.ts
@@ -1,0 +1,483 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+/**
+ * Live-database verification of the Task 9A write path
+ * (`storage-insert.ts` + `storage-commands.ts`'s `CollectionCommands` and
+ * `DocumentCommands.createDocumentVersion`) — the `@byline/db-conformance`
+ * `versioning` and `field-types` suites can't run yet (they read documents
+ * back via `getDocumentHistory` / `getDocumentByVersion` / `findDocuments`,
+ * which are Task 10's `storage-queries.ts`; see the report for Task 9A for
+ * why that read surface is out of this task's scope). Until Task 10 lands,
+ * this file is the write path's real-database regression gate: every
+ * assertion below queries the live MySQL test database directly (raw SQL
+ * through the pool, not the ORM's typed read path, and never a mock) so the
+ * actual bytes written by `createDocumentVersion` are what's checked, not a
+ * re-statement of the write code's own assumptions.
+ */
+
+import type { CollectionDefinition } from '@byline/core'
+import type mysql from 'mysql2/promise'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { setupTestDB, teardownTestDB } from '../../../lib/test-helper.js'
+import { classifyError } from '../classify-error.js'
+
+const timestamp = Date.now()
+
+/** `noUncheckedIndexedAccess` guard: unwrap a `T[0]`, failing loudly if empty. */
+function first<T>(rows: T[]): T {
+  const row = rows[0]
+  if (row == null) {
+    throw new Error('expected at least one row, got none')
+  }
+  return row
+}
+
+/** Raw SQL through the live pool — bypasses the ORM read path entirely. */
+async function queryRows(pool: mysql.Pool, sql: string, params: unknown[]): Promise<any[]> {
+  const [rows] = await pool.query(sql, params)
+  return rows as any[]
+}
+
+async function queryOne(pool: mysql.Pool, sql: string, params: unknown[]): Promise<any> {
+  return first(await queryRows(pool, sql, params))
+}
+
+const CategoriesCollectionConfig: CollectionDefinition = {
+  path: `cmd-test-categories-${timestamp}`,
+  labels: { singular: 'Category', plural: 'Categories' },
+  fields: [{ name: 'name', type: 'text' }],
+}
+
+const ArticlesCollectionConfig: CollectionDefinition = {
+  path: `cmd-test-articles-${timestamp}`,
+  labels: { singular: 'Article', plural: 'Articles' },
+  fields: [
+    { name: 'title', type: 'text', localized: true },
+    { name: 'views', type: 'integer' },
+    { name: 'price', type: 'decimal' },
+    { name: 'featured', type: 'boolean' },
+    { name: 'publishedOn', type: 'datetime' },
+    { name: 'category', type: 'relation', targetCollection: 'categories', optional: true },
+    { name: 'body', type: 'richText', localized: true },
+    {
+      name: 'links',
+      type: 'array',
+      fields: [{ name: 'label', type: 'text' }],
+    },
+  ],
+}
+
+describe('storage-commands (mysql, live database)', () => {
+  let testDb: ReturnType<typeof setupTestDB>
+  let rawPool: mysql.Pool
+  let categoriesId: string
+  let articlesId: string
+  let categoryDocumentId: string
+
+  beforeAll(async () => {
+    testDb = setupTestDB([CategoriesCollectionConfig, ArticlesCollectionConfig])
+    rawPool = testDb.pool
+
+    const categories = first(
+      await testDb.commandBuilders.collections.create(
+        CategoriesCollectionConfig.path,
+        CategoriesCollectionConfig
+      )
+    )
+    categoriesId = categories.id
+
+    const articles = first(
+      await testDb.commandBuilders.collections.create(
+        ArticlesCollectionConfig.path,
+        ArticlesCollectionConfig
+      )
+    )
+    articlesId = articles.id
+
+    const categoryVersion = await testDb.commandBuilders.documents.createDocumentVersion({
+      collectionId: categoriesId,
+      collectionVersion: 1,
+      collectionConfig: CategoriesCollectionConfig,
+      action: 'create',
+      documentData: { name: 'News' },
+      path: `news-${timestamp}`,
+      locale: 'all',
+      status: 'draft',
+    })
+    categoryDocumentId = categoryVersion.document.document_id
+  })
+
+  afterAll(async () => {
+    await testDb.commandBuilders.collections.delete(articlesId)
+    await testDb.commandBuilders.collections.delete(categoriesId)
+    await teardownTestDB()
+  })
+
+  describe('CollectionCommands', () => {
+    it('create constructs the row in JS (id/path/config known up front, no RETURNING)', async () => {
+      const row = first(
+        await testDb.commandBuilders.collections.create(`throwaway-${timestamp}`, {
+          path: `throwaway-${timestamp}`,
+          labels: { singular: 'Throwaway', plural: 'Throwaways' },
+          fields: [{ name: 'x', type: 'text' }],
+        })
+      )
+      expect(row.id).toBeTruthy()
+      expect(row.path).toBe(`throwaway-${timestamp}`)
+      expect(row.version).toBe(1)
+
+      const dbRow = await queryOne(
+        rawPool,
+        'SELECT id, path, version FROM byline_collections WHERE id = ?',
+        [row.id]
+      )
+      expect(dbRow.id).toBe(row.id)
+      expect(dbRow.path).toBe(`throwaway-${timestamp}`)
+
+      await testDb.commandBuilders.collections.delete(row.id)
+      const afterDelete = await queryRows(
+        rawPool,
+        'SELECT id FROM byline_collections WHERE id = ?',
+        [row.id]
+      )
+      expect(afterDelete.length).toBe(0)
+    })
+
+    it('update re-SELECTs the merged row (MySQL has no RETURNING)', async () => {
+      const row = first(
+        await testDb.commandBuilders.collections.create(`updatable-${timestamp}`, {
+          path: `updatable-${timestamp}`,
+          labels: { singular: 'Updatable', plural: 'Updatables' },
+          fields: [{ name: 'x', type: 'text' }],
+        })
+      )
+
+      const updated = first(await testDb.commandBuilders.collections.update(row.id, { version: 2 }))
+      expect(updated.version).toBe(2)
+      expect(updated.path).toBe(`updatable-${timestamp}`) // untouched fields survive the re-SELECT
+
+      await testDb.commandBuilders.collections.delete(row.id)
+    })
+  })
+
+  describe('DocumentCommands.createDocumentVersion', () => {
+    let firstVersionId: string
+    let articleDocumentId: string
+    const articlePath = `first-article-${timestamp}`
+
+    it('creates a document + version and writes every store bucket correctly', async () => {
+      const result = await testDb.commandBuilders.documents.createDocumentVersion({
+        collectionId: articlesId,
+        collectionVersion: 1,
+        collectionConfig: ArticlesCollectionConfig,
+        action: 'create',
+        documentData: {
+          title: { en: 'Hello world', es: 'Hola mundo' },
+          views: 42,
+          price: '19.99',
+          featured: true,
+          publishedOn: new Date('2024-01-15T10:30:00.123Z'),
+          category: { targetDocumentId: categoryDocumentId, targetCollectionId: categoriesId },
+          body: {
+            en: { root: { type: 'text', text: 'english body' } },
+            es: { root: { type: 'text', text: 'spanish body' } },
+          },
+          links: [{ label: 'one' }, { label: 'two' }],
+        },
+        path: articlePath,
+        availableLocales: ['en', 'es'],
+        locale: 'all',
+        status: 'draft',
+      })
+
+      expect(result.document.document_id).toBeTruthy()
+      expect(result.document.id).toBeTruthy()
+      expect(result.fieldCount).toBeGreaterThan(0)
+      firstVersionId = result.document.id
+      articleDocumentId = result.document.document_id
+
+      // byline_documents — source_locale anchored to the adapter's default ('en')
+      const docRow = await queryOne(
+        rawPool,
+        'SELECT id, collection_id, source_locale FROM byline_documents WHERE id = ?',
+        [articleDocumentId]
+      )
+      expect(docRow.source_locale).toBe('en')
+      expect(docRow.collection_id).toBe(articlesId)
+
+      // byline_document_versions
+      const versionRow = await queryOne(
+        rawPool,
+        'SELECT id, document_id, status, event_type, is_deleted FROM byline_document_versions WHERE id = ?',
+        [firstVersionId]
+      )
+      expect(versionRow.status).toBe('draft')
+      expect(versionRow.event_type).toBe('create')
+      expect(versionRow.is_deleted).toBe(0)
+
+      // byline_store_text — localized 'title', two locale rows
+      const textRows = await queryRows(
+        rawPool,
+        "SELECT locale, value FROM byline_store_text WHERE document_version_id = ? AND field_name = 'title' ORDER BY locale",
+        [firstVersionId]
+      )
+      expect(textRows.map((r) => [r.locale, r.value])).toEqual([
+        ['en', 'Hello world'],
+        ['es', 'Hola mundo'],
+      ])
+
+      // byline_store_numeric — integer 'views' and decimal 'price'
+      const viewsRow = await queryOne(
+        rawPool,
+        "SELECT number_type, value_integer FROM byline_store_numeric WHERE document_version_id = ? AND field_name = 'views'",
+        [firstVersionId]
+      )
+      expect(viewsRow.number_type).toBe('integer')
+      expect(viewsRow.value_integer).toBe(42)
+
+      const priceRow = await queryOne(
+        rawPool,
+        "SELECT number_type, value_decimal FROM byline_store_numeric WHERE document_version_id = ? AND field_name = 'price'",
+        [firstVersionId]
+      )
+      expect(priceRow.number_type).toBe('decimal')
+      // DECIMAL stays a string end to end (pool `decimalNumbers: false`).
+      expect(typeof priceRow.value_decimal).toBe('string')
+      expect(priceRow.value_decimal).toBe('19.99')
+
+      // byline_store_boolean — TINYINT(1) on the wire; the mysql2 driver
+      // returns a JS number here (0/1), not a boolean — confirmed live
+      // (see normalize-row.ts's docblock). This is the raw column value
+      // before any `normalizeRow` canonicalisation.
+      const featuredRow = await queryOne(
+        rawPool,
+        "SELECT value FROM byline_store_boolean WHERE document_version_id = ? AND field_name = 'featured'",
+        [firstVersionId]
+      )
+      expect(featuredRow.value).toBe(1)
+
+      // byline_store_datetime — DATETIME(3) round-trips as a Date with the
+      // pool's `timezone: 'Z'` option, millisecond precision intact.
+      const publishedRow = await queryOne(
+        rawPool,
+        "SELECT value_timestamp_tz FROM byline_store_datetime WHERE document_version_id = ? AND field_name = 'publishedOn'",
+        [firstVersionId]
+      )
+      expect(publishedRow.value_timestamp_tz).toBeInstanceOf(Date)
+      expect((publishedRow.value_timestamp_tz as Date).toISOString()).toBe(
+        '2024-01-15T10:30:00.123Z'
+      )
+
+      // byline_store_relation
+      const relationRow = await queryOne(
+        rawPool,
+        "SELECT target_document_id, target_collection_id, relationship_type, cascade_delete FROM byline_store_relation WHERE document_version_id = ? AND field_name = 'category'",
+        [firstVersionId]
+      )
+      expect(relationRow.target_document_id).toBe(categoryDocumentId)
+      expect(relationRow.target_collection_id).toBe(categoriesId)
+      expect(relationRow.relationship_type).toBe('reference')
+      expect(relationRow.cascade_delete).toBe(0)
+
+      // byline_store_json — richText 'body', already-parsed object on read
+      // (the driver parses JSON columns itself; `normalizeRow` must not
+      // double-`JSON.parse` them).
+      const bodyRow = await queryOne(
+        rawPool,
+        "SELECT value FROM byline_store_json WHERE document_version_id = ? AND field_name = 'body' AND locale = 'en'",
+        [firstVersionId]
+      )
+      expect(bodyRow.value).toEqual({ root: { type: 'text', text: 'english body' } })
+
+      // byline_store_meta — the array/array-item `_id` identity rows
+      const metaRows = await queryRows(
+        rawPool,
+        'SELECT type, path FROM byline_store_meta WHERE document_version_id = ?',
+        [firstVersionId]
+      )
+      expect(metaRows.length).toBeGreaterThan(0)
+
+      // byline_document_paths — upserted under the document's source_locale
+      const pathRow = await queryOne(
+        rawPool,
+        'SELECT path, locale, collection_id FROM byline_document_paths WHERE document_id = ?',
+        [articleDocumentId]
+      )
+      expect(pathRow.path).toBe(articlePath)
+      expect(pathRow.locale).toBe('en')
+      expect(pathRow.collection_id).toBe(articlesId)
+
+      // byline_document_available_locales — the editorial advertised set
+      const availableRows = await queryRows(
+        rawPool,
+        'SELECT locale FROM byline_document_available_locales WHERE document_id = ? ORDER BY locale',
+        [articleDocumentId]
+      )
+      expect(availableRows.map((r) => r.locale)).toEqual(['en', 'es'])
+
+      // byline_document_version_locales — the completeness ledger
+      const localeLedgerRows = await queryRows(
+        rawPool,
+        'SELECT locale FROM byline_document_version_locales WHERE document_version_id = ? ORDER BY locale',
+        [firstVersionId]
+      )
+      expect(localeLedgerRows.map((r) => r.locale)).toEqual(['en', 'es'])
+    })
+
+    it('creates a second version of the same document (multi-version, shared document_id)', async () => {
+      const second = await testDb.commandBuilders.documents.createDocumentVersion({
+        documentId: articleDocumentId,
+        collectionId: articlesId,
+        collectionVersion: 1,
+        collectionConfig: ArticlesCollectionConfig,
+        action: 'update',
+        documentData: {
+          title: { en: 'Hello world v2', es: 'Hola mundo v2' },
+          views: 43,
+          price: '29.99',
+          featured: false,
+          publishedOn: new Date('2024-02-01T00:00:00.000Z'),
+          links: [],
+        },
+        locale: 'all',
+        status: 'draft',
+      })
+
+      expect(second.document.document_id).toBe(articleDocumentId)
+      expect(second.document.id).not.toBe(firstVersionId)
+
+      const versionRows = await queryRows(
+        rawPool,
+        'SELECT id FROM byline_document_versions WHERE document_id = ?',
+        [articleDocumentId]
+      )
+      expect(versionRows.length).toBe(2)
+
+      // The first version's rows must be untouched — versioning is immutable.
+      const firstStillThere = await queryOne(
+        rawPool,
+        "SELECT value FROM byline_store_text WHERE document_version_id = ? AND field_name = 'title' AND locale = 'en'",
+        [firstVersionId]
+      )
+      expect(firstStillThere.value).toBe('Hello world')
+    })
+
+    it('copies non-active-locale rows forward when saving in a single locale', async () => {
+      const secondVersion = await queryOne(
+        rawPool,
+        'SELECT id FROM byline_document_versions WHERE document_id = ? ORDER BY id DESC LIMIT 1',
+        [articleDocumentId]
+      )
+
+      const third = await testDb.commandBuilders.documents.createDocumentVersion({
+        documentId: articleDocumentId,
+        collectionId: articlesId,
+        collectionVersion: 1,
+        collectionConfig: ArticlesCollectionConfig,
+        action: 'update',
+        documentData: {
+          title: 'Bonjour le monde', // single-locale shape: 'fr' is not 'all'
+          views: 43,
+          price: '29.99',
+          featured: false,
+          publishedOn: new Date('2024-02-01T00:00:00.000Z'),
+          links: [],
+        },
+        previousVersionId: secondVersion.id,
+        locale: 'fr',
+        status: 'draft',
+      })
+
+      const thirdVersionId = third.document.id
+
+      // The freshly-written 'fr' row plus the carried-forward 'en'/'es' rows
+      // from the previous version — three distinct locales, one row each.
+      const titleRows = await queryRows(
+        rawPool,
+        "SELECT locale, value FROM byline_store_text WHERE document_version_id = ? AND field_name = 'title' ORDER BY locale",
+        [thirdVersionId]
+      )
+      expect(titleRows.map((r) => [r.locale, r.value])).toEqual([
+        ['en', 'Hello world v2'],
+        ['es', 'Hola mundo v2'],
+        ['fr', 'Bonjour le monde'],
+      ])
+    })
+
+    it('re-saving the same document + locale updates the path row in place (no duplicate-key error)', async () => {
+      const updatedPath = `${articlePath}-renamed`
+
+      await testDb.commandBuilders.documents.createDocumentVersion({
+        documentId: articleDocumentId,
+        collectionId: articlesId,
+        collectionVersion: 1,
+        collectionConfig: ArticlesCollectionConfig,
+        action: 'update',
+        documentData: {
+          title: { en: 'Hello world v4' },
+          views: 44,
+          price: '39.99',
+          featured: false,
+          links: [],
+        },
+        path: updatedPath,
+        locale: 'all',
+        status: 'draft',
+      })
+
+      const pathRows = await queryRows(
+        rawPool,
+        'SELECT path FROM byline_document_paths WHERE document_id = ?',
+        [articleDocumentId]
+      )
+      expect(pathRows.length).toBe(1)
+      expect(pathRows[0]?.path).toBe(updatedPath)
+    })
+  })
+
+  describe('path conflicts surface as a real MySQL duplicate-key error that classifyError recognises', () => {
+    it('classifies a live ER_DUP_ENTRY from the (collection, locale, path) unique index', async () => {
+      const conflictingPath = `conflict-${timestamp}`
+
+      await testDb.commandBuilders.documents.createDocumentVersion({
+        collectionId: articlesId,
+        collectionVersion: 1,
+        collectionConfig: ArticlesCollectionConfig,
+        action: 'create',
+        documentData: { title: 'A', views: 1, price: '1.00', featured: false, links: [] },
+        path: conflictingPath,
+        locale: 'all',
+        status: 'draft',
+      })
+
+      let caught: unknown
+      try {
+        await testDb.commandBuilders.documents.createDocumentVersion({
+          collectionId: articlesId,
+          collectionVersion: 1,
+          collectionConfig: ArticlesCollectionConfig,
+          action: 'create',
+          documentData: { title: 'B', views: 1, price: '1.00', featured: false, links: [] },
+          path: conflictingPath,
+          locale: 'all',
+          status: 'draft',
+        })
+      } catch (err) {
+        caught = err
+      }
+
+      expect(caught).toBeDefined()
+      expect(classifyError(caught)).toEqual({
+        code: 'DB_UNIQUE_VIOLATION',
+        constraint: 'idx_document_paths_collection_locale_path',
+      })
+    })
+  })
+})

--- a/packages/db-mysql/src/modules/storage/tests/storage-document-paths.test.ts
+++ b/packages/db-mysql/src/modules/storage/tests/storage-document-paths.test.ts
@@ -1,0 +1,301 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+/**
+ * Live-database verification of `DocumentCommands.updateDocumentPath` and
+ * `DocumentCommands.setDocumentAvailableLocales` (Task 9B) — the standalone,
+ * non-versioned system-field writes. Same style as
+ * `storage-commands.test.ts`: every assertion queries the live MySQL test
+ * database directly (raw SQL through the pool), never a mock, never the
+ * ORM's typed read path (which doesn't exist yet — Task 10).
+ */
+
+import type { CollectionDefinition } from '@byline/core'
+import type mysql from 'mysql2/promise'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { setupTestDB, teardownTestDB } from '../../../lib/test-helper.js'
+import { classifyError } from '../classify-error.js'
+
+const timestamp = Date.now()
+
+function first<T>(rows: T[]): T {
+  const row = rows[0]
+  if (row == null) throw new Error('expected at least one row, got none')
+  return row
+}
+
+async function queryRows(pool: mysql.Pool, sql: string, params: unknown[]): Promise<any[]> {
+  const [rows] = await pool.query(sql, params)
+  return rows as any[]
+}
+
+async function queryOne(pool: mysql.Pool, sql: string, params: unknown[]): Promise<any> {
+  return first(await queryRows(pool, sql, params))
+}
+
+const PagesCollectionConfig: CollectionDefinition = {
+  path: `paths-test-pages-${timestamp}`,
+  labels: { singular: 'Page', plural: 'Pages' },
+  fields: [{ name: 'title', type: 'text' }],
+}
+
+describe('DocumentCommands.updateDocumentPath / setDocumentAvailableLocales (mysql, live database)', () => {
+  let testDb: ReturnType<typeof setupTestDB>
+  let rawPool: mysql.Pool
+  let collectionId: string
+
+  beforeAll(async () => {
+    testDb = setupTestDB([PagesCollectionConfig])
+    rawPool = testDb.pool
+    const created = first(
+      await testDb.commandBuilders.collections.create(
+        PagesCollectionConfig.path,
+        PagesCollectionConfig
+      )
+    )
+    collectionId = created.id
+  })
+
+  afterAll(async () => {
+    await testDb.commandBuilders.collections.delete(collectionId)
+    await teardownTestDB()
+  })
+
+  async function createDocWithoutPath(title: string): Promise<string> {
+    const created = await testDb.commandBuilders.documents.createDocumentVersion({
+      collectionId,
+      collectionVersion: 1,
+      collectionConfig: PagesCollectionConfig,
+      action: 'create',
+      documentData: { title },
+      locale: 'all',
+      status: 'draft',
+    })
+    return created.document.document_id
+  }
+
+  describe('updateDocumentPath', () => {
+    it('inserts a fresh path row when the document has none yet', async () => {
+      const documentId = await createDocWithoutPath('Fresh Path Doc')
+      const path = `fresh-${timestamp}`
+
+      await testDb.commandBuilders.documents.updateDocumentPath({
+        documentId,
+        collectionId,
+        locale: 'en',
+        path,
+      })
+
+      const rows = await queryRows(
+        rawPool,
+        'SELECT path, locale, collection_id FROM byline_document_paths WHERE document_id = ?',
+        [documentId]
+      )
+      expect(rows.length).toBe(1)
+      expect(rows[0]?.path).toBe(path)
+      expect(rows[0]?.locale).toBe('en')
+    })
+
+    it('updates the existing path row in place — no new document version', async () => {
+      const documentId = await createDocWithoutPath('Updatable Path Doc')
+      await testDb.commandBuilders.documents.updateDocumentPath({
+        documentId,
+        collectionId,
+        locale: 'en',
+        path: `updatable-v1-${timestamp}`,
+      })
+      const versionCountBefore = (
+        await queryRows(rawPool, 'SELECT id FROM byline_document_versions WHERE document_id = ?', [
+          documentId,
+        ])
+      ).length
+
+      const updatedPath = `updatable-v2-${timestamp}`
+      await testDb.commandBuilders.documents.updateDocumentPath({
+        documentId,
+        collectionId,
+        locale: 'en',
+        path: updatedPath,
+      })
+
+      const rows = await queryRows(
+        rawPool,
+        'SELECT path FROM byline_document_paths WHERE document_id = ?',
+        [documentId]
+      )
+      expect(rows.length).toBe(1) // still one row — updated, not duplicated
+      expect(rows[0]?.path).toBe(updatedPath)
+
+      const versionCountAfter = (
+        await queryRows(rawPool, 'SELECT id FROM byline_document_versions WHERE document_id = ?', [
+          documentId,
+        ])
+      ).length
+      expect(versionCountAfter).toBe(versionCountBefore) // no version minted
+    })
+
+    it('rejects a genuine cross-document path collision, surfaced via classifyError', async () => {
+      const path = `collide-${timestamp}`
+      const docA = await createDocWithoutPath('Collide A')
+      const docB = await createDocWithoutPath('Collide B')
+
+      await testDb.commandBuilders.documents.updateDocumentPath({
+        documentId: docA,
+        collectionId,
+        locale: 'en',
+        path,
+      })
+
+      let caught: unknown
+      try {
+        await testDb.commandBuilders.documents.updateDocumentPath({
+          documentId: docB,
+          collectionId,
+          locale: 'en',
+          path,
+        })
+      } catch (err) {
+        caught = err
+      }
+
+      expect(caught).toBeDefined()
+      expect(classifyError(caught)).toEqual({
+        code: 'DB_UNIQUE_VIOLATION',
+        constraint: 'idx_document_paths_collection_locale_path',
+      })
+
+      // docB's insert was rejected outright — no row for it, and docA's row untouched.
+      const bRows = await queryRows(
+        rawPool,
+        'SELECT path FROM byline_document_paths WHERE document_id = ?',
+        [docB]
+      )
+      expect(bRows.length).toBe(0)
+      const aRow = await queryOne(
+        rawPool,
+        'SELECT path FROM byline_document_paths WHERE document_id = ?',
+        [docA]
+      )
+      expect(aRow.path).toBe(path)
+    })
+
+    /**
+     * §C.2 (binding review finding): the path upsert had no concurrent-writer
+     * coverage. `writeDocumentPath` replaces Postgres's declarative
+     * `onConflictDoUpdate({ target })` with application-level control flow —
+     * insert, catch, classify, and only fall through to an `UPDATE` when the
+     * *own-document* unique index collided (see that method's docblock). This
+     * proves the classification still discriminates correctly under a true
+     * race, not just the sequential collision above: two never-before-pathed
+     * documents racing to claim the exact same (collection_id, locale, path)
+     * via `updateDocumentPath` — the second caller into `writeDocumentPath`
+     * this task wires in. Exactly one writer must win the unique index; the
+     * other must surface a `DB_UNIQUE_VIOLATION` on the *cross-document*
+     * index, not a duplicate row and not a silently swallowed error.
+     */
+    it('races two writers onto the same (collection, locale, path): one wins, one is classified as a path conflict', async () => {
+      const path = `race-${timestamp}`
+      const docA = await createDocWithoutPath('Race A')
+      const docB = await createDocWithoutPath('Race B')
+
+      const results = await Promise.allSettled([
+        testDb.commandBuilders.documents.updateDocumentPath({
+          documentId: docA,
+          collectionId,
+          locale: 'en',
+          path,
+        }),
+        testDb.commandBuilders.documents.updateDocumentPath({
+          documentId: docB,
+          collectionId,
+          locale: 'en',
+          path,
+        }),
+      ])
+
+      const fulfilled = results.filter((r) => r.status === 'fulfilled')
+      const rejected = results.filter((r): r is PromiseRejectedResult => r.status === 'rejected')
+      expect(fulfilled.length).toBe(1)
+      expect(rejected.length).toBe(1)
+      expect(classifyError(rejected[0]?.reason)).toEqual({
+        code: 'DB_UNIQUE_VIOLATION',
+        constraint: 'idx_document_paths_collection_locale_path',
+      })
+
+      // Exactly one row claims the contested path — no duplicate, no ghost row.
+      const claimants = await queryRows(
+        rawPool,
+        'SELECT document_id FROM byline_document_paths WHERE collection_id = ? AND locale = ? AND path = ?',
+        [collectionId, 'en', path]
+      )
+      expect(claimants.length).toBe(1)
+      expect([docA, docB]).toContain(claimants[0]?.document_id)
+    })
+  })
+
+  describe('setDocumentAvailableLocales', () => {
+    it('writes, replaces, and clears the advertised-locale set', async () => {
+      const documentId = await createDocWithoutPath('Locales Doc')
+
+      await testDb.commandBuilders.documents.setDocumentAvailableLocales({
+        documentId,
+        collectionId,
+        availableLocales: ['en', 'fr'],
+      })
+      let rows = await queryRows(
+        rawPool,
+        'SELECT locale FROM byline_document_available_locales WHERE document_id = ? ORDER BY locale',
+        [documentId]
+      )
+      expect(rows.map((r) => r.locale)).toEqual(['en', 'fr'])
+
+      // Replace wholesale — 'es' only, 'en'/'fr' dropped.
+      await testDb.commandBuilders.documents.setDocumentAvailableLocales({
+        documentId,
+        collectionId,
+        availableLocales: ['es'],
+      })
+      rows = await queryRows(
+        rawPool,
+        'SELECT locale FROM byline_document_available_locales WHERE document_id = ? ORDER BY locale',
+        [documentId]
+      )
+      expect(rows.map((r) => r.locale)).toEqual(['es'])
+
+      // Empty array clears the set entirely.
+      await testDb.commandBuilders.documents.setDocumentAvailableLocales({
+        documentId,
+        collectionId,
+        availableLocales: [],
+      })
+      rows = await queryRows(
+        rawPool,
+        'SELECT locale FROM byline_document_available_locales WHERE document_id = ?',
+        [documentId]
+      )
+      expect(rows.length).toBe(0)
+    })
+
+    it('deduplicates a caller-supplied duplicate locale (PK is document_id + locale)', async () => {
+      const documentId = await createDocWithoutPath('Dedup Locales Doc')
+
+      await testDb.commandBuilders.documents.setDocumentAvailableLocales({
+        documentId,
+        collectionId,
+        availableLocales: ['en', 'en', 'fr'],
+      })
+      const rows = await queryRows(
+        rawPool,
+        'SELECT locale FROM byline_document_available_locales WHERE document_id = ? ORDER BY locale',
+        [documentId]
+      )
+      expect(rows.map((r) => r.locale)).toEqual(['en', 'fr'])
+    })
+  })
+})

--- a/packages/db-mysql/src/modules/storage/tests/storage-document-tree.test.ts
+++ b/packages/db-mysql/src/modules/storage/tests/storage-document-tree.test.ts
@@ -1,0 +1,449 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+/**
+ * Live-database verification of the Task 9B document-tree command surface —
+ * `DocumentCommands.placeTreeNode`, `removeFromTree`, and
+ * `promoteChildrenAndRemoveFromTree`. Mirrors the write-half of
+ * `@byline/db-conformance`'s `document-tree` suite
+ * (`packages/db-conformance/src/suites/document-tree.ts`), but that suite
+ * also exercises `getTreeChildren` / `getTreeAncestors` / `getTreeSubtree`
+ * (Task 10 read surface, not implemented yet) — so every assertion here reads
+ * `byline_document_relationships` directly via raw SQL instead, and only
+ * behaviours observable from the write commands alone are covered. Once
+ * Task 10 lands, `document-tree` becomes runnable end to end and is the
+ * authoritative gate; this file is the interim live-database regression
+ * guard for the command half.
+ */
+
+import { type CollectionDefinition, ErrorCodes, TREE_PLACEMENT_STALE_MARKER } from '@byline/core'
+import type mysql from 'mysql2/promise'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { setupTestDB, teardownTestDB } from '../../../lib/test-helper.js'
+
+const timestamp = Date.now()
+
+function first<T>(rows: T[]): T {
+  const row = rows[0]
+  if (row == null) throw new Error('expected at least one row, got none')
+  return row
+}
+
+async function queryRows(pool: mysql.Pool, sql: string, params: unknown[]): Promise<any[]> {
+  const [rows] = await pool.query(sql, params)
+  return rows as any[]
+}
+
+/** Read one ordered sibling group directly from `byline_document_relationships`. */
+async function siblingIds(pool: mysql.Pool, parentDocumentId: string | null): Promise<string[]> {
+  // MySQL's null-safe equality (`<=>`) so `parentDocumentId: null` matches
+  // NULL rows (root siblings) the same way `parent_document_id IS NULL` does.
+  const rows = await queryRows(
+    pool,
+    'SELECT child_document_id FROM byline_document_relationships WHERE parent_document_id <=> ? ORDER BY order_key',
+    [parentDocumentId]
+  )
+  return rows.map((r) => r.child_document_id)
+}
+
+async function edgeRow(pool: mysql.Pool, documentId: string): Promise<any | undefined> {
+  const rows = await queryRows(
+    pool,
+    'SELECT child_document_id, parent_document_id, order_key FROM byline_document_relationships WHERE child_document_id = ?',
+    [documentId]
+  )
+  return rows[0]
+}
+
+const TreeCollectionConfig: CollectionDefinition = {
+  path: `tree-test-${timestamp}`,
+  labels: { singular: 'TreeTest', plural: 'TreeTests' },
+  fields: [{ name: 'title', type: 'text' }],
+}
+
+const OtherCollectionConfig: CollectionDefinition = {
+  path: `tree-other-test-${timestamp}`,
+  labels: { singular: 'TreeOther', plural: 'TreeOthers' },
+  fields: [{ name: 'title', type: 'text' }],
+}
+
+describe('DocumentCommands tree mutations (mysql, live database)', () => {
+  let testDb: ReturnType<typeof setupTestDB>
+  let rawPool: mysql.Pool
+  let treeCollectionId: string
+  let otherCollectionId: string
+
+  async function createDoc(
+    collectionId: string,
+    config: CollectionDefinition,
+    title: string
+  ): Promise<string> {
+    const created = await testDb.commandBuilders.documents.createDocumentVersion({
+      collectionId,
+      collectionVersion: 1,
+      collectionConfig: config,
+      action: 'create',
+      documentData: { title },
+      locale: 'all',
+      status: 'published',
+    })
+    return created.document.document_id
+  }
+
+  beforeAll(async () => {
+    testDb = setupTestDB([TreeCollectionConfig, OtherCollectionConfig])
+    rawPool = testDb.pool
+    treeCollectionId = first(
+      await testDb.commandBuilders.collections.create(
+        TreeCollectionConfig.path,
+        TreeCollectionConfig
+      )
+    ).id
+    otherCollectionId = first(
+      await testDb.commandBuilders.collections.create(
+        OtherCollectionConfig.path,
+        OtherCollectionConfig
+      )
+    ).id
+  })
+
+  afterAll(async () => {
+    await testDb.commandBuilders.collections.delete(treeCollectionId)
+    await testDb.commandBuilders.collections.delete(otherCollectionId)
+    await teardownTestDB()
+  })
+
+  it('places roots and children, ordered per-parent', async () => {
+    const a = await createDoc(treeCollectionId, TreeCollectionConfig, 'Root A')
+    const b = await createDoc(treeCollectionId, TreeCollectionConfig, 'Root B')
+    const c = await createDoc(treeCollectionId, TreeCollectionConfig, 'Child C')
+    const d = await createDoc(treeCollectionId, TreeCollectionConfig, 'Child D')
+
+    await testDb.commandBuilders.documents.placeTreeNode({
+      collectionId: treeCollectionId,
+      documentId: a,
+      parentDocumentId: null,
+    })
+    await testDb.commandBuilders.documents.placeTreeNode({
+      collectionId: treeCollectionId,
+      documentId: b,
+      parentDocumentId: null,
+      beforeDocumentId: a,
+    })
+    expect(await siblingIds(rawPool, null)).toEqual(expect.arrayContaining([a, b]))
+    const roots = await siblingIds(rawPool, null)
+    expect(roots.indexOf(a)).toBeLessThan(roots.indexOf(b))
+
+    await testDb.commandBuilders.documents.placeTreeNode({
+      collectionId: treeCollectionId,
+      documentId: c,
+      parentDocumentId: a,
+    })
+    await testDb.commandBuilders.documents.placeTreeNode({
+      collectionId: treeCollectionId,
+      documentId: d,
+      parentDocumentId: a,
+      beforeDocumentId: c,
+    })
+    expect(await siblingIds(rawPool, a)).toEqual([c, d])
+  })
+
+  it('reorders siblings in place — upsert keeps one row per document', async () => {
+    const a = await createDoc(treeCollectionId, TreeCollectionConfig, 'P A')
+    const x = await createDoc(treeCollectionId, TreeCollectionConfig, 'X')
+    const y = await createDoc(treeCollectionId, TreeCollectionConfig, 'Y')
+    await testDb.commandBuilders.documents.placeTreeNode({
+      collectionId: treeCollectionId,
+      documentId: a,
+      parentDocumentId: null,
+    })
+    await testDb.commandBuilders.documents.placeTreeNode({
+      collectionId: treeCollectionId,
+      documentId: x,
+      parentDocumentId: a,
+    })
+    await testDb.commandBuilders.documents.placeTreeNode({
+      collectionId: treeCollectionId,
+      documentId: y,
+      parentDocumentId: a,
+      beforeDocumentId: x,
+    })
+    expect(await siblingIds(rawPool, a)).toEqual([x, y])
+
+    await testDb.commandBuilders.documents.placeTreeNode({
+      collectionId: treeCollectionId,
+      documentId: y,
+      parentDocumentId: a,
+      afterDocumentId: x,
+    })
+    const kids = await siblingIds(rawPool, a)
+    expect(kids).toEqual([y, x])
+    expect(kids.length).toBe(2) // no duplicate row from the upsert
+  })
+
+  it('rejects a stale target neighbour group as a conflict', async () => {
+    const parentA = await createDoc(treeCollectionId, TreeCollectionConfig, 'Conflict Parent A')
+    const parentB = await createDoc(treeCollectionId, TreeCollectionConfig, 'Conflict Parent B')
+    const neighbour = await createDoc(treeCollectionId, TreeCollectionConfig, 'Conflict Neighbour')
+    const node = await createDoc(treeCollectionId, TreeCollectionConfig, 'Conflict Node')
+
+    await testDb.commandBuilders.documents.placeTreeNode({
+      collectionId: treeCollectionId,
+      documentId: neighbour,
+      parentDocumentId: parentA,
+    })
+    await testDb.commandBuilders.documents.placeTreeNode({
+      collectionId: treeCollectionId,
+      documentId: neighbour,
+      parentDocumentId: parentB,
+    })
+
+    await expect(
+      testDb.commandBuilders.documents.placeTreeNode({
+        collectionId: treeCollectionId,
+        documentId: node,
+        parentDocumentId: parentA,
+        beforeDocumentId: neighbour,
+      })
+    ).rejects.toMatchObject({
+      code: ErrorCodes.CONFLICT,
+      message: expect.stringContaining(TREE_PLACEMENT_STALE_MARKER),
+    })
+  })
+
+  it('allows only one concurrent placement into the same asserted sibling gap', async () => {
+    const parent = await createDoc(treeCollectionId, TreeCollectionConfig, 'Gap Parent')
+    const left = await createDoc(treeCollectionId, TreeCollectionConfig, 'Gap Left')
+    const right = await createDoc(treeCollectionId, TreeCollectionConfig, 'Gap Right')
+    const nodeFirst = await createDoc(treeCollectionId, TreeCollectionConfig, 'Gap First')
+    const nodeSecond = await createDoc(treeCollectionId, TreeCollectionConfig, 'Gap Second')
+
+    await testDb.commandBuilders.documents.placeTreeNode({
+      collectionId: treeCollectionId,
+      documentId: left,
+      parentDocumentId: parent,
+    })
+    await testDb.commandBuilders.documents.placeTreeNode({
+      collectionId: treeCollectionId,
+      documentId: right,
+      parentDocumentId: parent,
+      beforeDocumentId: left,
+    })
+
+    const placeInSameGap = (documentId: string) =>
+      testDb.commandBuilders.documents.placeTreeNode({
+        collectionId: treeCollectionId,
+        documentId,
+        parentDocumentId: parent,
+        beforeDocumentId: left,
+        afterDocumentId: right,
+      })
+    const results = await Promise.allSettled([
+      placeInSameGap(nodeFirst),
+      placeInSameGap(nodeSecond),
+    ])
+
+    const fulfilled = results.filter((r) => r.status === 'fulfilled')
+    const rejected = results.filter((r) => r.status === 'rejected')
+    expect(fulfilled).toHaveLength(1)
+    expect(rejected).toHaveLength(1)
+    expect(rejected[0]).toMatchObject({ reason: { code: ErrorCodes.CONFLICT } })
+
+    const winner = results[0]?.status === 'fulfilled' ? nodeFirst : nodeSecond
+    const loser = winner === nodeFirst ? nodeSecond : nodeFirst
+    expect(await siblingIds(rawPool, parent)).toEqual([left, winner, right])
+    expect(await edgeRow(rawPool, loser)).toBeUndefined() // never placed
+  })
+
+  it('rejects placement when the moving node was deleted after the placement snapshot', async () => {
+    const node = await createDoc(treeCollectionId, TreeCollectionConfig, 'Deleted Moving Node')
+    await testDb.commandBuilders.documents.placeTreeNode({
+      collectionId: treeCollectionId,
+      documentId: node,
+      parentDocumentId: null,
+    })
+    await testDb.commandBuilders.documents.softDeleteDocument({ document_id: node })
+
+    await expect(
+      testDb.commandBuilders.documents.placeTreeNode({
+        collectionId: treeCollectionId,
+        documentId: node,
+        parentDocumentId: null,
+      })
+    ).rejects.toMatchObject({ code: ErrorCodes.CONFLICT })
+  })
+
+  it('rejects a cross-collection neighbour as structural validation', async () => {
+    const parent = await createDoc(
+      treeCollectionId,
+      TreeCollectionConfig,
+      'Foreign Neighbour Parent'
+    )
+    const node = await createDoc(treeCollectionId, TreeCollectionConfig, 'Foreign Neighbour Node')
+    const foreign = await createDoc(otherCollectionId, OtherCollectionConfig, 'Foreign Neighbour')
+
+    await expect(
+      testDb.commandBuilders.documents.placeTreeNode({
+        collectionId: treeCollectionId,
+        documentId: node,
+        parentDocumentId: parent,
+        afterDocumentId: foreign,
+      })
+    ).rejects.toMatchObject({ code: ErrorCodes.VALIDATION })
+  })
+
+  it('rejects a self-parent and a cycle', async () => {
+    const a = await createDoc(treeCollectionId, TreeCollectionConfig, 'CA')
+    const c = await createDoc(treeCollectionId, TreeCollectionConfig, 'CC')
+    await testDb.commandBuilders.documents.placeTreeNode({
+      collectionId: treeCollectionId,
+      documentId: a,
+      parentDocumentId: null,
+    })
+    await testDb.commandBuilders.documents.placeTreeNode({
+      collectionId: treeCollectionId,
+      documentId: c,
+      parentDocumentId: a,
+    })
+
+    await expect(
+      testDb.commandBuilders.documents.placeTreeNode({
+        collectionId: treeCollectionId,
+        documentId: a,
+        parentDocumentId: a,
+      })
+    ).rejects.toThrow()
+
+    // A is C's ancestor, so making A a child of C is a cycle — exercises the
+    // `WITH RECURSIVE chain AS (...)` cycle guard.
+    await expect(
+      testDb.commandBuilders.documents.placeTreeNode({
+        collectionId: treeCollectionId,
+        documentId: a,
+        parentDocumentId: c,
+      })
+    ).rejects.toThrow()
+  })
+
+  it('re-parents atomically — one edge row, updated in place', async () => {
+    const a = await createDoc(treeCollectionId, TreeCollectionConfig, 'RA')
+    const b = await createDoc(treeCollectionId, TreeCollectionConfig, 'RB')
+    const c = await createDoc(treeCollectionId, TreeCollectionConfig, 'RC')
+    await testDb.commandBuilders.documents.placeTreeNode({
+      collectionId: treeCollectionId,
+      documentId: a,
+      parentDocumentId: null,
+    })
+    await testDb.commandBuilders.documents.placeTreeNode({
+      collectionId: treeCollectionId,
+      documentId: b,
+      parentDocumentId: null,
+    })
+    await testDb.commandBuilders.documents.placeTreeNode({
+      collectionId: treeCollectionId,
+      documentId: c,
+      parentDocumentId: a,
+    })
+    expect(await siblingIds(rawPool, a)).toEqual([c])
+
+    await testDb.commandBuilders.documents.placeTreeNode({
+      collectionId: treeCollectionId,
+      documentId: c,
+      parentDocumentId: b,
+    })
+
+    expect(await siblingIds(rawPool, a)).toEqual([])
+    expect(await siblingIds(rawPool, b)).toEqual([c])
+    const edge = await edgeRow(rawPool, c)
+    expect(edge.parent_document_id).toBe(b)
+  })
+
+  it('removeFromTree returns a node to the unplaced state and is idempotent', async () => {
+    const a = await createDoc(treeCollectionId, TreeCollectionConfig, 'UA')
+    const c = await createDoc(treeCollectionId, TreeCollectionConfig, 'UC')
+    await testDb.commandBuilders.documents.placeTreeNode({
+      collectionId: treeCollectionId,
+      documentId: a,
+      parentDocumentId: null,
+    })
+    await testDb.commandBuilders.documents.placeTreeNode({
+      collectionId: treeCollectionId,
+      documentId: c,
+      parentDocumentId: a,
+    })
+    expect(await siblingIds(rawPool, a)).toEqual([c])
+
+    const removed = await testDb.commandBuilders.documents.removeFromTree({
+      collectionId: treeCollectionId,
+      documentId: c,
+    })
+    expect(removed.changed).toBe(true)
+    expect(await siblingIds(rawPool, a)).toEqual([])
+    expect(await edgeRow(rawPool, c)).toBeUndefined()
+
+    // Idempotent — removing an already-unplaced node is a no-op.
+    await expect(
+      testDb.commandBuilders.documents.removeFromTree({
+        collectionId: treeCollectionId,
+        documentId: c,
+      })
+    ).resolves.toMatchObject({ changed: false })
+  })
+
+  it('promoteChildrenAndRemoveFromTree promotes children to root and removes the parent edge', async () => {
+    const parent = await createDoc(treeCollectionId, TreeCollectionConfig, 'Promote Parent')
+    const grandparent = await createDoc(
+      treeCollectionId,
+      TreeCollectionConfig,
+      'Promote Grandparent'
+    )
+    const childOne = await createDoc(treeCollectionId, TreeCollectionConfig, 'Promote Child 1')
+    const childTwo = await createDoc(treeCollectionId, TreeCollectionConfig, 'Promote Child 2')
+
+    await testDb.commandBuilders.documents.placeTreeNode({
+      collectionId: treeCollectionId,
+      documentId: grandparent,
+      parentDocumentId: null,
+    })
+    await testDb.commandBuilders.documents.placeTreeNode({
+      collectionId: treeCollectionId,
+      documentId: parent,
+      parentDocumentId: grandparent,
+    })
+    await testDb.commandBuilders.documents.placeTreeNode({
+      collectionId: treeCollectionId,
+      documentId: childOne,
+      parentDocumentId: parent,
+    })
+    await testDb.commandBuilders.documents.placeTreeNode({
+      collectionId: treeCollectionId,
+      documentId: childTwo,
+      parentDocumentId: parent,
+      beforeDocumentId: childOne,
+    })
+    expect(await siblingIds(rawPool, parent)).toEqual([childOne, childTwo])
+
+    const result = await testDb.commandBuilders.documents.promoteChildrenAndRemoveFromTree({
+      collectionId: treeCollectionId,
+      documentId: parent,
+    })
+    expect(result.removed.changed).toBe(true)
+    expect(result.promoted.map((p) => p.documentId).sort()).toEqual([childOne, childTwo].sort())
+
+    // Parent edge gone; both children now root-level (parent_document_id NULL).
+    expect(await edgeRow(rawPool, parent)).toBeUndefined()
+    const oneEdge = await edgeRow(rawPool, childOne)
+    const twoEdge = await edgeRow(rawPool, childTwo)
+    expect(oneEdge.parent_document_id).toBeNull()
+    expect(twoEdge.parent_document_id).toBeNull()
+
+    // No longer children of the (now-removed) parent edge.
+    expect(await siblingIds(rawPool, parent)).toEqual([])
+  })
+})

--- a/packages/db-mysql/src/modules/storage/tests/storage-queries.test.ts
+++ b/packages/db-mysql/src/modules/storage/tests/storage-queries.test.ts
@@ -75,6 +75,27 @@ const OrderingPaginationCollectionConfig: CollectionDefinition = {
   fields: [{ name: 'title', type: 'text' }],
 }
 
+const AuthorsCollectionConfig: CollectionDefinition = {
+  path: `queries-test-authors-${timestamp}`,
+  labels: { singular: 'Author', plural: 'Authors' },
+  fields: [{ name: 'name', type: 'text' }],
+}
+
+const PostsCollectionConfig: CollectionDefinition = {
+  path: `queries-test-posts-${timestamp}`,
+  labels: { singular: 'Post', plural: 'Posts' },
+  fields: [
+    { name: 'title', type: 'text' },
+    { name: 'views', type: 'integer', optional: true },
+    {
+      name: 'author',
+      type: 'relation',
+      targetCollection: `queries-test-authors-${timestamp}`,
+      optional: true,
+    },
+  ],
+}
+
 describe('DocumentQueries.getDocumentById locale-chain path resolution (mysql, live database)', () => {
   let testDb: ReturnType<typeof setupTestDB>
   let collectionId: string
@@ -167,9 +188,8 @@ describe('findDocuments ordering and pagination (mysql, live database)', () => {
     testDb = setupTestDB([OrderKeyCollectionConfig, OrderingPaginationCollectionConfig])
   })
 
-  afterAll(async () => {
-    await teardownTestDB()
-  })
+  // `teardownTestDB()` is called once, at the very end of this file (see the
+  // last describe block below) — not here.
 
   async function createDoc(
     collectionId: string,
@@ -374,5 +394,254 @@ describe('findDocuments ordering and pagination (mysql, live database)', () => {
       expect(pageBeyond.total).toBe(total)
       expect(pageBeyond.documents).toEqual([])
     })
+  })
+})
+
+/**
+ * `findDocuments`' predicate compiler and the LATERAL field-sort join —
+ * none of the eleven registered `@byline/db-conformance` suites exercise
+ * the `$and`/`$or` combinators, a relation hop, `pathFilter`, `query`
+ * (LIKE search), or `sort` through `findDocuments` directly (the
+ * document-tree suite's `filters` only reach a plain field filter via
+ * `buildTreeVisibility`; `@byline/client`'s own combinator/relation-filter
+ * integration suite is pg-only — see `packages/client/tests/fixtures/
+ * setup.ts`). This describe block is this port's own live-database proof
+ * for that surface, mirroring the values-not-just-compiles standard the
+ * rest of this file already applies to `pathProjection`/`buildDocumentOrderClause`.
+ */
+describe('findDocuments filters, combinators, relation hops, search, and sort (mysql, live database)', () => {
+  let testDb: ReturnType<typeof setupTestDB>
+  let authorsCollectionId: string
+  let postsCollectionId: string
+  let adaId: string
+  let graceId: string
+  let post1: string // by Ada, views 10, title "First post"
+  let post2: string // by Grace, views 20, title "Second post"
+  let post3: string // by Ada, no views (NULL), title "Ünïcödé Post" (accents, mixed case)
+
+  beforeAll(async () => {
+    testDb = setupTestDB([AuthorsCollectionConfig, PostsCollectionConfig])
+    authorsCollectionId = first(
+      await testDb.commandBuilders.collections.create(
+        AuthorsCollectionConfig.path,
+        AuthorsCollectionConfig
+      )
+    ).id
+    postsCollectionId = first(
+      await testDb.commandBuilders.collections.create(
+        PostsCollectionConfig.path,
+        PostsCollectionConfig
+      )
+    ).id
+
+    async function createAuthor(name: string): Promise<string> {
+      const created = await testDb.commandBuilders.documents.createDocumentVersion({
+        collectionId: authorsCollectionId,
+        collectionVersion: 1,
+        collectionConfig: AuthorsCollectionConfig,
+        action: 'create',
+        documentData: { name },
+        path: `${name.toLowerCase()}-${timestamp}`,
+        locale: 'en',
+        status: 'published',
+      })
+      return created.document.document_id
+    }
+    async function createPost(
+      title: string,
+      views: number | undefined,
+      authorId: string,
+      path: string
+    ): Promise<string> {
+      const created = await testDb.commandBuilders.documents.createDocumentVersion({
+        collectionId: postsCollectionId,
+        collectionVersion: 1,
+        collectionConfig: PostsCollectionConfig,
+        action: 'create',
+        documentData: {
+          title,
+          ...(views !== undefined ? { views } : {}),
+          author: { targetDocumentId: authorId, targetCollectionId: authorsCollectionId },
+        },
+        path,
+        locale: 'en',
+        status: 'published',
+      })
+      return created.document.document_id
+    }
+
+    adaId = await createAuthor('Ada')
+    graceId = await createAuthor('Grace')
+    post1 = await createPost('First post', 10, adaId, `first-post-${timestamp}`)
+    await sleep(5)
+    post2 = await createPost('Second post', 20, graceId, `second-post-${timestamp}`)
+    await sleep(5)
+    post3 = await createPost('Ünïcödé Post', undefined, adaId, `unicode-post-${timestamp}`)
+  })
+
+  afterAll(async () => {
+    await teardownTestDB()
+  })
+
+  it('$or combinator: matches either field-filter branch', async () => {
+    const result = await testDb.queryBuilders.documents.findDocuments({
+      collection_id: postsCollectionId,
+      locale: 'en',
+      filters: [
+        {
+          kind: 'or',
+          children: [
+            {
+              kind: 'field',
+              fieldName: 'title',
+              storeType: 'text',
+              valueColumn: 'value',
+              operator: '$eq',
+              value: 'First post',
+            },
+            {
+              kind: 'field',
+              fieldName: 'title',
+              storeType: 'text',
+              valueColumn: 'value',
+              operator: '$eq',
+              value: 'Second post',
+            },
+          ],
+        },
+      ],
+    })
+    expect(new Set(result.documents.map((d) => d.document_id))).toEqual(new Set([post1, post2]))
+    expect(result.total).toBe(2)
+  })
+
+  it('$and combinator wrapping a docColumn(status) filter: intersects with a field filter', async () => {
+    const result = await testDb.queryBuilders.documents.findDocuments({
+      collection_id: postsCollectionId,
+      locale: 'en',
+      filters: [
+        {
+          kind: 'and',
+          children: [
+            { kind: 'docColumn', column: 'status', operator: '$eq', value: 'published' },
+            {
+              kind: 'field',
+              fieldName: 'title',
+              storeType: 'text',
+              valueColumn: 'value',
+              operator: '$eq',
+              value: 'First post',
+            },
+          ],
+        },
+      ],
+    })
+    expect(result.documents.map((d) => d.document_id)).toEqual([post1])
+  })
+
+  it('relation hop: finds posts whose author matches a nested field filter', async () => {
+    const result = await testDb.queryBuilders.documents.findDocuments({
+      collection_id: postsCollectionId,
+      locale: 'en',
+      filters: [
+        {
+          kind: 'relation',
+          fieldName: 'author',
+          targetCollectionId: authorsCollectionId,
+          nested: [
+            {
+              kind: 'field',
+              fieldName: 'name',
+              storeType: 'text',
+              valueColumn: 'value',
+              operator: '$eq',
+              value: 'Ada',
+            },
+          ],
+        },
+      ],
+    })
+    expect(new Set(result.documents.map((d) => d.document_id))).toEqual(new Set([post1, post3]))
+  })
+
+  it('relation hop with quantifier "none": finds posts NOT authored by Ada', async () => {
+    const result = await testDb.queryBuilders.documents.findDocuments({
+      collection_id: postsCollectionId,
+      locale: 'en',
+      filters: [
+        {
+          kind: 'relation',
+          fieldName: 'author',
+          targetCollectionId: authorsCollectionId,
+          quantifier: 'none',
+          nested: [
+            {
+              kind: 'field',
+              fieldName: 'name',
+              storeType: 'text',
+              valueColumn: 'value',
+              operator: '$eq',
+              value: 'Ada',
+            },
+          ],
+        },
+      ],
+    })
+    expect(result.documents.map((d) => d.document_id)).toEqual([post2])
+  })
+
+  it('pathFilter: matches an exact document path', async () => {
+    const result = await testDb.queryBuilders.documents.findDocuments({
+      collection_id: postsCollectionId,
+      locale: 'en',
+      pathFilter: { operator: '$eq', value: `first-post-${timestamp}` },
+    })
+    expect(result.documents.map((d) => d.document_id)).toEqual([post1])
+  })
+
+  it('query (LIKE admin search): matches case- and accent-insensitively — the elected ILIKE→LIKE divergence', async () => {
+    // "unicode post" (lowercase, unaccented) must still match "Ünïcödé Post"
+    // — utf8mb4_0900_ai_ci (the store `value` column's collation) folds both
+    // case and diacritics, a strictly wider match than pg's case-only ILIKE.
+    // This is the divergence documented at `findDocuments`' query-search site
+    // and `buildFilterCondition`'s `$contains` branch — pinned here against a
+    // real accented row rather than just asserted in a comment.
+    const result = await testDb.queryBuilders.documents.findDocuments({
+      collection_id: postsCollectionId,
+      locale: 'en',
+      query: 'unicode post',
+    })
+    expect(result.documents.map((d) => d.document_id)).toEqual([post3])
+  })
+
+  it('sort: LEFT JOIN LATERAL field sort on a numeric column, NULLS-last both directions', async () => {
+    // post1 views=10, post2 views=20, post3 views=NULL.
+    const asc = await testDb.queryBuilders.documents.findDocuments({
+      collection_id: postsCollectionId,
+      locale: 'en',
+      sort: {
+        fieldName: 'views',
+        storeType: 'numeric',
+        valueColumn: 'value_integer',
+        direction: 'asc',
+      },
+    })
+    // Ascending: real values first (10, 20), NULL last — the `(col IS NULL)
+    // ASC, col ASC` emulation this pins (MySQL's native ASC sorts NULL first).
+    expect(asc.documents.map((d) => d.document_id)).toEqual([post1, post2, post3])
+
+    const desc = await testDb.queryBuilders.documents.findDocuments({
+      collection_id: postsCollectionId,
+      locale: 'en',
+      sort: {
+        fieldName: 'views',
+        storeType: 'numeric',
+        valueColumn: 'value_integer',
+        direction: 'desc',
+      },
+    })
+    // Descending: MySQL's native DESC already sorts NULL last — no emulation
+    // needed, confirmed here rather than just asserted.
+    expect(desc.documents.map((d) => d.document_id)).toEqual([post2, post1, post3])
   })
 })

--- a/packages/db-mysql/src/modules/storage/tests/storage-queries.test.ts
+++ b/packages/db-mysql/src/modules/storage/tests/storage-queries.test.ts
@@ -1,0 +1,120 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+/**
+ * Live-database verification of `DocumentQueries.getDocumentById`'s locale
+ * priority chain (Task 10A) — specifically `pathProjection`'s conversion of
+ * pg's `ANY(ARRAY[...])` + `array_position(...)` locale-chain resolution to
+ * MySQL's `IN (...)` + `ORDER BY FIELD(...)`.
+ *
+ * The `@byline/db-conformance` `versioning`/`field-types` suites this task
+ * turns green never exercise a document with more than one
+ * `byline_document_paths` row, so they can't distinguish "picks the only
+ * matching row" from "picks the *highest-priority* matching row when
+ * several match" — this file pins the latter directly, per the Task 10A
+ * brief's requirement to verify (not assume) that `FIELD()`'s ordering
+ * semantics match `array_position`'s.
+ */
+
+import type { CollectionDefinition } from '@byline/core'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { setupTestDB, teardownTestDB } from '../../../lib/test-helper.js'
+
+const timestamp = Date.now()
+
+function first<T>(rows: T[]): T {
+  const row = rows[0]
+  if (row == null) throw new Error('expected at least one row, got none')
+  return row
+}
+
+const PagesCollectionConfig: CollectionDefinition = {
+  path: `queries-test-pages-${timestamp}`,
+  labels: { singular: 'Page', plural: 'Pages' },
+  fields: [{ name: 'title', type: 'text' }],
+}
+
+describe('DocumentQueries.getDocumentById locale-chain path resolution (mysql, live database)', () => {
+  let testDb: ReturnType<typeof setupTestDB>
+  let collectionId: string
+
+  beforeAll(async () => {
+    // setupTestDB's defaultContentLocale is 'en' (see test-helper.ts).
+    testDb = setupTestDB([PagesCollectionConfig])
+    const created = first(
+      await testDb.commandBuilders.collections.create(
+        PagesCollectionConfig.path,
+        PagesCollectionConfig
+      )
+    )
+    collectionId = created.id
+  })
+
+  afterAll(async () => {
+    await testDb.commandBuilders.collections.delete(collectionId)
+    await teardownTestDB()
+  })
+
+  it('prioritises the requested locale over the source-locale floor when both have a path row (FIELD() ordering)', async () => {
+    const enPath = `en-path-${timestamp}`
+    const frPath = `fr-path-${timestamp}`
+
+    const created = await testDb.commandBuilders.documents.createDocumentVersion({
+      collectionId,
+      collectionVersion: 1,
+      collectionConfig: PagesCollectionConfig,
+      action: 'create',
+      documentData: { title: 'Locale chain doc' },
+      path: enPath,
+      locale: 'en',
+      status: 'draft',
+    })
+    const documentId = created.document.document_id
+
+    // Add a second path row in a different locale for the same document —
+    // now `byline_document_paths` has two rows: source_locale ('en') and 'fr'.
+    await testDb.commandBuilders.documents.updateDocumentPath({
+      documentId,
+      collectionId,
+      locale: 'fr',
+      path: frPath,
+    })
+
+    // Requesting 'fr' directly: chain = ['fr', 'en'] (requested, then the
+    // floor). Both rows are candidates — FIELD() must rank 'fr' first,
+    // exactly like pg's array_position ranks the requested locale first.
+    const frDoc = await testDb.queryBuilders.documents.getDocumentById({
+      collection_id: collectionId,
+      document_id: documentId,
+      locale: 'fr',
+    })
+    expect(frDoc?.path).toBe(frPath)
+
+    // Requesting a third, unrelated locale ('es'): chain = ['es', 'en'].
+    // Neither row is 'es', so the `WHERE locale IN (chain)` filter alone
+    // (not FIELD()'s ordering) must exclude the irrelevant 'fr' row and land
+    // on the source-locale floor, 'en'.
+    const esDoc = await testDb.queryBuilders.documents.getDocumentById({
+      collection_id: collectionId,
+      document_id: documentId,
+      locale: 'es',
+    })
+    expect(esDoc?.path).toBe(enPath)
+
+    // Requesting 'en' directly: chain collapses to a single-element chain
+    // (`buildLocaleChain` dedupes requested === floor). Sanity check that
+    // this degenerate case still resolves correctly.
+    const enDoc = await testDb.queryBuilders.documents.getDocumentById({
+      collection_id: collectionId,
+      document_id: documentId,
+      locale: 'en',
+    })
+    expect(enDoc?.path).toBe(enPath)
+  })
+})

--- a/packages/db-mysql/src/modules/storage/tests/storage-queries.test.ts
+++ b/packages/db-mysql/src/modules/storage/tests/storage-queries.test.ts
@@ -96,6 +96,13 @@ const PostsCollectionConfig: CollectionDefinition = {
   ],
 }
 
+const DeepTreeCollectionConfig: CollectionDefinition = {
+  path: `queries-test-deep-tree-${timestamp}`,
+  labels: { singular: 'Node', plural: 'Nodes' },
+  fields: [{ name: 'title', type: 'text' }],
+  tree: true,
+}
+
 describe('DocumentQueries.getDocumentById locale-chain path resolution (mysql, live database)', () => {
   let testDb: ReturnType<typeof setupTestDB>
   let collectionId: string
@@ -479,9 +486,8 @@ describe('findDocuments filters, combinators, relation hops, search, and sort (m
     post3 = await createPost('Ünïcödé Post', undefined, adaId, `unicode-post-${timestamp}`)
   })
 
-  afterAll(async () => {
-    await teardownTestDB()
-  })
+  // `teardownTestDB()` is called once, at the very end of this file (see the
+  // last describe block below) — not here.
 
   it('$or combinator: matches either field-filter branch', async () => {
     const result = await testDb.queryBuilders.documents.findDocuments({
@@ -643,5 +649,120 @@ describe('findDocuments filters, combinators, relation hops, search, and sort (m
     // Descending: MySQL's native DESC already sorts NULL last — no emulation
     // needed, confirmed here rather than just asserted.
     expect(desc.documents.map((d) => d.document_id)).toEqual([post2, post1, post3])
+  })
+})
+
+/**
+ * `getTreeSubtree`'s recursive CTE `path` column — a live-database
+ * regression pin for the fix reviewed in the Task 10B fix round.
+ *
+ * MySQL infers a recursive CTE's column types from the non-recursive
+ * (anchor) leg only. The anchor's `path` column started life as a bare
+ * `r.order_key` reference, which made it inherit `order_key`'s declared
+ * `varchar(128)` width — every recursive iteration's `CONCAT` was then
+ * silently constrained to 128 bytes, and this database's `sql_mode`
+ * (`STRICT_TRANS_TABLES`) turns that into a hard `ER_DATA_TOO_LONG` rather
+ * than silent truncation. `documentTreeSuite`'s 20 tests all build shallow
+ * trees (a handful of levels), so none of them reach the threshold —
+ * `Σ len(order_key) + depth − 1 > 128`, roughly 11–40 levels for typical
+ * fractional-index keys. This describe block builds a straight-line chain
+ * deep enough to guarantee crossing that threshold and asserts the subtree
+ * comes back correctly ordered, not merely that it doesn't throw.
+ *
+ * Not added to `@byline/db-conformance`'s shared `document-tree` suite —
+ * this is a MySQL-only regression (Postgres's `::text` cast has no width
+ * cap), and per the fix-round instruction, the shared suite stays
+ * untouched.
+ */
+describe('getTreeSubtree deep path width (mysql, live database)', () => {
+  let testDb: ReturnType<typeof setupTestDB>
+  let collectionId: string
+  // 60 single-child levels: each level's order_key is the fractional-index
+  // library's first-in-an-empty-group key ('a0', 2 bytes), so the
+  // accumulated path is `a0/a0/a0/…` — 60 * 3 - 1 = 179 bytes, comfortably
+  // past the 128-byte threshold that reproduced ER_DATA_TOO_LONG before the
+  // fix (and still comfortably under this fix's 4096-byte cast width).
+  const depth = 60
+  let chain: string[] = []
+
+  beforeAll(async () => {
+    testDb = setupTestDB([DeepTreeCollectionConfig])
+    collectionId = first(
+      await testDb.commandBuilders.collections.create(
+        DeepTreeCollectionConfig.path,
+        DeepTreeCollectionConfig
+      )
+    ).id
+
+    chain = []
+    for (let i = 0; i < depth; i++) {
+      const created = await testDb.commandBuilders.documents.createDocumentVersion({
+        collectionId,
+        collectionVersion: 1,
+        collectionConfig: DeepTreeCollectionConfig,
+        action: 'create',
+        documentData: { title: `node-${i}` },
+        path: `deep-tree-node-${i}-${timestamp}`,
+        locale: 'en',
+        status: 'published',
+      })
+      chain.push(created.document.document_id)
+    }
+
+    // Place as a single-child chain: chain[0] is root, chain[1] is its only
+    // child, chain[2] is chain[1]'s only child, and so on. Each placement
+    // targets a brand-new (empty) sibling group, so every level mints the
+    // same short 'a0' key via the fractional-index library's empty-group
+    // default — the worst case for path growth (no width saved by longer
+    // keys pushing the depth threshold down, but also none saved by very
+    // short keys pushing it up beyond what's realistic in practice).
+    for (let i = 0; i < depth; i++) {
+      await testDb.commandBuilders.documents.placeTreeNode({
+        collectionId,
+        documentId: chain[i] as string,
+        parentDocumentId: i === 0 ? null : (chain[i - 1] as string),
+      })
+    }
+  })
+
+  afterAll(async () => {
+    await testDb.commandBuilders.collections.delete(collectionId)
+    await teardownTestDB()
+  })
+
+  it('returns a 60-level single-child chain, correctly ordered, without ER_DATA_TOO_LONG', async () => {
+    const subtree = await testDb.queryBuilders.documents.getTreeSubtree({
+      collectionId,
+      rootDocumentId: null,
+    })
+    // Correctness, not just "didn't throw": exact count, exact document
+    // order (root-to-leaf, since it's a single-child chain), and exact
+    // depth per node.
+    expect(subtree.length).toBe(depth)
+    expect(subtree.map((n) => n.document_id)).toEqual(chain)
+    expect(subtree.map((n) => n.depth)).toEqual(Array.from({ length: depth }, (_, i) => i))
+    expect(subtree[0]?.parent_document_id).toBeNull()
+    for (let i = 1; i < depth; i++) {
+      expect(subtree[i]?.parent_document_id).toBe(chain[i - 1])
+    }
+  })
+
+  it('getTreeAncestors on the deepest leaf walks the full 59-ancestor chain root-first', async () => {
+    // The fixed-width uuidChar columns getTreeAncestors accumulates were
+    // never at risk (see the fix-round docblock), but this pins the deep
+    // case end to end alongside the subtree fix, using the same fixture.
+    const leaf = chain[depth - 1] as string
+    const ancestors = await testDb.queryBuilders.documents.getTreeAncestors({
+      document_id: leaf,
+    })
+    expect(ancestors.length).toBe(depth - 1)
+    // Root-first (`ORDER BY depth DESC`): chain[0] (the root) has the
+    // highest depth value (depth-1) and comes first; chain[depth-2] (the
+    // immediate parent) has depth 1 and comes last. `chain.slice(0,
+    // depth-1)` is already root-to-immediate-parent order, so no reverse.
+    expect(ancestors.map((a) => a.document_id)).toEqual(chain.slice(0, depth - 1))
+    expect(ancestors.map((a) => a.depth)).toEqual(
+      Array.from({ length: depth - 1 }, (_, i) => depth - 1 - i)
+    )
   })
 })

--- a/packages/db-mysql/src/modules/storage/tests/storage-queries.test.ts
+++ b/packages/db-mysql/src/modules/storage/tests/storage-queries.test.ts
@@ -47,11 +47,12 @@ function first<T>(rows: T[]): T {
 }
 
 /**
- * DATETIME(3) is millisecond-precision, and back-to-back inserts in a tight
- * loop can otherwise land in the same millisecond, making a `created_at`-
+ * `created_at` is `DATETIME(6)` (microsecond precision — see `common.ts`'s
+ * `auditTimestamp` docblock), but back-to-back inserts in a tight loop can
+ * still in principle land close enough together to make a `created_at`-
  * ordered (or `created_at`-tiebreaking) assertion flaky. A short delay
  * between creates keeps `created_at` strictly increasing and the expected
- * order deterministic.
+ * order deterministic, independent of how fine the column's own resolution is.
  */
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))

--- a/packages/db-mysql/src/modules/storage/tests/storage-queries.test.ts
+++ b/packages/db-mysql/src/modules/storage/tests/storage-queries.test.ts
@@ -184,6 +184,95 @@ describe('DocumentQueries.getDocumentById locale-chain path resolution (mysql, l
   })
 })
 
+const DatesCollectionConfig: CollectionDefinition = {
+  path: `queries-test-dates-${timestamp}`,
+  labels: { singular: 'DatedThing', plural: 'DatedThings' },
+  fields: [
+    { name: 'title', type: 'text' },
+    { name: 'onDate', type: 'date' },
+    { name: 'atTime', type: 'datetime' },
+  ],
+}
+
+/**
+ * `date`/`datetime` field-type values round-trip as real `Date` objects
+ * through the ordinary `getDocumentById` read path — i.e. through
+ * `getAllFieldValuesForMultipleVersions`'s raw `db.execute(sql\`...\`)` UNION
+ * ALL and `normalizeRow`'s coercion. Task 11's audit-log fix
+ * (`audit-queries.ts`) found that drizzle-orm's mysql2 driver returns
+ * `DATE`/`DATETIME` columns as strings on that code path regardless of the
+ * pool's own `timezone` option; `normalizeRow` picked up the same defect for
+ * `value_date`/`value_timestamp_tz` — this is the live, end-to-end pin for
+ * that fix (`normalize-row.test.node.ts` pins the unit separately). No
+ * existing suite exercised a `date`/`datetime` field through this path, so
+ * nothing caught the un-coerced string before this test.
+ */
+describe('date/datetime field values are real Date objects on read (mysql, live database)', () => {
+  let testDb: ReturnType<typeof setupTestDB>
+  let collectionId: string
+
+  beforeAll(async () => {
+    testDb = setupTestDB([DatesCollectionConfig])
+    const created = first(
+      await testDb.commandBuilders.collections.create(
+        DatesCollectionConfig.path,
+        DatesCollectionConfig
+      )
+    )
+    collectionId = created.id
+  })
+
+  afterAll(async () => {
+    await testDb.commandBuilders.collections.delete(collectionId)
+  })
+
+  it('returns value_date as a Date (UTC midnight for the stored calendar date)', async () => {
+    const onDate = new Date('2026-01-15T00:00:00.000Z')
+    const created = await testDb.commandBuilders.documents.createDocumentVersion({
+      collectionId,
+      collectionVersion: 1,
+      collectionConfig: DatesCollectionConfig,
+      action: 'create',
+      documentData: { title: 'Dated', onDate },
+      locale: 'all',
+      status: 'draft',
+    })
+
+    const doc = await testDb.queryBuilders.documents.getDocumentById({
+      collection_id: collectionId,
+      document_id: created.document.document_id,
+      locale: 'all',
+    })
+
+    const onDateValue = doc?.fields?.onDate
+    expect(onDateValue).toBeInstanceOf(Date)
+    expect((onDateValue as Date).toISOString()).toBe('2026-01-15T00:00:00.000Z')
+  })
+
+  it('returns value_timestamp_tz as a Date with full instant fidelity', async () => {
+    const atTime = new Date('2026-01-15T10:30:00.123Z')
+    const created = await testDb.commandBuilders.documents.createDocumentVersion({
+      collectionId,
+      collectionVersion: 1,
+      collectionConfig: DatesCollectionConfig,
+      action: 'create',
+      documentData: { title: 'Timed', atTime },
+      locale: 'all',
+      status: 'draft',
+    })
+
+    const doc = await testDb.queryBuilders.documents.getDocumentById({
+      collection_id: collectionId,
+      document_id: created.document.document_id,
+      locale: 'all',
+    })
+
+    const atTimeValue = doc?.fields?.atTime
+    expect(atTimeValue).toBeInstanceOf(Date)
+    expect((atTimeValue as Date).toISOString()).toBe('2026-01-15T10:30:00.123Z')
+  })
+})
+
 describe('findDocuments ordering and pagination (mysql, live database)', () => {
   let testDb: ReturnType<typeof setupTestDB>
 

--- a/packages/db-mysql/src/modules/storage/tests/storage-queries.test.ts
+++ b/packages/db-mysql/src/modules/storage/tests/storage-queries.test.ts
@@ -7,18 +7,30 @@
  */
 
 /**
- * Live-database verification of `DocumentQueries.getDocumentById`'s locale
- * priority chain (Task 10A) — specifically `pathProjection`'s conversion of
- * pg's `ANY(ARRAY[...])` + `array_position(...)` locale-chain resolution to
- * MySQL's `IN (...)` + `ORDER BY FIELD(...)`.
+ * Live-database verification of two `DocumentQueries` read paths that the
+ * `@byline/db-conformance` `versioning`/`field-types` suites (Task 10A's
+ * gate) can't distinguish from an easier, coincidentally-correct case:
  *
- * The `@byline/db-conformance` `versioning`/`field-types` suites this task
- * turns green never exercise a document with more than one
- * `byline_document_paths` row, so they can't distinguish "picks the only
- * matching row" from "picks the *highest-priority* matching row when
- * several match" — this file pins the latter directly, per the Task 10A
- * brief's requirement to verify (not assume) that `FIELD()`'s ordering
- * semantics match `array_position`'s.
+ *   - `getDocumentById`'s locale priority chain — `pathProjection`'s
+ *     conversion of pg's `ANY(ARRAY[...])` + `array_position(...)` to
+ *     MySQL's `IN (...)` + `ORDER BY FIELD(...)`. The gating suites never
+ *     give a document more than one `byline_document_paths` row, so they
+ *     can't tell "picks the only matching row" from "picks the
+ *     *highest-priority* matching row when several match."
+ *   - `findDocuments`' `buildDocumentOrderClause` and pagination — ported
+ *     as part of Task 10A's `findDocuments` (see that method's docblock),
+ *     but exercised by neither gating suite (both call `findDocuments` with
+ *     only `collection_id`/`locale`/`fields`, no `orderBy`/`page`/
+ *     `pageSize`). The `order_key` `ASC` branch in particular emulates
+ *     Postgres's explicit `NULLS LAST` (see pg's
+ *     `storage-queries.ts:2412-2416` — `NULLS LAST` on *both* directions)
+ *     against MySQL's native default, which is the *opposite* of Postgres's
+ *     per direction: MySQL's own `DESC` already sorts NULL last (no
+ *     emulation needed, confirmed live), but MySQL's own `ASC` sorts NULL
+ *     *first* (the emulation idiom `(col IS NULL) ASC, col ASC` is
+ *     required). Untested dialect-emulation logic is exactly the kind of
+ *     thing that silently diverges, so this file pins both directions
+ *     against real NULL/non-NULL rows.
  */
 
 import type { CollectionDefinition } from '@byline/core'
@@ -34,9 +46,32 @@ function first<T>(rows: T[]): T {
   return row
 }
 
+/**
+ * DATETIME(3) is millisecond-precision, and back-to-back inserts in a tight
+ * loop can otherwise land in the same millisecond, making a `created_at`-
+ * ordered (or `created_at`-tiebreaking) assertion flaky. A short delay
+ * between creates keeps `created_at` strictly increasing and the expected
+ * order deterministic.
+ */
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
 const PagesCollectionConfig: CollectionDefinition = {
   path: `queries-test-pages-${timestamp}`,
   labels: { singular: 'Page', plural: 'Pages' },
+  fields: [{ name: 'title', type: 'text' }],
+}
+
+const OrderKeyCollectionConfig: CollectionDefinition = {
+  path: `queries-test-orderkey-${timestamp}`,
+  labels: { singular: 'Item', plural: 'Items' },
+  fields: [{ name: 'title', type: 'text' }],
+}
+
+const OrderingPaginationCollectionConfig: CollectionDefinition = {
+  path: `queries-test-ordering-${timestamp}`,
+  labels: { singular: 'Item', plural: 'Items' },
   fields: [{ name: 'title', type: 'text' }],
 }
 
@@ -57,8 +92,10 @@ describe('DocumentQueries.getDocumentById locale-chain path resolution (mysql, l
   })
 
   afterAll(async () => {
+    // `teardownTestDB()` is called once, at the very end of this file (see
+    // the last describe block below) — closing the shared pool here would
+    // pull it out from under the ordering/pagination describes that follow.
     await testDb.commandBuilders.collections.delete(collectionId)
-    await teardownTestDB()
   })
 
   it('prioritises the requested locale over the source-locale floor when both have a path row (FIELD() ordering)', async () => {
@@ -116,5 +153,226 @@ describe('DocumentQueries.getDocumentById locale-chain path resolution (mysql, l
       locale: 'en',
     })
     expect(enDoc?.path).toBe(enPath)
+  })
+})
+
+describe('findDocuments ordering and pagination (mysql, live database)', () => {
+  let testDb: ReturnType<typeof setupTestDB>
+
+  beforeAll(() => {
+    // Both collections used by the nested describes below are declared
+    // upfront so `DocumentQueries.getDefinitionForCollection` can resolve
+    // either one's `CollectionDefinition` off this single `queryBuilders`
+    // instance — see `setupTestDB`'s doc comment.
+    testDb = setupTestDB([OrderKeyCollectionConfig, OrderingPaginationCollectionConfig])
+  })
+
+  afterAll(async () => {
+    await teardownTestDB()
+  })
+
+  async function createDoc(
+    collectionId: string,
+    config: CollectionDefinition,
+    title: string,
+    path: string
+  ): Promise<string> {
+    const created = await testDb.commandBuilders.documents.createDocumentVersion({
+      collectionId,
+      collectionVersion: 1,
+      collectionConfig: config,
+      action: 'create',
+      documentData: { title },
+      path,
+      locale: 'en',
+      status: 'draft',
+    })
+    return created.document.document_id
+  }
+
+  describe('order_key ordering — NULLS-last emulation', () => {
+    let collectionId: string
+    let doc1: string
+    let doc2: string
+    let doc3: string
+    let doc4: string
+
+    beforeAll(async () => {
+      const created = first(
+        await testDb.commandBuilders.collections.create(
+          OrderKeyCollectionConfig.path,
+          OrderKeyCollectionConfig
+        )
+      )
+      collectionId = created.id
+
+      // doc1/doc2 get an order_key; doc3/doc4 stay unkeyed (NULL). Created
+      // sequentially with a short delay so the NULL rows' `created_at`
+      // tiebreak (newest-first) is deterministic.
+      doc1 = await createDoc(
+        collectionId,
+        OrderKeyCollectionConfig,
+        'keyed-1',
+        `keyed-1-${timestamp}`
+      )
+      await sleep(5)
+      doc2 = await createDoc(
+        collectionId,
+        OrderKeyCollectionConfig,
+        'keyed-2',
+        `keyed-2-${timestamp}`
+      )
+      await sleep(5)
+      doc3 = await createDoc(
+        collectionId,
+        OrderKeyCollectionConfig,
+        'unkeyed-3',
+        `unkeyed-3-${timestamp}`
+      )
+      await sleep(5)
+      doc4 = await createDoc(
+        collectionId,
+        OrderKeyCollectionConfig,
+        'unkeyed-4',
+        `unkeyed-4-${timestamp}`
+      )
+
+      await testDb.commandBuilders.documents.setOrderKey({ document_id: doc1, order_key: '1' })
+      await testDb.commandBuilders.documents.setOrderKey({ document_id: doc2, order_key: '2' })
+    })
+
+    afterAll(async () => {
+      await testDb.commandBuilders.collections.delete(collectionId)
+    })
+
+    it('ascending: keyed rows first in key order, unkeyed rows last (MySQL ASC sorts NULL first natively — the emulation this pins)', async () => {
+      const result = await testDb.queryBuilders.documents.findDocuments({
+        collection_id: collectionId,
+        locale: 'en',
+        orderBy: 'order_key',
+        orderDirection: 'asc',
+      })
+      // doc1 ('1') < doc2 ('2') ascending; doc3/doc4 (NULL) sort last, tied
+      // on order_key so the `created_at DESC` secondary column decides —
+      // doc4 (created after doc3) comes first.
+      expect(result.documents.map((d) => d.document_id)).toEqual([doc1, doc2, doc4, doc3])
+    })
+
+    it('descending: keyed rows first in reverse key order, unkeyed rows still last (MySQL DESC already sorts NULL last natively — no emulation needed)', async () => {
+      const result = await testDb.queryBuilders.documents.findDocuments({
+        collection_id: collectionId,
+        locale: 'en',
+        orderBy: 'order_key',
+        orderDirection: 'desc',
+      })
+      // doc2 ('2') > doc1 ('1') descending; doc3/doc4 (NULL) still sort
+      // last, same created_at DESC tiebreak as the ascending case.
+      expect(result.documents.map((d) => d.document_id)).toEqual([doc2, doc1, doc4, doc3])
+    })
+  })
+
+  describe('document-column ordering and pagination', () => {
+    let collectionId: string
+    let docIds: string[] = []
+
+    beforeAll(async () => {
+      const created = first(
+        await testDb.commandBuilders.collections.create(
+          OrderingPaginationCollectionConfig.path,
+          OrderingPaginationCollectionConfig
+        )
+      )
+      collectionId = created.id
+
+      docIds = []
+      for (let i = 0; i < 5; i++) {
+        docIds.push(
+          await createDoc(
+            collectionId,
+            OrderingPaginationCollectionConfig,
+            `col-${i}`,
+            `col-${i}-${timestamp}`
+          )
+        )
+        await sleep(5)
+      }
+    })
+
+    afterAll(async () => {
+      await testDb.commandBuilders.collections.delete(collectionId)
+    })
+
+    it('orders ascending by created_at (the non-order_key branch of buildDocumentOrderClause)', async () => {
+      const result = await testDb.queryBuilders.documents.findDocuments({
+        collection_id: collectionId,
+        locale: 'en',
+        orderBy: 'created_at',
+        orderDirection: 'asc',
+        pageSize: docIds.length,
+      })
+      expect(result.documents.map((d) => d.document_id)).toEqual(docIds)
+    })
+
+    it('orders descending by created_at', async () => {
+      const result = await testDb.queryBuilders.documents.findDocuments({
+        collection_id: collectionId,
+        locale: 'en',
+        orderBy: 'created_at',
+        orderDirection: 'desc',
+        pageSize: docIds.length,
+      })
+      expect(result.documents.map((d) => d.document_id)).toEqual([...docIds].reverse())
+    })
+
+    it('paginates with page/pageSize, including a page beyond the last row', async () => {
+      const total = docIds.length // 5
+
+      const page1 = await testDb.queryBuilders.documents.findDocuments({
+        collection_id: collectionId,
+        locale: 'en',
+        orderBy: 'created_at',
+        orderDirection: 'asc',
+        page: 1,
+        pageSize: 2,
+      })
+      expect(page1.total).toBe(total)
+      expect(page1.documents.map((d) => d.document_id)).toEqual(docIds.slice(0, 2))
+
+      const page2 = await testDb.queryBuilders.documents.findDocuments({
+        collection_id: collectionId,
+        locale: 'en',
+        orderBy: 'created_at',
+        orderDirection: 'asc',
+        page: 2,
+        pageSize: 2,
+      })
+      expect(page2.total).toBe(total)
+      expect(page2.documents.map((d) => d.document_id)).toEqual(docIds.slice(2, 4))
+
+      const page3 = await testDb.queryBuilders.documents.findDocuments({
+        collection_id: collectionId,
+        locale: 'en',
+        orderBy: 'created_at',
+        orderDirection: 'asc',
+        page: 3,
+        pageSize: 2,
+      })
+      expect(page3.total).toBe(total)
+      expect(page3.documents.map((d) => d.document_id)).toEqual(docIds.slice(4, 5))
+
+      // A page beyond the last row: `total` still reflects the full
+      // matching count (pagination doesn't change what's being counted),
+      // but this page's slice is empty.
+      const pageBeyond = await testDb.queryBuilders.documents.findDocuments({
+        collection_id: collectionId,
+        locale: 'en',
+        orderBy: 'created_at',
+        orderDirection: 'asc',
+        page: 4,
+        pageSize: 2,
+      })
+      expect(pageBeyond.total).toBe(total)
+      expect(pageBeyond.documents).toEqual([])
+    })
   })
 })

--- a/packages/db-mysql/src/modules/storage/tests/storage-status-and-lifecycle.test.ts
+++ b/packages/db-mysql/src/modules/storage/tests/storage-status-and-lifecycle.test.ts
@@ -1,0 +1,355 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+/**
+ * Live-database verification of the Task 9B status / archive / soft-delete /
+ * order-key / delete-locale command surface — `DocumentCommands.setDocumentStatus`,
+ * `archivePublishedVersions`, `softDeleteDocument`, `setOrderKey`, and
+ * `deleteDocumentLocale`. Same style as `storage-commands.test.ts`: every
+ * assertion queries the live MySQL test database directly, never a mock.
+ *
+ * Where a command's effect is a state transition (status, archive,
+ * soft-delete), the version stream is asserted as NOT disturbed alongside the
+ * changed row — status is lifecycle metadata, not content, and mutates the
+ * existing version row in place rather than minting a version.
+ */
+
+import type { CollectionDefinition } from '@byline/core'
+import type mysql from 'mysql2/promise'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { setupTestDB, teardownTestDB } from '../../../lib/test-helper.js'
+
+const timestamp = Date.now()
+
+function first<T>(rows: T[]): T {
+  const row = rows[0]
+  if (row == null) throw new Error('expected at least one row, got none')
+  return row
+}
+
+async function queryRows(pool: mysql.Pool, sql: string, params: unknown[]): Promise<any[]> {
+  const [rows] = await pool.query(sql, params)
+  return rows as any[]
+}
+
+async function queryOne(pool: mysql.Pool, sql: string, params: unknown[]): Promise<any> {
+  return first(await queryRows(pool, sql, params))
+}
+
+const PostsCollectionConfig: CollectionDefinition = {
+  path: `lifecycle-test-posts-${timestamp}`,
+  labels: { singular: 'Post', plural: 'Posts' },
+  fields: [
+    { name: 'title', type: 'text', localized: true },
+    {
+      name: 'links',
+      type: 'array',
+      fields: [{ name: 'label', type: 'text' }],
+    },
+  ],
+}
+
+describe('DocumentCommands status/archive/soft-delete/order-key/delete-locale (mysql, live database)', () => {
+  let testDb: ReturnType<typeof setupTestDB>
+  let rawPool: mysql.Pool
+  let collectionId: string
+
+  beforeAll(async () => {
+    testDb = setupTestDB([PostsCollectionConfig])
+    rawPool = testDb.pool
+    const created = first(
+      await testDb.commandBuilders.collections.create(
+        PostsCollectionConfig.path,
+        PostsCollectionConfig
+      )
+    )
+    collectionId = created.id
+  })
+
+  afterAll(async () => {
+    await testDb.commandBuilders.collections.delete(collectionId)
+    await teardownTestDB()
+  })
+
+  describe('setDocumentStatus', () => {
+    it('mutates the version row in place — no new version minted', async () => {
+      const created = await testDb.commandBuilders.documents.createDocumentVersion({
+        collectionId,
+        collectionVersion: 1,
+        collectionConfig: PostsCollectionConfig,
+        action: 'create',
+        documentData: { title: 'Status Doc', links: [] },
+        locale: 'all',
+        status: 'draft',
+      })
+      const versionId = created.document.id
+      const documentId = created.document.document_id
+
+      await testDb.commandBuilders.documents.setDocumentStatus({
+        document_version_id: versionId,
+        status: 'published',
+      })
+
+      const versionRow = await queryOne(
+        rawPool,
+        'SELECT status FROM byline_document_versions WHERE id = ?',
+        [versionId]
+      )
+      expect(versionRow.status).toBe('published')
+
+      const allVersions = await queryRows(
+        rawPool,
+        'SELECT id FROM byline_document_versions WHERE document_id = ?',
+        [documentId]
+      )
+      expect(allVersions.length).toBe(1) // still one version — status is metadata, not content
+    })
+  })
+
+  describe('archivePublishedVersions', () => {
+    it('archives every published version of a document except an excluded one', async () => {
+      const v1 = await testDb.commandBuilders.documents.createDocumentVersion({
+        collectionId,
+        collectionVersion: 1,
+        collectionConfig: PostsCollectionConfig,
+        action: 'create',
+        documentData: { title: 'Archive Doc v1', links: [] },
+        locale: 'all',
+        status: 'published',
+      })
+      const documentId = v1.document.document_id
+
+      const v2 = await testDb.commandBuilders.documents.createDocumentVersion({
+        documentId,
+        collectionId,
+        collectionVersion: 1,
+        collectionConfig: PostsCollectionConfig,
+        action: 'update',
+        documentData: { title: 'Archive Doc v2', links: [] },
+        locale: 'all',
+        status: 'published',
+      })
+
+      const updated = await testDb.commandBuilders.documents.archivePublishedVersions({
+        document_id: documentId,
+        currentStatus: 'published',
+        excludeVersionId: v2.document.id,
+      })
+      expect(updated).toBe(1)
+
+      const v1Row = await queryOne(
+        rawPool,
+        'SELECT status FROM byline_document_versions WHERE id = ?',
+        [v1.document.id]
+      )
+      expect(v1Row.status).toBe('archived')
+      const v2Row = await queryOne(
+        rawPool,
+        'SELECT status FROM byline_document_versions WHERE id = ?',
+        [v2.document.id]
+      )
+      expect(v2Row.status).toBe('published') // excluded — untouched
+
+      const versionCount = await queryRows(
+        rawPool,
+        'SELECT id FROM byline_document_versions WHERE document_id = ?',
+        [documentId]
+      )
+      expect(versionCount.length).toBe(2) // no new version minted by archiving
+    })
+
+    it('returns 0 when no version matches the target status', async () => {
+      const created = await testDb.commandBuilders.documents.createDocumentVersion({
+        collectionId,
+        collectionVersion: 1,
+        collectionConfig: PostsCollectionConfig,
+        action: 'create',
+        documentData: { title: 'Never Published', links: [] },
+        locale: 'all',
+        status: 'draft',
+      })
+      const updated = await testDb.commandBuilders.documents.archivePublishedVersions({
+        document_id: created.document.document_id,
+      })
+      expect(updated).toBe(0)
+    })
+  })
+
+  describe('softDeleteDocument', () => {
+    it('marks every version of a document as deleted', async () => {
+      const v1 = await testDb.commandBuilders.documents.createDocumentVersion({
+        collectionId,
+        collectionVersion: 1,
+        collectionConfig: PostsCollectionConfig,
+        action: 'create',
+        documentData: { title: 'Delete Doc v1', links: [] },
+        locale: 'all',
+        status: 'draft',
+      })
+      const documentId = v1.document.document_id
+      await testDb.commandBuilders.documents.createDocumentVersion({
+        documentId,
+        collectionId,
+        collectionVersion: 1,
+        collectionConfig: PostsCollectionConfig,
+        action: 'update',
+        documentData: { title: 'Delete Doc v2', links: [] },
+        locale: 'all',
+        status: 'draft',
+      })
+
+      const affected = await testDb.commandBuilders.documents.softDeleteDocument({
+        document_id: documentId,
+      })
+      expect(affected).toBe(2)
+
+      const rows = await queryRows(
+        rawPool,
+        'SELECT is_deleted FROM byline_document_versions WHERE document_id = ?',
+        [documentId]
+      )
+      expect(rows.length).toBe(2) // rows preserved, only tombstoned
+      expect(rows.every((r) => r.is_deleted === 1)).toBe(true)
+    })
+
+    it('returns 0 for a document with no version rows (defensive guard)', async () => {
+      const affected = await testDb.commandBuilders.documents.softDeleteDocument({
+        document_id: '00000000-0000-7000-8000-000000000000',
+      })
+      expect(affected).toBe(0)
+    })
+  })
+
+  describe('setOrderKey', () => {
+    it('writes order_key on byline_documents without touching the version stream', async () => {
+      const created = await testDb.commandBuilders.documents.createDocumentVersion({
+        collectionId,
+        collectionVersion: 1,
+        collectionConfig: PostsCollectionConfig,
+        action: 'create',
+        documentData: { title: 'Order Key Doc', links: [] },
+        locale: 'all',
+        status: 'draft',
+      })
+      const documentId = created.document.document_id
+
+      await testDb.commandBuilders.documents.setOrderKey({
+        document_id: documentId,
+        order_key: 'a0',
+      })
+
+      const docRow = await queryOne(
+        rawPool,
+        'SELECT order_key FROM byline_documents WHERE id = ?',
+        [documentId]
+      )
+      expect(docRow.order_key).toBe('a0')
+
+      const versionCount = await queryRows(
+        rawPool,
+        'SELECT id FROM byline_document_versions WHERE document_id = ?',
+        [documentId]
+      )
+      expect(versionCount.length).toBe(1) // no new version
+    })
+  })
+
+  describe('deleteDocumentLocale', () => {
+    it('writes a new version carrying forward every locale except the deleted one, plus meta identities', async () => {
+      const v1 = await testDb.commandBuilders.documents.createDocumentVersion({
+        collectionId,
+        collectionVersion: 1,
+        collectionConfig: PostsCollectionConfig,
+        action: 'create',
+        documentData: {
+          title: { en: 'Hello', es: 'Hola', fr: 'Bonjour' },
+          links: [{ label: 'one' }],
+        },
+        locale: 'all',
+        status: 'draft',
+      })
+      const documentId = v1.document.document_id
+      const firstVersionId = v1.document.id
+
+      const result = await testDb.commandBuilders.documents.deleteDocumentLocale({
+        documentId,
+        locale: 'es',
+        status: 'draft',
+      })
+      expect(result).not.toBeNull()
+      expect(result?.previousVersionId).toBe(firstVersionId)
+      const newVersionId = result?.newVersionId as string
+      expect(newVersionId).not.toBe(firstVersionId)
+
+      // A genuinely new, distinct version row.
+      const versionRows = await queryRows(
+        rawPool,
+        'SELECT id, event_type, status, change_summary FROM byline_document_versions WHERE document_id = ? ORDER BY id',
+        [documentId]
+      )
+      expect(versionRows.length).toBe(2)
+      const newVersionRow = versionRows.find((r) => r.id === newVersionId)
+      expect(newVersionRow.event_type).toBe('delete_locale')
+      expect(newVersionRow.status).toBe('draft')
+      expect(newVersionRow.change_summary).toBe('deleted content locale es')
+
+      // 'en' and 'fr' carried forward; 'es' dropped.
+      const titleRows = await queryRows(
+        rawPool,
+        "SELECT locale, value FROM byline_store_text WHERE document_version_id = ? AND field_name = 'title' ORDER BY locale",
+        [newVersionId]
+      )
+      expect(titleRows.map((r) => [r.locale, r.value])).toEqual([
+        ['en', 'Hello'],
+        ['fr', 'Bonjour'],
+      ])
+
+      // The prior version is untouched (immutability) — still has all three.
+      const prevTitleRows = await queryRows(
+        rawPool,
+        "SELECT locale FROM byline_store_text WHERE document_version_id = ? AND field_name = 'title' ORDER BY locale",
+        [firstVersionId]
+      )
+      expect(prevTitleRows.map((r) => r.locale)).toEqual(['en', 'es', 'fr'])
+
+      // Meta identity rows (the array item's stable _id) carried forward too.
+      const newMetaRows = await queryRows(
+        rawPool,
+        'SELECT type, path, item_id FROM byline_store_meta WHERE document_version_id = ?',
+        [newVersionId]
+      )
+      const prevMetaRows = await queryRows(
+        rawPool,
+        'SELECT type, path, item_id FROM byline_store_meta WHERE document_version_id = ?',
+        [firstVersionId]
+      )
+      expect(newMetaRows.length).toBe(prevMetaRows.length)
+      expect(newMetaRows.length).toBeGreaterThan(0)
+      expect(new Set(newMetaRows.map((r) => r.item_id))).toEqual(
+        new Set(prevMetaRows.map((r) => r.item_id))
+      )
+
+      // The completeness ledger no longer advertises 'es'.
+      const ledgerRows = await queryRows(
+        rawPool,
+        'SELECT locale FROM byline_document_version_locales WHERE document_version_id = ? ORDER BY locale',
+        [newVersionId]
+      )
+      expect(ledgerRows.map((r) => r.locale)).toEqual(['en', 'fr'])
+    })
+
+    it('returns null when the document has no current (non-deleted) version', async () => {
+      const result = await testDb.commandBuilders.documents.deleteDocumentLocale({
+        documentId: '00000000-0000-7000-8000-000000000000',
+        locale: 'es',
+      })
+      expect(result).toBeNull()
+    })
+  })
+})

--- a/packages/db-mysql/tests/_global-setup.ts
+++ b/packages/db-mysql/tests/_global-setup.ts
@@ -1,0 +1,25 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import { config as loadEnv } from 'dotenv'
+
+import { assertTestDatabase, migrateTestDatabase } from '../src/lib/test-db.js'
+
+/**
+ * Vitest `globalSetup`: runs once per `vitest run` before any test file
+ * loads. Asserts the configured connection points at a `_test` database and
+ * applies the full Drizzle migration set. Drizzle's migrator is idempotent,
+ * so re-running the suite is cheap. Mirrors `packages/db-postgres/tests/_global-setup.ts`.
+ */
+export default async function setup() {
+  loadEnv({ path: '.env.test' })
+
+  const connectionString = process.env.BYLINE_DB_MYSQL_CONNECTION_STRING
+  assertTestDatabase(connectionString)
+  await migrateTestDatabase(connectionString as string)
+}

--- a/packages/db-mysql/tests/_per-file-setup.ts
+++ b/packages/db-mysql/tests/_per-file-setup.ts
@@ -1,0 +1,29 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import { config as loadEnv } from 'dotenv'
+import { beforeAll } from 'vitest'
+
+import { resetTestDatabase } from '../src/lib/test-db.js'
+
+loadEnv({ path: '.env.test' })
+
+/**
+ * Vitest `setupFiles`: runs once per test file. The `beforeAll` truncates
+ * every user table (foreign keys disabled around the truncates — MySQL has
+ * no `TRUNCATE ... CASCADE` — and restored afterwards) so each file starts
+ * from a known state — a crashed test in a prior file can't leak rows into
+ * the next. Mirrors `packages/db-postgres/tests/_per-file-setup.ts`.
+ */
+beforeAll(async () => {
+  const connectionString = process.env.BYLINE_DB_MYSQL_CONNECTION_STRING
+  if (!connectionString) {
+    throw new Error('BYLINE_DB_MYSQL_CONNECTION_STRING is not set')
+  }
+  await resetTestDatabase(connectionString)
+})

--- a/packages/db-mysql/tests/conformance.integration.test.ts
+++ b/packages/db-mysql/tests/conformance.integration.test.ts
@@ -11,54 +11,22 @@
  * adapter — the same behavioural gate `packages/db-postgres/tests/
  * conformance.integration.test.ts` runs for the Postgres adapter.
  *
- * Suites are registered here one at a time, as each lands its own task
- * (`@byline/db-conformance`'s index exports every suite by name so an
- * adapter mid-port can register only the ones it currently passes without
- * turning the rest of `pnpm test:integration` — and CI, which runs it at
- * the repo root on every push — red for the whole of the port):
- *
- *   - Task 10A: `versioningSuite`, `fieldTypesSuite`.
- *   - Task 10B: `documentPathsSuite`, `documentTreeSuite`, `transactionsSuite`,
- *     `deleteLocaleSuite`, `documentAvailableLocalesSuite`,
- *     `systemFieldsDirectWriteSuite`, `restoreSuite`, `localeFallbackSuite`
- *     — the full storage surface minus tree-audit atomicity, 10 of the 14
- *     total suites.
- *   - Task 11 (this file): `countersSuite`, `auditSuite`, and
- *     `documentTreeAuditSuite` — `commands.counters.*` and
- *     `commands.audit.*` / `queries.audit.*` are real as of this task, so
- *     the tree-mutation lifecycle functions
- *     (`placeTreeNode`/`removeFromTree`/`promoteChildrenAndRemove`) that
- *     `documentTreeAuditSuite` exercises can now append to and read back
- *     from a working audit log. 13 of the 14 suites.
- *
- * `adminStoreSuite` stays unregistered — the admin-store repositories are
- * Task 12.
- *
- * TODO(Task 13): once every suite passes, replace the list below with a
- * single `runAdapterConformanceSuite(hooks)` call — see db-postgres's
- * conformance entry for the target shape.
+ * All 14 suites are registered as of Task 12 (the admin-store repositories
+ * and `createAdminStore` hook). The staged, one-suite-per-task registration
+ * that preceded this — kept CI green while the write surface (Task 9), read
+ * surface (Task 10), and counters/audit (Task 11) landed incrementally — is
+ * no longer needed now that every suite passes, so this collapses to a
+ * single `runAdapterConformanceSuite(hooks)` call, matching db-postgres's
+ * conformance entry.
  */
 
+import type { AdminStore } from '@byline/admin'
 import type { CollectionDefinition, IDbAdapter } from '@byline/core'
-import {
-  auditSuite,
-  type ConformanceHooks,
-  countersSuite,
-  deleteLocaleSuite,
-  documentAvailableLocalesSuite,
-  documentPathsSuite,
-  documentTreeAuditSuite,
-  documentTreeSuite,
-  fieldTypesSuite,
-  localeFallbackSuite,
-  restoreSuite,
-  systemFieldsDirectWriteSuite,
-  transactionsSuite,
-  versioningSuite,
-} from '@byline/db-conformance'
+import { runAdapterConformanceSuite } from '@byline/db-conformance'
 
 import { assertTestDatabase, migrateTestDatabase, resetTestDatabase } from '../src/lib/test-db.js'
 import { setupTestDB, teardownTestDB } from '../src/lib/test-helper.js'
+import { createAdminStore as createMysqlAdminStore } from '../src/modules/admin/admin-store.js'
 import { createAuditCommands } from '../src/modules/audit/audit-commands.js'
 import { createAuditQueries } from '../src/modules/audit/audit-queries.js'
 import { createCounterCommands } from '../src/modules/counters/counters-commands.js'
@@ -70,7 +38,7 @@ function getConnectionString(): string {
   return connectionString as string
 }
 
-const hooks: ConformanceHooks = {
+runAdapterConformanceSuite({
   async createAdapter(collections: readonly CollectionDefinition[]): Promise<IDbAdapter> {
     const testDb = setupTestDB(collections as CollectionDefinition[])
     // Counters take the raw mysql2 pool (`testDb.pool`), never `dbManager` —
@@ -114,22 +82,8 @@ const hooks: ConformanceHooks = {
     await teardownTestDB()
   },
 
-  // `createAdminStore` intentionally omitted — the admin-store repositories
-  // are Task 12. The admin-store conformance suites are not registered
-  // below, so this is a correct omission rather than a gap: no `describe`/
-  // `it` blocks exist for them, so they never show up as skipped.
-}
-
-versioningSuite(hooks)
-fieldTypesSuite(hooks)
-documentPathsSuite(hooks)
-documentTreeSuite(hooks)
-documentTreeAuditSuite(hooks)
-transactionsSuite(hooks)
-deleteLocaleSuite(hooks)
-documentAvailableLocalesSuite(hooks)
-systemFieldsDirectWriteSuite(hooks)
-restoreSuite(hooks)
-localeFallbackSuite(hooks)
-countersSuite(hooks)
-auditSuite(hooks)
+  async createAdminStore(): Promise<AdminStore> {
+    const testDb = setupTestDB()
+    return createMysqlAdminStore(testDb.db)
+  },
+})

--- a/packages/db-mysql/tests/conformance.integration.test.ts
+++ b/packages/db-mysql/tests/conformance.integration.test.ts
@@ -1,0 +1,131 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+/**
+ * Runs the shared `@byline/db-conformance` storage suite against the MySQL
+ * adapter — the same behavioural gate `packages/db-postgres/tests/
+ * conformance.integration.test.ts` runs for the Postgres adapter.
+ *
+ * Suites are registered here one at a time, as each lands its own task
+ * (`@byline/db-conformance`'s index exports every suite by name so an
+ * adapter mid-port can register only the ones it currently passes without
+ * turning the rest of `pnpm test:integration` — and CI, which runs it at
+ * the repo root on every push — red for the whole of the port):
+ *
+ *   - Task 10A: `versioningSuite`, `fieldTypesSuite` (this file).
+ *
+ * TODO(Task 13): once every suite passes, replace the list below with a
+ * single `runAdapterConformanceSuite(hooks)` call — see db-postgres's
+ * conformance entry for the target shape.
+ */
+
+import type { CollectionDefinition, IDbAdapter } from '@byline/core'
+import { type ConformanceHooks, fieldTypesSuite, versioningSuite } from '@byline/db-conformance'
+
+import { assertTestDatabase, migrateTestDatabase, resetTestDatabase } from '../src/lib/test-db.js'
+import { setupTestDB, teardownTestDB } from '../src/lib/test-helper.js'
+import { classifyError } from '../src/modules/storage/classify-error.js'
+
+function getConnectionString(): string {
+  const connectionString = process.env.BYLINE_DB_MYSQL_CONNECTION_STRING
+  assertTestDatabase(connectionString)
+  return connectionString as string
+}
+
+const hooks: ConformanceHooks = {
+  async createAdapter(collections: readonly CollectionDefinition[]): Promise<IDbAdapter> {
+    const testDb = setupTestDB(collections as CollectionDefinition[])
+
+    return {
+      classifyError,
+      commands: {
+        ...testDb.commandBuilders,
+        counters: {
+          ensureCounterGroup: notImplemented('commands.counters.ensureCounterGroup'),
+          nextCounterValue: notImplemented('commands.counters.nextCounterValue'),
+          nextScopedCounterValue: notImplemented('commands.counters.nextScopedCounterValue'),
+        },
+        audit: {
+          append: notImplemented('commands.audit.append'),
+        },
+      },
+      queries: {
+        // `testDb.queryBuilders.collections` fully implements
+        // `ICollectionQueries` (Task 10A).
+        collections: testDb.queryBuilders.collections,
+        // `testDb.queryBuilders.documents` (`DocumentQueries`) implements
+        // only the reconstruction path as of Task 10A — mirror
+        // `src/index.ts`'s per-member composition rather than spreading,
+        // since `DocumentQueries` does not (yet) satisfy the full
+        // `IDocumentQueries` shape this object must return.
+        documents: {
+          getDocumentSystemFieldsForUpdate: notImplemented(
+            'queries.documents.getDocumentSystemFieldsForUpdate'
+          ),
+          getDocumentById: (params) => testDb.queryBuilders.documents.getDocumentById(params),
+          getCurrentVersionMetadata: notImplemented('queries.documents.getCurrentVersionMetadata'),
+          getCurrentPath: notImplemented('queries.documents.getCurrentPath'),
+          getDocumentByPath: notImplemented('queries.documents.getDocumentByPath'),
+          getDocumentByVersion: (params) =>
+            testDb.queryBuilders.documents.getDocumentByVersion(params),
+          getDocumentsByVersionIds: notImplemented('queries.documents.getDocumentsByVersionIds'),
+          getDocumentsByDocumentIds: notImplemented('queries.documents.getDocumentsByDocumentIds'),
+          getDocumentHistory: (params) => testDb.queryBuilders.documents.getDocumentHistory(params),
+          getPublishedVersion: notImplemented('queries.documents.getPublishedVersion'),
+          getPublishedDocumentIds: notImplemented('queries.documents.getPublishedDocumentIds'),
+          getDocumentCountsByStatus: notImplemented('queries.documents.getDocumentCountsByStatus'),
+          findDocuments: (params) => testDb.queryBuilders.documents.findDocuments(params),
+          getLastOrderKey: notImplemented('queries.documents.getLastOrderKey'),
+          getNeighborOrderKeys: notImplemented('queries.documents.getNeighborOrderKeys'),
+          getCanonicalDocumentOrder: notImplemented('queries.documents.getCanonicalDocumentOrder'),
+          getTreeAncestors: notImplemented('queries.documents.getTreeAncestors'),
+          getTreeChildren: notImplemented('queries.documents.getTreeChildren'),
+          getTreeParent: notImplemented('queries.documents.getTreeParent'),
+          getTreeSubtree: notImplemented('queries.documents.getTreeSubtree'),
+        },
+        audit: {
+          getDocumentAuditLog: notImplemented('queries.audit.getDocumentAuditLog'),
+          findAuditLog: notImplemented('queries.audit.findAuditLog'),
+        },
+      },
+      withTransaction: (fn) => testDb.txManager.withTransaction(fn),
+    }
+  },
+
+  async migrate(): Promise<void> {
+    await migrateTestDatabase(getConnectionString())
+  },
+
+  async truncate(): Promise<void> {
+    await resetTestDatabase(getConnectionString())
+  },
+
+  async teardown(): Promise<void> {
+    await teardownTestDB()
+  },
+
+  // `createAdminStore` intentionally omitted — the admin-store repositories
+  // are Task 12. The admin-store conformance suites are not registered
+  // below, so this is a correct omission rather than a gap: no `describe`/
+  // `it` blocks exist for them, so they never show up as skipped.
+}
+
+/**
+ * Build a stub matching one not-yet-implemented `IDbAdapter` member's exact
+ * call signature. Neither of the two suites registered below (`versioning`,
+ * `field-types`) exercises counters, audit, or the admin store — those are
+ * Tasks 11/12. Throwing keeps that honest rather than silently no-op-ing.
+ */
+function notImplemented<T>(member: string): T {
+  return (() => {
+    throw new Error(`@byline/db-mysql: ${member} is not implemented yet`)
+  }) as unknown as T
+}
+
+versioningSuite(hooks)
+fieldTypesSuite(hooks)

--- a/packages/db-mysql/tests/conformance.integration.test.ts
+++ b/packages/db-mysql/tests/conformance.integration.test.ts
@@ -18,14 +18,25 @@
  * the repo root on every push — red for the whole of the port):
  *
  *   - Task 10A: `versioningSuite`, `fieldTypesSuite`.
- *   - Task 10B: `documentPathsSuite`, `documentTreeSuite`,
- *     `documentTreeAuditSuite`, `transactionsSuite`, `deleteLocaleSuite`,
- *     `documentAvailableLocalesSuite`, `systemFieldsDirectWriteSuite`,
- *     `restoreSuite`, `localeFallbackSuite` (this file) — the full storage
- *     surface, 11 of the 14 total suites.
+ *   - Task 10B: `documentPathsSuite`, `documentTreeSuite`, `transactionsSuite`,
+ *     `deleteLocaleSuite`, `documentAvailableLocalesSuite`,
+ *     `systemFieldsDirectWriteSuite`, `restoreSuite`, `localeFallbackSuite`
+ *     (this file) — the full storage surface minus tree-audit atomicity,
+ *     10 of the 14 total suites.
  *
  * `auditSuite`, `countersSuite`, and `adminStoreSuite` stay unregistered —
  * counters/audit are Task 11, the admin-store repositories are Task 12.
+ * `documentTreeAuditSuite` also stays unregistered here, for the same
+ * reason: every test in it calls a tree-mutation lifecycle function
+ * (`placeTreeNode`/`removeFromTree`/`promoteChildrenAndRemove`) that itself
+ * calls `commands.audit.append` inside the same transaction and then asserts
+ * against `queries.audit.getDocumentAuditLog` — it is a tree+audit
+ * atomicity suite, not a general storage suite, so it cannot pass against
+ * the `notImplemented` audit stubs below. Task 11 owns it: register
+ * `documentTreeAuditSuite(hooks)` once `commands.audit.append` and
+ * `queries.audit.*` are real — `testDb.queryBuilders.documents` already
+ * satisfies everything else the suite needs, so no other wiring change
+ * should be required.
  *
  * TODO(Task 13): once every suite passes, replace the list below with a
  * single `runAdapterConformanceSuite(hooks)` call — see db-postgres's
@@ -38,7 +49,6 @@ import {
   deleteLocaleSuite,
   documentAvailableLocalesSuite,
   documentPathsSuite,
-  documentTreeAuditSuite,
   documentTreeSuite,
   fieldTypesSuite,
   localeFallbackSuite,
@@ -112,9 +122,11 @@ const hooks: ConformanceHooks = {
 
 /**
  * Build a stub matching one not-yet-implemented `IDbAdapter` member's exact
- * call signature. None of the eleven suites registered below exercise
- * counters, audit, or the admin store — those are Tasks 11/12. Throwing
- * keeps that honest rather than silently no-op-ing.
+ * call signature. None of the ten suites registered below exercise
+ * counters, audit, or the admin store — those are Tasks 11/12 (and, for
+ * `documentTreeAuditSuite` specifically, the reason it isn't registered
+ * below yet — see the module docblock). Throwing keeps that honest rather
+ * than silently no-op-ing.
  */
 function notImplemented<T>(member: string): T {
   return (() => {
@@ -126,7 +138,8 @@ versioningSuite(hooks)
 fieldTypesSuite(hooks)
 documentPathsSuite(hooks)
 documentTreeSuite(hooks)
-documentTreeAuditSuite(hooks)
+// documentTreeAuditSuite(hooks) — Task 11: needs commands.audit.append /
+// queries.audit.* (see module docblock above).
 transactionsSuite(hooks)
 deleteLocaleSuite(hooks)
 documentAvailableLocalesSuite(hooks)

--- a/packages/db-mysql/tests/conformance.integration.test.ts
+++ b/packages/db-mysql/tests/conformance.integration.test.ts
@@ -21,22 +21,18 @@
  *   - Task 10B: `documentPathsSuite`, `documentTreeSuite`, `transactionsSuite`,
  *     `deleteLocaleSuite`, `documentAvailableLocalesSuite`,
  *     `systemFieldsDirectWriteSuite`, `restoreSuite`, `localeFallbackSuite`
- *     (this file) — the full storage surface minus tree-audit atomicity,
- *     10 of the 14 total suites.
+ *     — the full storage surface minus tree-audit atomicity, 10 of the 14
+ *     total suites.
+ *   - Task 11 (this file): `countersSuite`, `auditSuite`, and
+ *     `documentTreeAuditSuite` — `commands.counters.*` and
+ *     `commands.audit.*` / `queries.audit.*` are real as of this task, so
+ *     the tree-mutation lifecycle functions
+ *     (`placeTreeNode`/`removeFromTree`/`promoteChildrenAndRemove`) that
+ *     `documentTreeAuditSuite` exercises can now append to and read back
+ *     from a working audit log. 13 of the 14 suites.
  *
- * `auditSuite`, `countersSuite`, and `adminStoreSuite` stay unregistered —
- * counters/audit are Task 11, the admin-store repositories are Task 12.
- * `documentTreeAuditSuite` also stays unregistered here, for the same
- * reason: every test in it calls a tree-mutation lifecycle function
- * (`placeTreeNode`/`removeFromTree`/`promoteChildrenAndRemove`) that itself
- * calls `commands.audit.append` inside the same transaction and then asserts
- * against `queries.audit.getDocumentAuditLog` — it is a tree+audit
- * atomicity suite, not a general storage suite, so it cannot pass against
- * the `notImplemented` audit stubs below. Task 11 owns it: register
- * `documentTreeAuditSuite(hooks)` once `commands.audit.append` and
- * `queries.audit.*` are real — `testDb.queryBuilders.documents` already
- * satisfies everything else the suite needs, so no other wiring change
- * should be required.
+ * `adminStoreSuite` stays unregistered — the admin-store repositories are
+ * Task 12.
  *
  * TODO(Task 13): once every suite passes, replace the list below with a
  * single `runAdapterConformanceSuite(hooks)` call — see db-postgres's
@@ -45,10 +41,13 @@
 
 import type { CollectionDefinition, IDbAdapter } from '@byline/core'
 import {
+  auditSuite,
   type ConformanceHooks,
+  countersSuite,
   deleteLocaleSuite,
   documentAvailableLocalesSuite,
   documentPathsSuite,
+  documentTreeAuditSuite,
   documentTreeSuite,
   fieldTypesSuite,
   localeFallbackSuite,
@@ -60,6 +59,9 @@ import {
 
 import { assertTestDatabase, migrateTestDatabase, resetTestDatabase } from '../src/lib/test-db.js'
 import { setupTestDB, teardownTestDB } from '../src/lib/test-helper.js'
+import { createAuditCommands } from '../src/modules/audit/audit-commands.js'
+import { createAuditQueries } from '../src/modules/audit/audit-queries.js'
+import { createCounterCommands } from '../src/modules/counters/counters-commands.js'
 import { classifyError } from '../src/modules/storage/classify-error.js'
 
 function getConnectionString(): string {
@@ -71,19 +73,20 @@ function getConnectionString(): string {
 const hooks: ConformanceHooks = {
   async createAdapter(collections: readonly CollectionDefinition[]): Promise<IDbAdapter> {
     const testDb = setupTestDB(collections as CollectionDefinition[])
+    // Counters take the raw mysql2 pool (`testDb.pool`), never `dbManager` —
+    // see the class docblock on `CounterCommands` for why. Audit appends
+    // take `dbManager` (join the ambient transaction); audit reads take the
+    // plain `db` (the pool).
+    const counterCommands = createCounterCommands(testDb.pool)
+    const auditCommands = createAuditCommands(testDb.dbManager)
+    const auditQueries = createAuditQueries(testDb.db)
 
     return {
       classifyError,
       commands: {
         ...testDb.commandBuilders,
-        counters: {
-          ensureCounterGroup: notImplemented('commands.counters.ensureCounterGroup'),
-          nextCounterValue: notImplemented('commands.counters.nextCounterValue'),
-          nextScopedCounterValue: notImplemented('commands.counters.nextScopedCounterValue'),
-        },
-        audit: {
-          append: notImplemented('commands.audit.append'),
-        },
+        counters: counterCommands,
+        audit: auditCommands,
       },
       queries: {
         // `testDb.queryBuilders.collections` fully implements
@@ -93,10 +96,7 @@ const hooks: ConformanceHooks = {
         // implements `IDocumentQueries` as of Task 10B — spread directly,
         // unlike the Task 10A per-member composition this replaces.
         documents: testDb.queryBuilders.documents,
-        audit: {
-          getDocumentAuditLog: notImplemented('queries.audit.getDocumentAuditLog'),
-          findAuditLog: notImplemented('queries.audit.findAuditLog'),
-        },
+        audit: auditQueries,
       },
       withTransaction: (fn) => testDb.txManager.withTransaction(fn),
     }
@@ -120,29 +120,16 @@ const hooks: ConformanceHooks = {
   // `it` blocks exist for them, so they never show up as skipped.
 }
 
-/**
- * Build a stub matching one not-yet-implemented `IDbAdapter` member's exact
- * call signature. None of the ten suites registered below exercise
- * counters, audit, or the admin store — those are Tasks 11/12 (and, for
- * `documentTreeAuditSuite` specifically, the reason it isn't registered
- * below yet — see the module docblock). Throwing keeps that honest rather
- * than silently no-op-ing.
- */
-function notImplemented<T>(member: string): T {
-  return (() => {
-    throw new Error(`@byline/db-mysql: ${member} is not implemented yet`)
-  }) as unknown as T
-}
-
 versioningSuite(hooks)
 fieldTypesSuite(hooks)
 documentPathsSuite(hooks)
 documentTreeSuite(hooks)
-// documentTreeAuditSuite(hooks) — Task 11: needs commands.audit.append /
-// queries.audit.* (see module docblock above).
+documentTreeAuditSuite(hooks)
 transactionsSuite(hooks)
 deleteLocaleSuite(hooks)
 documentAvailableLocalesSuite(hooks)
 systemFieldsDirectWriteSuite(hooks)
 restoreSuite(hooks)
 localeFallbackSuite(hooks)
+countersSuite(hooks)
+auditSuite(hooks)

--- a/packages/db-mysql/tests/conformance.integration.test.ts
+++ b/packages/db-mysql/tests/conformance.integration.test.ts
@@ -17,7 +17,15 @@
  * turning the rest of `pnpm test:integration` — and CI, which runs it at
  * the repo root on every push — red for the whole of the port):
  *
- *   - Task 10A: `versioningSuite`, `fieldTypesSuite` (this file).
+ *   - Task 10A: `versioningSuite`, `fieldTypesSuite`.
+ *   - Task 10B: `documentPathsSuite`, `documentTreeSuite`,
+ *     `documentTreeAuditSuite`, `transactionsSuite`, `deleteLocaleSuite`,
+ *     `documentAvailableLocalesSuite`, `systemFieldsDirectWriteSuite`,
+ *     `restoreSuite`, `localeFallbackSuite` (this file) — the full storage
+ *     surface, 11 of the 14 total suites.
+ *
+ * `auditSuite`, `countersSuite`, and `adminStoreSuite` stay unregistered —
+ * counters/audit are Task 11, the admin-store repositories are Task 12.
  *
  * TODO(Task 13): once every suite passes, replace the list below with a
  * single `runAdapterConformanceSuite(hooks)` call — see db-postgres's
@@ -25,7 +33,20 @@
  */
 
 import type { CollectionDefinition, IDbAdapter } from '@byline/core'
-import { type ConformanceHooks, fieldTypesSuite, versioningSuite } from '@byline/db-conformance'
+import {
+  type ConformanceHooks,
+  deleteLocaleSuite,
+  documentAvailableLocalesSuite,
+  documentPathsSuite,
+  documentTreeAuditSuite,
+  documentTreeSuite,
+  fieldTypesSuite,
+  localeFallbackSuite,
+  restoreSuite,
+  systemFieldsDirectWriteSuite,
+  transactionsSuite,
+  versioningSuite,
+} from '@byline/db-conformance'
 
 import { assertTestDatabase, migrateTestDatabase, resetTestDatabase } from '../src/lib/test-db.js'
 import { setupTestDB, teardownTestDB } from '../src/lib/test-helper.js'
@@ -58,36 +79,10 @@ const hooks: ConformanceHooks = {
         // `testDb.queryBuilders.collections` fully implements
         // `ICollectionQueries` (Task 10A).
         collections: testDb.queryBuilders.collections,
-        // `testDb.queryBuilders.documents` (`DocumentQueries`) implements
-        // only the reconstruction path as of Task 10A — mirror
-        // `src/index.ts`'s per-member composition rather than spreading,
-        // since `DocumentQueries` does not (yet) satisfy the full
-        // `IDocumentQueries` shape this object must return.
-        documents: {
-          getDocumentSystemFieldsForUpdate: notImplemented(
-            'queries.documents.getDocumentSystemFieldsForUpdate'
-          ),
-          getDocumentById: (params) => testDb.queryBuilders.documents.getDocumentById(params),
-          getCurrentVersionMetadata: notImplemented('queries.documents.getCurrentVersionMetadata'),
-          getCurrentPath: notImplemented('queries.documents.getCurrentPath'),
-          getDocumentByPath: notImplemented('queries.documents.getDocumentByPath'),
-          getDocumentByVersion: (params) =>
-            testDb.queryBuilders.documents.getDocumentByVersion(params),
-          getDocumentsByVersionIds: notImplemented('queries.documents.getDocumentsByVersionIds'),
-          getDocumentsByDocumentIds: notImplemented('queries.documents.getDocumentsByDocumentIds'),
-          getDocumentHistory: (params) => testDb.queryBuilders.documents.getDocumentHistory(params),
-          getPublishedVersion: notImplemented('queries.documents.getPublishedVersion'),
-          getPublishedDocumentIds: notImplemented('queries.documents.getPublishedDocumentIds'),
-          getDocumentCountsByStatus: notImplemented('queries.documents.getDocumentCountsByStatus'),
-          findDocuments: (params) => testDb.queryBuilders.documents.findDocuments(params),
-          getLastOrderKey: notImplemented('queries.documents.getLastOrderKey'),
-          getNeighborOrderKeys: notImplemented('queries.documents.getNeighborOrderKeys'),
-          getCanonicalDocumentOrder: notImplemented('queries.documents.getCanonicalDocumentOrder'),
-          getTreeAncestors: notImplemented('queries.documents.getTreeAncestors'),
-          getTreeChildren: notImplemented('queries.documents.getTreeChildren'),
-          getTreeParent: notImplemented('queries.documents.getTreeParent'),
-          getTreeSubtree: notImplemented('queries.documents.getTreeSubtree'),
-        },
+        // `testDb.queryBuilders.documents` (`DocumentQueries`) fully
+        // implements `IDocumentQueries` as of Task 10B — spread directly,
+        // unlike the Task 10A per-member composition this replaces.
+        documents: testDb.queryBuilders.documents,
         audit: {
           getDocumentAuditLog: notImplemented('queries.audit.getDocumentAuditLog'),
           findAuditLog: notImplemented('queries.audit.findAuditLog'),
@@ -117,9 +112,9 @@ const hooks: ConformanceHooks = {
 
 /**
  * Build a stub matching one not-yet-implemented `IDbAdapter` member's exact
- * call signature. Neither of the two suites registered below (`versioning`,
- * `field-types`) exercises counters, audit, or the admin store — those are
- * Tasks 11/12. Throwing keeps that honest rather than silently no-op-ing.
+ * call signature. None of the eleven suites registered below exercise
+ * counters, audit, or the admin store — those are Tasks 11/12. Throwing
+ * keeps that honest rather than silently no-op-ing.
  */
 function notImplemented<T>(member: string): T {
   return (() => {
@@ -129,3 +124,12 @@ function notImplemented<T>(member: string): T {
 
 versioningSuite(hooks)
 fieldTypesSuite(hooks)
+documentPathsSuite(hooks)
+documentTreeSuite(hooks)
+documentTreeAuditSuite(hooks)
+transactionsSuite(hooks)
+deleteLocaleSuite(hooks)
+documentAvailableLocalesSuite(hooks)
+systemFieldsDirectWriteSuite(hooks)
+restoreSuite(hooks)
+localeFallbackSuite(hooks)

--- a/packages/db-postgres/src/modules/storage/classify-error-contract.test.node.ts
+++ b/packages/db-postgres/src/modules/storage/classify-error-contract.test.node.ts
@@ -1,0 +1,30 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import { runClassifyErrorContract } from '@byline/db-conformance'
+
+import { classifyError } from './classify-error.js'
+
+runClassifyErrorContract([
+  {
+    adapterName: 'postgres',
+    classifyError,
+    uniqueViolationError: {
+      code: '23505',
+      constraint: 'idx_document_paths_collection_locale_path',
+    },
+    nestedUniqueViolationError: {
+      name: 'DrizzleQueryError',
+      cause: {
+        code: '23505',
+        constraint: 'idx_document_paths_collection_locale_path',
+      },
+    },
+    unrelatedError: { code: '23503' },
+  },
+])

--- a/packages/db-postgres/src/modules/storage/storage-queries.ts
+++ b/packages/db-postgres/src/modules/storage/storage-queries.ts
@@ -140,7 +140,7 @@ export class DocumentQueries implements IDocumentQueries {
     db: DatabaseConnection,
     collections: readonly CollectionDefinition[],
     defaultContentLocale: string,
-    transactionDb: DBManager = { get: () => db }
+    transactionDb: DBManager
   ) {
     this.db = db
     this.transactionDb = transactionDb
@@ -2524,7 +2524,7 @@ export function createQueryBuilders(
   db: DatabaseConnection,
   collections: readonly CollectionDefinition[],
   defaultContentLocale: string,
-  transactionDb?: DBManager
+  transactionDb: DBManager
 ) {
   return {
     collections: new CollectionQueries(db),

--- a/packages/db-postgres/src/modules/storage/tests/storage-locale-fallback.test.ts
+++ b/packages/db-postgres/src/modules/storage/tests/storage-locale-fallback.test.ts
@@ -37,6 +37,7 @@ import { createQueryBuilders } from '../storage-queries.js'
 let commandBuilders: ReturnType<typeof import('../storage-commands.js').createCommandBuilders>
 let queryBuilders: ReturnType<typeof import('../storage-queries.js').createQueryBuilders>
 let db: ReturnType<typeof setupTestDB>['db']
+let dbManager: ReturnType<typeof setupTestDB>['dbManager']
 
 const timestamp = Date.now()
 
@@ -97,6 +98,7 @@ describe('content-locale resolution — source_locale internals (Postgres)', () 
     commandBuilders = testDB.commandBuilders
     queryBuilders = testDB.queryBuilders
     db = testDB.db
+    dbManager = testDB.dbManager
 
     const result = await commandBuilders.collections.create(
       LocaleCollectionConfig.path,
@@ -348,8 +350,12 @@ describe('content-locale resolution — source_locale internals (Postgres)', () 
     const slug = (pathRow.rows[0] as { path: string }).path
 
     // Simulate the global default switched to fr: a fresh query layer built
-    // with defaultContentLocale = 'fr' over the very same rows.
-    const frQueries = createQueryBuilders(db, [LocaleCollectionConfig], 'fr')
+    // with defaultContentLocale = 'fr' over the very same rows. Reuses the
+    // suite's own `dbManager` — this read-only scenario never calls
+    // `getDocumentSystemFieldsForUpdate`, but `transactionDb` is a required
+    // constructor parameter as of the §H ruling (no more silent
+    // pool-connection default), so every caller must supply one.
+    const frQueries = createQueryBuilders(db, [LocaleCollectionConfig], 'fr', dbManager)
 
     // Detail read in fr (the NEW default) with fallback: the doc has no fr
     // content, but rides its own source_locale 'en' floor → returns the en

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -684,6 +684,9 @@ importers:
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
+      uuid:
+        specifier: ^14.0.1
+        version: 14.0.1
     devDependencies:
       '@biomejs/biome':
         specifier: 2.5.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -672,6 +672,9 @@ importers:
 
   packages/db-mysql:
     dependencies:
+      '@byline/admin':
+        specifier: workspace:*
+        version: link:../admin
       '@byline/core':
         specifier: workspace:*
         version: link:../core


### PR DESCRIPTION
Phase 2, PR 2 of 3 for the MySQL adapter program. Tasks 9–12 of
[`specs/2026-07-24-db-mysql-adapter-plan.md`](https://github.com/Byline-CMS/bylinecms.dev/blob/develop/specs/2026-07-24-db-mysql-adapter-plan.md).

Part of #42. Builds on #49 (schema and package foundation).

## The headline

**All 14 conformance suites from `@byline/db-conformance` now pass on MySQL — 141/141, matching `@byline/db-postgres` exactly.** `packages/db-mysql` runs 190/190 integration tests.

That suite is the point of the whole program: Phase 1 (#41, v4.7.0) extracted the dialect-independent storage machinery into `@byline/core` and turned the Postgres integration tests into a parameterised contract. This PR is the first evidence that the contract holds for a second dialect — and it passes **unchanged**, with one fixture correction described below.

| Task | |
|---|---|
| 9 | Write surface — test harness, `classifyError` + a shared classifier-contract test, row normalisation, `storage-insert`, and the complete command surface (paths, available-locales, status, archive, soft-delete, delete-locale, order-key, tree mutations) |
| 10 | Read surface — store manifest and UNION ALL projection, document reconstruction, field-value filters, `$and`/`$or` combinators, relation hops, document-column filters, `LEFT JOIN LATERAL` field sort, `query` LIKE search, locale fallback, path lookups, recursive tree reads |
| 11 | Table-emulated counters (MySQL has no sequences) and the audit log |
| 12 | Admin-store repositories and the `./admin` subpath export |

## Nine MySQL-vs-Postgres divergences, every one found by executing SQL

Not one of these came from reading documentation. Several were caught only because a reviewer or implementer reproduced them against a live server.

1. **`ON DUPLICATE KEY UPDATE` has no per-constraint targeting.** Postgres's `onConflictDoUpdate` names the constraint it reacts to; MySQL's fires on *any* unique violation. Tables with more than one unique key need insert-then-catch-and-conditionally-update, discriminating on the constraint name. The choice is made per table, by unique-key count — `placeTreeNode` correctly keeps the untargeted form because its table has exactly one.
2. **`WITH` must follow `INSERT INTO`**, not precede the statement.
3. **mysql2's `'connection'` event** hands back a callback-style connection at runtime despite its declared type; `.promise()` is required.
4. **mysql2's undeclared default collation** (`utf8mb4_unicode_ci`, charset 224) doesn't match the schema's `utf8mb4_0900_ai_ci` (255), breaking the UNION ALL with `ER_CANT_AGGREGATE_NCOLLATIONS`. Fixed at the pool, not per query.
5. **Recursive CTE column widths are inferred from the anchor leg only.** `getTreeSubtree`'s bare `r.order_key` anchor capped the accumulating path at `varchar(128)` and hard-errored past ~11–40 levels. The Postgres `::text` cast that was dropped as "redundant collation" was doing a second job: making the column unbounded.
6. **`db.execute(sql\`…\`)` always returns `DATETIME` as a string**, never a `Date` — drizzle's mysql2 driver has no schema-typed field mapper on that path. This was a **user-facing bug**: `datetime` and `date` field values silently returned strings through the ordinary `getDocumentById` path.
7. **`BEFORE` is a reserved word** and needs backtick-quoting in the audit log's column list.
8. **`JSON_MERGE_PATCH` semantics differ from Postgres's `||`** (RFC 7396), so it was deliberately not used for the preferences merge.
9. **Drizzle-kit's auto-named foreign keys** overflow MySQL's 64-character identifier cap where Postgres silently truncates (carried from #49).

## Changes outside the new package

**`packages/db-conformance/src/suites/audit.ts` — a shared-suite fixture correction.** The audit date-range fixture established its window as `created_at + 1ms` and assumed later appends landed outside it. Postgres's `now()` has microsecond resolution, giving that pad ~1000 sub-buckets of headroom; MySQL's clock is coarser and the test was genuinely flaky (~30%).

Two independent causes, both fixed:
- Column precision — the schema moved to `DATETIME(6)`, matching Byline's Postgres convention `timestamp(name, { precision: 6, withTimezone: true })`. This **deviates from the design spec's `DATETIME(3)`**, which stated no rationale; the spec correction is owed in PR 3.
- **Independent of column precision:** `IAuditQueries.findAuditLog`'s `from`/`to` are typed `Date` in `@byline/core`, and a JS `Date` cannot represent sub-millisecond time. The query boundary is millisecond-quantised no matter how precise the column is. The fixture now takes a real awaited phase separation.

Every `expect(...)` in that file is byte-identical — the boundary *mechanism* changed, no assertion was weakened. `db-postgres` re-verified at **173/173**.

**`packages/db-postgres/src/modules/storage/storage-queries.ts` — `transactionDb` is now a required parameter.** It defaulted to `{ get: () => db }`, so omitting it silently yielded a manager handing back the raw pool — and the `SELECT … FOR UPDATE` in `getDocumentSystemFieldsForUpdate` would then lock a pool connection outside the caller's transaction and serialise nothing, with no error and no failing test. Both adapters carried the footgun. Now a compile error. `db-postgres` re-verified at 173/173.

## Notes for review

- **Concurrency is proved, not asserted.** The counters test instruments `pool.getConnection`, asserts observed overlap *and* the exact contiguous set {1..20}, and was verified by deliberately breaking connection discipline and watching it fail 3/3. The path-upsert race test races two writers on separate pool connections and asserts the loser's classification down to the constraint name.
- **Counters emulation:** `LAST_INSERT_ID()` is per-connection state, so `nextCounterValue` runs both statements on one checked-out connection — and on the pool, never the ambient transaction, so a long document-create transaction can't serialise a counter group.
- `packages/db-mysql` gains a stacked `0001` (counter allocator column) and `0002` (fsp 3→6). `0000` is untouched — it is merged and rewriting an applied migration's checksum would break anyone who has run it.

## Known divergence, deliberately deferred

`toDateOnly` returns **UTC midnight**; node-postgres returns **local** midnight (`postgres-date` v1.0.7: *"Force YYYY-MM-DD dates to be parsed as local time"*). On a non-UTC host the same stored `date` field materialises differently between adapters. The docblock now says so plainly. The semantics decision is deferred to PR 3, which adds temporal fixtures to the conformance suite and a non-UTC `TZ` CI leg — the suite currently asserts **no temporal value at all**, which is how divergence 6 above also went unnoticed.

## Verification

- 14/14 conformance suites, 141/141, matching `db-postgres`
- `packages/db-mysql` integration 190/190 across consecutive runs
- `db-postgres` 173/173 and `@byline/client` 142/142 unaffected
- Repo root: `pnpm test:integration`, `pnpm typecheck`, `pnpm lint`, `pnpm knip` all green