### PR TITLE
ci: added a mysql service container and db-mysql test env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,33 @@ jobs:
           --health-timeout 5s
           --health-retries 10
 
+      # Pinned to 8.0 deliberately: the adapter's engine floor is MySQL
+      # 8.0.14 (the release that added LATERAL joins and lifted the
+      # no-subquery-in-a-view's-FROM restriction, both of which the storage
+      # layer relies on). Local development runs `mysql:latest` (9.x) via
+      # `mysql/docker-compose.yml`, so pinning 8.0 here is what actually
+      # exercises the floor rather than a version comfortably above it.
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: test
+          MYSQL_DATABASE: byline_test
+          MYSQL_USER: byline
+          MYSQL_PASSWORD: byline
+        ports:
+          - 3306:3306
+        # `mysqladmin ping` with explicit root credentials: an unauthenticated
+        # ping can report success while the server is still initialising the
+        # data directory, which would let the migration step race startup.
+        options: >-
+          --health-cmd "mysqladmin ping -h 127.0.0.1 -uroot -ptest --silent"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+
     env:
       BYLINE_DB_POSTGRES_CONNECTION_STRING: postgres://byline:byline@127.0.0.1:5432/byline_test
+      BYLINE_DB_MYSQL_CONNECTION_STRING: mysql://byline:byline@127.0.0.1:3306/byline_test
 
     steps:
       - uses: actions/checkout@v6
@@ -74,9 +99,12 @@ jobs:
       # all packages ensures every import path resolves.
       - run: pnpm build:packages
 
-      # Both test runners read BYLINE_DB_POSTGRES_CONNECTION_STRING from
-      # `.env.test` files. CI writes them from the job-level env block; they're
-      # gitignored so committing them by accident isn't possible.
+      # Every integration runner reads its connection string from a `.env.test`
+      # file. CI writes them from the job-level env block; they're gitignored so
+      # committing them by accident isn't possible. Each adapter's
+      # `assertTestDatabase` also refuses any database whose name doesn't end in
+      # `_test`, so a misconfigured string fails loudly rather than pointing at
+      # something it shouldn't.
       - name: Write .env.test files
         run: |
           cat > packages/db-postgres/.env.test <<EOF
@@ -84,6 +112,9 @@ jobs:
           EOF
           cat > packages/client/.env.test <<EOF
           BYLINE_DB_POSTGRES_CONNECTION_STRING=$BYLINE_DB_POSTGRES_CONNECTION_STRING
+          EOF
+          cat > packages/db-mysql/.env.test <<EOF
+          BYLINE_DB_MYSQL_CONNECTION_STRING=$BYLINE_DB_MYSQL_CONNECTION_STRING
           EOF
 
       # Unit suites across every package (core/auth/admin/ai/host/client/...).


### PR DESCRIPTION
Fixes `develop`, which went red on the #50 merge.

## What broke

#50 gave `@byline/db-mysql` runnable integration tests, but CI had no MySQL to run them against — the workflow provisions a Postgres service and writes `.env.test` for `db-postgres` and `client` only. So root `pnpm test:integration` fans out to `db-mysql` and dies before a single test runs:

```
Error: BYLINE_DB_MYSQL_CONNECTION_STRING is not set. Copy .env.test.example to .env.test.
  ❯ assertTestDatabase src/lib/test-db.ts:41:11
  ❯ Object.setup tests/_global-setup.ts:23:3
Failed: @byline/db-mysql#test:integration
```

Nothing is wrong with the merged code — all 190 tests pass against a real MySQL. This is Task 14 of the [adapter plan](https://github.com/Byline-CMS/bylinecms.dev/blob/develop/specs/2026-07-24-db-mysql-adapter-plan.md), pulled out of PR 3 and landed on its own so `develop` goes green now rather than waiting on the conformance-fixture and docs work.

Part of #42.

## The change

- A `mysql:8.0` service container beside Postgres, with `byline_test` / `byline` provisioned by the image entrypoint.
- `BYLINE_DB_MYSQL_CONNECTION_STRING` on the job env block, and `packages/db-mysql/.env.test` written alongside the two existing ones.

**Pinned to `8.0` deliberately.** The adapter's engine floor is MySQL 8.0.14 — the release that added `LATERAL` joins and lifted the no-subquery-in-a-view's-`FROM` restriction, both of which the storage layer depends on. Local development runs `mysql:latest` (9.x), so pinning 8.0 here is what actually exercises the floor instead of a version comfortably above it.

**Health check uses explicit root credentials.** An unauthenticated `mysqladmin ping` can report success while the server is still initialising its data directory, which would let the migration step race startup.

## Verified before pushing

Rather than assume 8.0 behaves like the 9.7 we develop against, I ran the full suite against a throwaway `mysql:8.0` container:

```
MySQL 8.0.46, utf8mb4 / utf8mb4_0900_ai_ci
Test Files  7 passed (7)
     Tests  190 passed (190)
```

So the floor is genuinely green, including the dialect-sensitive paths — `LATERAL` field sort, recursive CTEs, the UNION ALL collation unification, and the counters `LAST_INSERT_ID()` emulation.

## One deviation from the plan

Task 14's text asks for the two database suites to run as separate parallel jobs "so a MySQL failure is immediately attributable." I kept a single `test-suite` job with both services instead: Turborepo already attributes precisely (`Failed: @byline/db-mysql#test:integration` is exactly how this bug was diagnosed), and splitting would duplicate `pnpm install` and `pnpm build:packages` for marginal benefit on a 3-minute job. Easy to revisit if the job grows.