### PR TITLE
feat(db-mysql): conformance fixtures, temporal convergence, docs and release

### DIFF
--- a/.changeset/db-mysql-adapter.md
+++ b/.changeset/db-mysql-adapter.md
@@ -1,0 +1,25 @@
+---
+"@byline/db-mysql": minor
+"@byline/db-postgres": minor
+---
+
+Added `@byline/db-mysql`, Byline's second database adapter. `mysqlAdapter()` implements
+the same `IDbAdapter` contract as `@byline/db-postgres` over MySQL 8.0.14+ (InnoDB only;
+the boot check rejects older servers and MariaDB) and passes the same shared
+`@byline/db-conformance` suite the Postgres adapter runs, so document storage, versioning,
+patches, workflow, populate, and admin auth behave identically regardless of which
+database is configured. See `packages/db-mysql/README.md` for install steps, the engine
+floor, and the documented differences from the Postgres adapter.
+
+**BREAKING (`@byline/db-postgres`):** `date` and `datetime` field values now arrive as
+`Date` objects instead of raw driver strings. `date` values are anchored to **UTC
+midnight** for their calendar day; `datetime` values carry the full instant; `time`
+values are unchanged and remain a string. This was previously undocumented raw driver
+output — `packages/core/src/storage/storage-row-types.ts` already typed both columns as
+`Date | string`, so code written to handle either shape is unaffected. Check any code
+that reads a `date` or `datetime` field value and calls a string method on it (`.slice()`,
+`.split()`, a regex) or hands it to a date-parsing library expecting a string — that code
+now receives a `Date` and must be updated to use `Date` methods (or call `.toISOString()`
+itself) instead. This is a `minor`, not a `major`, release: every publishable `@byline/*`
+package is versioned in one lockstep group, and this change does not warrant taking all
+sixteen packages to 5.0.0.

--- a/docs/03-architecture/01-document-storage.md
+++ b/docs/03-architecture/01-document-storage.md
@@ -12,6 +12,7 @@ Companions:
 - [Document Paths](../04-collections/05-document-paths.md) — `path` was the first system attribute promoted out of the storage layer; it now lives in a dedicated `byline_document_paths` table keyed by `(document_id, locale)`.
 - [Collection Versioning](../04-collections/08-collection-versioning.md) — schema versioning sits beside, but is independent of, document versioning.
 - [Storage benchmark sweep — 2026-07-21](https://github.com/Byline-CMS/bylinecms.dev/blob/develop/benchmarks/storage/results/2026-07-21-storage-cold-summary.md) — the cold-path latency evidence cited below; it carries the 2026-04-18 baseline it is compared against.
+- [`@byline/db-mysql` README](https://github.com/Byline-CMS/bylinecms.dev/blob/develop/packages/db-mysql/README.md) — the second adapter's install steps, engine floor, and its documented differences from the Postgres adapter described here.
 
 ## Overview
 
@@ -42,6 +43,26 @@ The architecture exists to deliver three properties at once:
 These compose only because the storage layer treats every field value as a row keyed by version, locale, and field path. Fold them into a per-collection table model and at least one of the three has to give.
 
 The cost of EAV is read-time reconstruction across several tables. That is the model's central risk, it is measured rather than asserted, and the [benchmarks](#indicative-benchmarks) below show where it stays flat and where it does not.
+
+### Adapters
+
+Everything above is a description of the model, not of one database. Byline ships two
+adapters that implement it: `@byline/db-postgres`, the original adapter, and
+`@byline/db-mysql`, added in v4.8.0 for MySQL 8.0.14 and later. Both implement the same
+`IDbAdapter` contract, and the dialect-independent parts of the model described in this
+document — flatten, reconstruct, the store manifest, field-path resolution, selective
+field loading — live once in `@byline/core` rather than in either adapter, so an
+improvement to the model benefits both databases at once. Each adapter still owns its
+own schema, SQL, and driver-specific row normalisation; where the two databases genuinely
+differ, they are free to differ, and each adapter documents its own divergences (the
+[`@byline/db-mysql` README](https://github.com/Byline-CMS/bylinecms.dev/blob/develop/packages/db-mysql/README.md)
+covers that adapter's).
+
+The contract instrument that keeps the two in sync is `packages/db-conformance` — a
+private, unpublished workspace package holding one behavioural test suite, parameterised
+over an `IDbAdapter` factory. Both adapters run the same 14 suites against their own test
+database; a change to the shared model that breaks either adapter's behaviour fails a
+conformance suite before it fails anything a consumer would notice.
 
 ## What happens when you save a document
 

--- a/packages/core/src/storage/storage-row-types.ts
+++ b/packages/core/src/storage/storage-row-types.ts
@@ -38,13 +38,16 @@ interface FlattenedDateTimeFieldValue extends BaseFlattenedFieldData {
   field_type: 'datetime'
   date_type: 'datetime' | 'date' | 'time'
   value_time?: string
-  // `value_date` is a Date when flattened from form input, or a 'YYYY-MM-DD'
-  // string when re-flattened from previously-read storage content (drizzle's
-  // `date()` column returns strings by default). `value_timestamp_tz` is a
-  // Date from form widgets but a string from the EAV UNION ALL read path
-  // (the manifest's nullCast collapses the column to `timestamp` without
-  // TZ, which node-postgres returns as a string). The insert path accepts
-  // both shapes for both columns.
+  // Both adapters' ordinary read path (`normalize-row.ts`, mysql and pg
+  // alike, as of task 13b) and the Zod schema builder's `z.coerce.date()`
+  // for form/API input hand this a `Date`, so `Date` covers every value
+  // that reaches `flattenFieldSetData` through the validated API surface.
+  // The `string` arm stays for the documented direct-`db.commands.*`
+  // escape hatch (seeds, migrations, internal tooling — see CLAUDE.md's
+  // "Auth" section) that can call `createDocumentVersion` with
+  // hand-built field-set data bypassing Zod entirely, e.g. a raw
+  // `'YYYY-MM-DD'` or ISO string. `storage-insert.ts`'s `toDateOnlyString`
+  // / `toDate` (pg) and `toDate` (mysql) tolerate both shapes on purpose.
   value_date?: Date | string
   value_timestamp_tz?: Date | string
 }

--- a/packages/db-conformance/src/suites/document-paths.ts
+++ b/packages/db-conformance/src/suites/document-paths.ts
@@ -293,5 +293,61 @@ export function documentPathsSuite(hooks: ConformanceHooks): void {
         expect(path).toBe(null)
       })
     })
+
+    // `byline_document_paths.path` is `ascii_bin`/`utf8mb4_bin`-equivalent
+    // (case- and accent-sensitive) on both adapters specifically so path
+    // uniqueness is byte-exact and agrees across dialects — see
+    // `varcharCaseSensitive` in `packages/db-mysql/src/database/schema/
+    // common.ts` and the plain `text`/default-collation `path` column on
+    // Postgres. Pins today's behaviour (`/About` and `/about` are two
+    // distinct documents) so that issue #48 (normalising manual path
+    // overrides through core's slugifier, which would make them the *same*
+    // document on both adapters) is a deliberate, knowing change rather
+    // than something that drifts in per-dialect.
+    it('treats case-variant paths as distinct documents', async () => {
+      const stem = `Case-Variant-${Date.now()}`
+      const upperPath = `/${stem}`
+      const lowerPath = `/${stem.toLowerCase()}`
+
+      const upper = await adapter.commands.documents.createDocumentVersion({
+        collectionId: testCollection.id,
+        collectionVersion: 1,
+        collectionConfig: PathsCollectionConfig,
+        action: 'create',
+        documentData: { title: 'Upper' },
+        path: upperPath,
+        locale: 'all',
+        status: 'draft',
+      })
+
+      const lower = await adapter.commands.documents.createDocumentVersion({
+        collectionId: testCollection.id,
+        collectionVersion: 1,
+        collectionConfig: PathsCollectionConfig,
+        action: 'create',
+        documentData: { title: 'Lower' },
+        path: lowerPath,
+        locale: 'all',
+        status: 'draft',
+      })
+
+      // Two distinct logical documents — the second create did not collide
+      // with the first, and did not upsert onto it.
+      expect(lower.document.document_id).not.toBe(upper.document.document_id)
+
+      const upperFound = await adapter.queries.documents.getDocumentByPath({
+        collection_id: testCollection.id,
+        path: upperPath,
+        reconstruct: false,
+      })
+      const lowerFound = await adapter.queries.documents.getDocumentByPath({
+        collection_id: testCollection.id,
+        path: lowerPath,
+        reconstruct: false,
+      })
+
+      expect(upperFound?.document_id).toBe(upper.document.document_id)
+      expect(lowerFound?.document_id).toBe(lower.document.document_id)
+    })
   })
 }

--- a/packages/db-conformance/src/suites/field-types.ts
+++ b/packages/db-conformance/src/suites/field-types.ts
@@ -63,65 +63,6 @@ const sampleDocument = {
 }
 
 /**
- * Recover the instant (epoch milliseconds) a `datetime` field value
- * represents, whether the adapter returned a real `Date` (mysql, via its
- * `normalize-row.ts` coercion) or the raw driver string (postgres — the EAV
- * UNION ALL collapses `value_timestamp_tz` to a TZ-less `timestamp` for
- * cross-store-table type alignment, which node-postgres returns as text;
- * see `packages/core/src/storage/storage-row-types.ts`'s
- * `FlattenedDateTimeFieldValue` doc comment). Returns `null` when the value
- * can't be parsed as either.
- */
-function toInstantMs(value: unknown): number | null {
-  if (value instanceof Date) return value.getTime()
-  if (typeof value === 'string') {
-    const parsed = new Date(value)
-    return Number.isNaN(parsed.getTime()) ? null : parsed.getTime()
-  }
-  return null
-}
-
-/**
- * Recover the calendar date(s) a `date` field value could represent as
- * 'YYYY-MM-DD' strings, tolerant of every representation an adapter might
- * currently return:
- *
- *   - a raw driver string (postgres, today) — the literal stored text, no
- *     midnight or timezone interpretation involved at all.
- *   - a `Date` (mysql, today) — two candidates, the calendar date read via
- *     the process's *local* getters and via its *UTC* getters. Exactly one
- *     of these is guaranteed to reproduce the stored calendar date no
- *     matter the adapter's midnight convention or the host's timezone
- *     offset: a `Date` built at UTC midnight (mysql's `toDateOnly`)
- *     recovers correctly via UTC getters always, and via local getters
- *     whenever the host is at or east of UTC; a `Date` built at local
- *     midnight (what node-postgres's own default type parser would
- *     produce, were it in play here) recovers correctly via local getters
- *     always. Returning both candidates and asking the caller to check
- *     "is the expected date among them" is what makes the assertion below
- *     agnostic to which convention is in play — see the `date` fixture's
- *     comment and the task-13 report's §B.1 evidence table for the full
- *     story, including the one case (a Date anchored at UTC midnight, read
- *     via local getters, on a host west of UTC) where the *local* candidate
- *     alone would be wrong — which is exactly why both candidates are
- *     offered rather than just one.
- */
-function calendarDateCandidates(value: unknown): string[] {
-  if (typeof value === 'string') {
-    const match = value.match(/^\d{4}-\d{2}-\d{2}/)
-    return match ? [match[0]] : []
-  }
-  if (value instanceof Date) {
-    const pad = (n: number) => String(n).padStart(2, '0')
-    return [
-      `${value.getFullYear()}-${pad(value.getMonth() + 1)}-${pad(value.getDate())}`,
-      `${value.getUTCFullYear()}-${pad(value.getUTCMonth() + 1)}-${pad(value.getUTCDate())}`,
-    ]
-  }
-  return []
-}
-
-/**
  * Ported from `packages/db-postgres/src/modules/storage/tests/storage-field-types.test.ts`.
  */
 export function fieldTypesSuite(hooks: ConformanceHooks): void {
@@ -230,17 +171,20 @@ export function fieldTypesSuite(hooks: ConformanceHooks): void {
     // returning strings instead of `Date`s through the ordinary read
     // path, a `value_time` column generated as `TIME(0)` (truncating
     // fractional seconds against a spec saying `TIME(3)`), and an
-    // unresolved UTC-vs-local divergence in `date` handling. See the
-    // task-13 report for the full evidence, including the discovery
-    // (while writing these fixtures) that postgres's `date` **and**
-    // `datetime` fields both currently return the raw driver string
-    // through this same read path — already documented, if easy to miss,
-    // at `packages/core/src/storage/storage-row-types.ts`'s
-    // `FlattenedDateTimeFieldValue` — so mysql and postgres disagree on
-    // representation (`Date` vs. string) as well as, for `date`, on
-    // midnight anchor. None of that is this suite's to resolve; see the
-    // `toInstantMs` / `calendarDateCandidates` helpers above for how these
-    // fixtures stay representation-agnostic instead of picking a side.
+    // unresolved UTC-vs-local divergence in `date` handling. Task 13
+    // found that mysql and postgres disagreed here — mysql returned a
+    // `Date`, postgres a raw driver string — and wrote these fixtures
+    // representation-tolerant because resolving the divergence was not
+    // the implementer's call to make.
+    //
+    // Task 13b carries the project owner's ruling: both adapters return a
+    // real `Date` for `date` and `datetime`, and `date` anchors at UTC
+    // midnight on both (mysql already did; postgres's
+    // `normalize-row.ts` now matches — see that file's docblock for the
+    // evidence that the fix belongs there rather than in the store
+    // manifest). `time` is explicitly out of scope and stays a string on
+    // both adapters — see the dedicated fixture below. These fixtures now
+    // pin the resolved contract instead of tolerating either answer.
     // ------------------------------------------------------------------
 
     it('round-trips a datetime value with its sub-second precision intact', async () => {
@@ -264,9 +208,10 @@ export function fieldTypesSuite(hooks: ConformanceHooks): void {
         document_version_id: result.document.id,
       })
 
-      const instant = toInstantMs(document?.fields.publishedOn)
-      expect(instant, 'expected a Date or a parseable timestamp string').not.toBeNull()
-      expect(instant).toBe(expected.getTime())
+      // Ruling (task 13b): `datetime` is a real `Date` on both adapters.
+      const publishedOn = document?.fields.publishedOn
+      expect(publishedOn).toBeInstanceOf(Date)
+      expect((publishedOn as Date).getTime()).toBe(expected.getTime())
     })
 
     it('round-trips a bare time value at its declared precision', async () => {
@@ -286,14 +231,17 @@ export function fieldTypesSuite(hooks: ConformanceHooks): void {
       })
 
       // `time` is a plain string on both adapters — never a `Date` — per
-      // `TimeField` (`packages/core/src/@types/field-types.ts`). This is
-      // the fixture whose absence let a `TIME(0)` column ship on mysql,
-      // silently truncating this same fractional-second value to
-      // '14:30:00'.
+      // `TimeField` (`packages/core/src/@types/field-types.ts`). A
+      // time-of-day is not an instant (no calendar date, no UTC/local
+      // question applies), so the task-13b "converge on Date" ruling
+      // deliberately excludes it — this is the fixture pinning that as
+      // intentional, not an oversight. It's also the fixture whose
+      // absence let a `TIME(0)` column ship on mysql, silently truncating
+      // this same fractional-second value to '14:30:00'.
       expect(document?.fields.onTime).toBe('14:30:00.123')
     })
 
-    it('round-trips a calendar date, preserved regardless of which midnight the adapter anchors to', async () => {
+    it('round-trips a calendar date at UTC midnight on both adapters', async () => {
       const path = `date-precision-${Date.now()}`
 
       const result = await adapter.commands.documents.createDocumentVersion({
@@ -312,19 +260,21 @@ export function fieldTypesSuite(hooks: ConformanceHooks): void {
         document_version_id: result.document.id,
       })
 
-      // Deliberately NOT asserting `instanceof Date` here, and deliberately
-      // not deciding which midnight a `Date` return would anchor to — both
-      // are an open, project-owner-only decision (see the task-13 report's
-      // §B.1 evidence table). What both adapters agree on today, and all
-      // this asserts, is that the calendar date itself survives the
-      // round-trip.
+      // Ruling (task 13b): `date` is a real `Date` anchored at **UTC**
+      // midnight on both adapters — deterministic across host timezones,
+      // unlike host-local midnight, which would make the same stored row
+      // render as a different calendar day depending on where the process
+      // runs. Assert via the UTC getters, not local ones, so this fixture
+      // itself doesn't become host-timezone-dependent.
       const value = document?.fields.onDate
-      const candidates = calendarDateCandidates(value)
-      expect(
-        candidates.length,
-        `expected a Date or a date string, got ${typeof value}`
-      ).toBeGreaterThan(0)
-      expect(candidates).toContain('2026-03-10')
+      expect(value).toBeInstanceOf(Date)
+      const date = value as Date
+      expect(date.getUTCFullYear()).toBe(2026)
+      expect(date.getUTCMonth()).toBe(2) // 0-indexed: March
+      expect(date.getUTCDate()).toBe(10)
+      expect(date.getUTCHours()).toBe(0)
+      expect(date.getUTCMinutes()).toBe(0)
+      expect(date.getUTCSeconds()).toBe(0)
     })
   })
 }

--- a/packages/db-conformance/src/suites/field-types.ts
+++ b/packages/db-conformance/src/suites/field-types.ts
@@ -24,6 +24,8 @@ const FieldTypesCollectionConfig: CollectionDefinition = {
     { name: 'title', type: 'text', localized: true },
     { name: 'summary', type: 'text', localized: true },
     { name: 'publishedOn', type: 'datetime', optional: true },
+    { name: 'onDate', type: 'date', optional: true },
+    { name: 'onTime', type: 'time', optional: true },
     { name: 'views', type: 'integer', optional: true },
     { name: 'price', type: 'decimal', optional: true },
     { name: 'attachment', type: 'file', optional: true },
@@ -58,6 +60,65 @@ const sampleDocument = {
     storageProvider: 'local',
     storagePath: 'uploads/attachments/sample-attachment.pdf',
   },
+}
+
+/**
+ * Recover the instant (epoch milliseconds) a `datetime` field value
+ * represents, whether the adapter returned a real `Date` (mysql, via its
+ * `normalize-row.ts` coercion) or the raw driver string (postgres — the EAV
+ * UNION ALL collapses `value_timestamp_tz` to a TZ-less `timestamp` for
+ * cross-store-table type alignment, which node-postgres returns as text;
+ * see `packages/core/src/storage/storage-row-types.ts`'s
+ * `FlattenedDateTimeFieldValue` doc comment). Returns `null` when the value
+ * can't be parsed as either.
+ */
+function toInstantMs(value: unknown): number | null {
+  if (value instanceof Date) return value.getTime()
+  if (typeof value === 'string') {
+    const parsed = new Date(value)
+    return Number.isNaN(parsed.getTime()) ? null : parsed.getTime()
+  }
+  return null
+}
+
+/**
+ * Recover the calendar date(s) a `date` field value could represent as
+ * 'YYYY-MM-DD' strings, tolerant of every representation an adapter might
+ * currently return:
+ *
+ *   - a raw driver string (postgres, today) — the literal stored text, no
+ *     midnight or timezone interpretation involved at all.
+ *   - a `Date` (mysql, today) — two candidates, the calendar date read via
+ *     the process's *local* getters and via its *UTC* getters. Exactly one
+ *     of these is guaranteed to reproduce the stored calendar date no
+ *     matter the adapter's midnight convention or the host's timezone
+ *     offset: a `Date` built at UTC midnight (mysql's `toDateOnly`)
+ *     recovers correctly via UTC getters always, and via local getters
+ *     whenever the host is at or east of UTC; a `Date` built at local
+ *     midnight (what node-postgres's own default type parser would
+ *     produce, were it in play here) recovers correctly via local getters
+ *     always. Returning both candidates and asking the caller to check
+ *     "is the expected date among them" is what makes the assertion below
+ *     agnostic to which convention is in play — see the `date` fixture's
+ *     comment and the task-13 report's §B.1 evidence table for the full
+ *     story, including the one case (a Date anchored at UTC midnight, read
+ *     via local getters, on a host west of UTC) where the *local* candidate
+ *     alone would be wrong — which is exactly why both candidates are
+ *     offered rather than just one.
+ */
+function calendarDateCandidates(value: unknown): string[] {
+  if (typeof value === 'string') {
+    const match = value.match(/^\d{4}-\d{2}-\d{2}/)
+    return match ? [match[0]] : []
+  }
+  if (value instanceof Date) {
+    const pad = (n: number) => String(n).padStart(2, '0')
+    return [
+      `${value.getFullYear()}-${pad(value.getMonth() + 1)}-${pad(value.getDate())}`,
+      `${value.getUTCFullYear()}-${pad(value.getUTCMonth() + 1)}-${pad(value.getUTCDate())}`,
+    ]
+  }
+  return []
 }
 
 /**
@@ -158,6 +219,112 @@ export function fieldTypesSuite(hooks: ConformanceHooks): void {
       expect(doc.fields, 'document should have fields').toBeTruthy()
       expect(doc.fields.title, 'should include title').toBeTruthy()
       expect(doc.path, 'should include the system path on the document envelope').toBeTruthy()
+    })
+
+    // ------------------------------------------------------------------
+    // Temporal round-trip fixtures.
+    //
+    // Added by task 13. Before this, the suite asserted no temporal value
+    // at all (only `attachment.fileSize`) — a blind spot that let three
+    // real defects through the mysql port: `date`/`datetime` silently
+    // returning strings instead of `Date`s through the ordinary read
+    // path, a `value_time` column generated as `TIME(0)` (truncating
+    // fractional seconds against a spec saying `TIME(3)`), and an
+    // unresolved UTC-vs-local divergence in `date` handling. See the
+    // task-13 report for the full evidence, including the discovery
+    // (while writing these fixtures) that postgres's `date` **and**
+    // `datetime` fields both currently return the raw driver string
+    // through this same read path — already documented, if easy to miss,
+    // at `packages/core/src/storage/storage-row-types.ts`'s
+    // `FlattenedDateTimeFieldValue` — so mysql and postgres disagree on
+    // representation (`Date` vs. string) as well as, for `date`, on
+    // midnight anchor. None of that is this suite's to resolve; see the
+    // `toInstantMs` / `calendarDateCandidates` helpers above for how these
+    // fixtures stay representation-agnostic instead of picking a side.
+    // ------------------------------------------------------------------
+
+    it('round-trips a datetime value with its sub-second precision intact', async () => {
+      const path = `datetime-precision-${Date.now()}`
+      // Both adapters store microsecond-capable columns (pg `TIMESTAMPTZ(6)`,
+      // mysql `DATETIME(6)`), but a JS `Date` only resolves to milliseconds —
+      // that's the ceiling that's actually round-trippable through the
+      // public API, so this only asserts to millisecond precision.
+      const expected = new Date('2024-06-01T10:15:30.123Z')
+
+      const result = await adapter.commands.documents.createDocumentVersion({
+        collectionId: testCollection.id,
+        collectionVersion: 1,
+        collectionConfig: FieldTypesCollectionConfig,
+        action: 'create',
+        documentData: { ...structuredClone(sampleDocument), publishedOn: expected },
+        path,
+      })
+
+      const document = await adapter.queries.documents.getDocumentByVersion({
+        document_version_id: result.document.id,
+      })
+
+      const instant = toInstantMs(document?.fields.publishedOn)
+      expect(instant, 'expected a Date or a parseable timestamp string').not.toBeNull()
+      expect(instant).toBe(expected.getTime())
+    })
+
+    it('round-trips a bare time value at its declared precision', async () => {
+      const path = `time-precision-${Date.now()}`
+
+      const result = await adapter.commands.documents.createDocumentVersion({
+        collectionId: testCollection.id,
+        collectionVersion: 1,
+        collectionConfig: FieldTypesCollectionConfig,
+        action: 'create',
+        documentData: { ...structuredClone(sampleDocument), onTime: '14:30:00.123' },
+        path,
+      })
+
+      const document = await adapter.queries.documents.getDocumentByVersion({
+        document_version_id: result.document.id,
+      })
+
+      // `time` is a plain string on both adapters — never a `Date` — per
+      // `TimeField` (`packages/core/src/@types/field-types.ts`). This is
+      // the fixture whose absence let a `TIME(0)` column ship on mysql,
+      // silently truncating this same fractional-second value to
+      // '14:30:00'.
+      expect(document?.fields.onTime).toBe('14:30:00.123')
+    })
+
+    it('round-trips a calendar date, preserved regardless of which midnight the adapter anchors to', async () => {
+      const path = `date-precision-${Date.now()}`
+
+      const result = await adapter.commands.documents.createDocumentVersion({
+        collectionId: testCollection.id,
+        collectionVersion: 1,
+        collectionConfig: FieldTypesCollectionConfig,
+        action: 'create',
+        documentData: {
+          ...structuredClone(sampleDocument),
+          onDate: new Date('2026-03-10T00:00:00.000Z'),
+        },
+        path,
+      })
+
+      const document = await adapter.queries.documents.getDocumentByVersion({
+        document_version_id: result.document.id,
+      })
+
+      // Deliberately NOT asserting `instanceof Date` here, and deliberately
+      // not deciding which midnight a `Date` return would anchor to — both
+      // are an open, project-owner-only decision (see the task-13 report's
+      // §B.1 evidence table). What both adapters agree on today, and all
+      // this asserts, is that the calendar date itself survives the
+      // round-trip.
+      const value = document?.fields.onDate
+      const candidates = calendarDateCandidates(value)
+      expect(
+        candidates.length,
+        `expected a Date or a date string, got ${typeof value}`
+      ).toBeGreaterThan(0)
+      expect(candidates).toContain('2026-03-10')
     })
   })
 }

--- a/packages/db-mysql/README.md
+++ b/packages/db-mysql/README.md
@@ -1,0 +1,212 @@
+# @byline/db-mysql
+
+MySQL adapter for Byline CMS — Drizzle schema, migrations, and the storage /
+queries / commands implementation behind `IDbAdapter`. It is Byline's second
+database adapter, alongside `@byline/db-postgres`. The subpath
+`@byline/db-mysql/admin` ships the MySQL-backed admin-store repositories that
+plug into `@byline/admin`, the same way `@byline/db-postgres/admin` does.
+
+Both adapters implement the same `IDbAdapter` contract and pass the same
+shared `@byline/db-conformance` behavioural suite, so document storage,
+versioning, patches, workflow, populate, and admin auth behave identically
+regardless of which database backs an installation. See
+[Core Document Storage](https://github.com/Byline-CMS/bylinecms.dev/blob/develop/docs/03-architecture/01-document-storage.md)
+for the storage model both adapters implement.
+
+This package is part of [Byline CMS](https://github.com/Byline-CMS/bylinecms.dev)
+— a developer-friendly, open-source headless CMS with versioning, editorial
+workflow, and content translation as first-class concerns.
+
+## Install
+
+```sh
+pnpm add @byline/db-mysql
+```
+
+`mysql2` is a direct dependency, so no separate driver install is required.
+
+## Usage
+
+`mysqlAdapter()` takes a connection string, your `CollectionDefinition[]`, and
+the installation's default content locale, and returns an `IDbAdapter` (plus
+the underlying `drizzle` handle and `pool`, exposed for housekeeping and
+migration tooling):
+
+```ts
+import { initBylineCore } from '@byline/core'
+import { mysqlAdapter } from '@byline/db-mysql'
+import { createAdminStore } from '@byline/db-mysql/admin'
+
+import { collections } from './byline/collections/index.js'
+import { i18n } from './byline/i18n.js'
+import { routes } from './byline/routes.js'
+
+const db = mysqlAdapter({
+  connectionString: process.env.BYLINE_DB_MYSQL_CONNECTION_STRING!,
+  collections,
+  defaultContentLocale: i18n.content.defaultLocale,
+  connectionLimit: 20, // optional — mysql2 pool size, defaults to 20
+})
+
+const core = await initBylineCore({
+  serverURL: process.env.VITE_SERVER_URL!,
+  i18n,
+  routes,
+  collections,
+  db,
+  adminStore: createAdminStore(db.drizzle),
+  // storage, search, hooks, … — see @byline/core's ServerConfig type
+})
+```
+
+This mirrors how `apps/webapp/byline/server.config.ts` wires `@byline/db-postgres` today —
+swap `pgAdapter` / `@byline/db-postgres/admin` for `mysqlAdapter` /
+`@byline/db-mysql/admin` and the rest of an existing Byline server config is unchanged,
+because both adapters implement the same `IDbAdapter` and `AdminStore` contracts.
+
+`connectionString` is the **only** connection input `mysqlAdapter` takes, and
+it must be a `mysql://` URL — mysql2 parses connection URLs natively (`uri`
+is a first-class `createPool` option), so there is no separate host / port /
+user / password / database set of fields to keep in sync with it. An earlier
+version of this package's `.env.example` implied the URL existed only to
+serve the `db_init.sh` / `db_init_test.sh` shell scripts, which had the
+relationship backwards: the connection string is the adapter's own input
+first, and the shell scripts parse the same string only because the `mysql`
+CLI takes discrete flags rather than a URL.
+
+Special characters in the connection string's user or password must be
+percent-encoded (`@` as `%40`, `#` as `%23`, `/` as `%2F`, …) — mysql2 and
+the init scripts' shell-side URL parsing both percent-decode the userinfo the
+same way, so an unencoded reserved character parses differently, or fails to
+parse, on one side or the other.
+
+## Engine floor: MySQL 8.0.14+
+
+`mysqlAdapter` runs a boot-time `SELECT VERSION()` check against the pool's
+first connection and throws if the server is older than 8.0.14 or is
+MariaDB (MariaDB reports version strings that would otherwise satisfy the
+numeric floor, so it is rejected explicitly by name — see
+`src/lib/boot-check.ts`). A too-old server or MariaDB is a configuration
+error, so the check fails fast at `initBylineCore()` boot rather than
+surfacing later as an obscure SQL error the first time a query needs a
+feature the server doesn't have.
+
+8.0.14 is not an arbitrary floor — it is the first MySQL release with two
+features this adapter's storage layer depends on:
+
+- **`LEFT JOIN LATERAL`**, used for the field-level sort path in
+  `findDocuments`.
+- **Subqueries in a view's `FROM` clause**, which MySQL forbade before
+  8.0.14. Both current-version views
+  (`byline_current_documents`, `byline_current_published_documents`) resolve
+  the current version per document via a `ROW_NUMBER() OVER (PARTITION BY
+  document_id)` window inside a derived table in their `FROM` clause — the
+  same shape as the Postgres adapter's views — so this restriction, not the
+  `LATERAL` requirement, is the adapter's real engine floor.
+
+MariaDB is out of scope for this release: it lacks `LATERAL` joins, so
+supporting it would need a correlated-subquery rewrite of the field-sort
+path. Tracked as
+[on-demand follow-up work](https://github.com/Byline-CMS/bylinecms.dev/issues/54)
+if you need it sooner than "on demand."
+
+## UUID and timestamp conventions
+
+- **Ids are `CHAR(36) CHARACTER SET ascii COLLATE ascii_bin`** — canonical
+  UUID text, compared byte-wise rather than under an accent- or
+  case-folding collation. Every id and foreign-key column in the schema
+  uses this type. Ids are always app-generated UUIDv7 (the `uuid` package's
+  `v7()`), never database-generated — UUIDv7's canonical text form is
+  time-ordered, so `ORDER BY id DESC` version resolution works the same way
+  it does on the numeric-friendly ids some other schemas use.
+- **Audit timestamps are `DATETIME(6)`** (microsecond precision), matching
+  the Postgres adapter's `timestamp(name, { precision: 6, withTimezone: true })`
+  convention exactly. Every table's `created_at` / `updated_at` uses this
+  shape. `TIMESTAMP` (MySQL's other temporal type) is not used anywhere in
+  this schema — its year-2038 range limit makes it unsuitable for an
+  audit trail with no defined retention horizon.
+- **Every `DATETIME` column is UTC by convention.** MySQL's `DATETIME` type
+  carries no time zone identity the way Postgres's `TIMESTAMPTZ` does, so
+  UTC discipline is enforced entirely at the connection layer: the mysql2
+  pool is opened with `timezone: 'Z'`, which stops the driver from
+  reinterpreting stored UTC values against the server's or session's local
+  time zone on the way in or out.
+- **`document_paths.path` is pinned `utf8mb4_bin`** rather than the
+  database's default collation, so path lookups compare bytes exactly and
+  agree with the Postgres adapter's default (accent- and case-sensitive)
+  comparison — see "Differences from the Postgres adapter" below for why
+  this column needed a deliberate override.
+
+## Counters emulation
+
+MySQL has no `CREATE SEQUENCE`. Byline's counter groups (used for
+per-installation and per-scope sequential numbering) are emulated with a
+registry table, `byline_counter_groups`, that **is** the allocator rather
+than a wrapper around a database sequence object: `current_value` holds the
+counter's live state, and each allocation issues an atomic
+`UPDATE`/`INSERT ... ON DUPLICATE KEY UPDATE` followed by a same-connection
+`SELECT LAST_INSERT_ID()` to read back the value it just set — the classic
+`LAST_INSERT_ID(expr)` idiom, requiring no separate `SELECT ... FOR UPDATE`
+round trip. Because `LAST_INSERT_ID()` is per-connection session state, the
+two-statement sequence is issued over a single checked-out pool connection
+rather than through `pool.query()` directly, which could otherwise hand the
+two statements to two different physical connections and return the wrong
+session's value. See `src/modules/counters/counters-commands.ts` for the
+full implementation.
+
+## Differences from the Postgres adapter
+
+Both adapters implement the same storage model and pass the same
+`@byline/db-conformance` suite, but MySQL and Postgres are different
+databases, and a few divergences are real rather than papered over.
+
+- **`LIKE` is case- *and* accent-insensitive**, unlike Postgres's `ILIKE`,
+  which is case-insensitive only. Store *value* columns keep the database's
+  default collation, `utf8mb4_0900_ai_ci` (`ai` = accent-insensitive, `ci` =
+  case-insensitive), so a `query` search against `store_text` values will
+  match `café` when searching `cafe`, and `Café` when searching `cafe`,
+  where the same search against the Postgres adapter would match neither.
+  This is a deliberate, spec-elected divergence, not an oversight — see
+  `packages/db-mysql/src/database/schema/common.ts`'s `varcharCaseSensitive`
+  docblock for the evidence that ruled it in. The one place this divergence
+  is *not* allowed to stand is `byline_document_paths.path`: that column is
+  pinned to `utf8mb4_bin` (byte-exact) instead, so `/About` and `/about`
+  remain two distinct paths on both adapters, and so combining marks that
+  are meaning-bearing in some scripts (a Thai tone mark, a Devanagari
+  anusvara, Hebrew niqqud) are never silently folded together the way
+  `ai_ci` would fold them.
+- **No search provider yet.** `@byline/search-postgres` has no MySQL
+  counterpart today — a collection's `search` config
+  (`CollectionDefinition.search`) requires a registered `SearchProvider`,
+  and none ships for MySQL yet. Track
+  [the `@byline/search-mysql` follow-up issue](https://github.com/Byline-CMS/bylinecms.dev/issues/52)
+  for status.
+- **The connection string is the only connection input.** See "Usage"
+  above — this is called out here too because it is the most common way
+  this adapter is misconfigured by a reader coming from the Postgres
+  adapter's `.env.example`, which historically documented the same shape
+  for a different reason.
+- **Temporal field values.** As of this release both adapters return `date`
+  and `datetime` field values as `Date` objects (`date` anchored to UTC
+  midnight for its calendar day; `time` remains a string on both adapters).
+  This adapter always returned `Date` here; the Postgres adapter converged
+  onto the same shape in this release. See the changeset for what a
+  consumer upgrading `@byline/db-postgres` needs to check.
+
+## Not yet shipped
+
+- **`@byline/search-mysql`** — see "No search provider yet" above. Tracked in
+  [issue #52](https://github.com/Byline-CMS/bylinecms.dev/issues/52).
+- **A MySQL storage-benchmark target.** The design spec flags view
+  materialisation (the `ROW_NUMBER()` window inside a derived table, used
+  by both current-version views) as a question to answer before this
+  adapter's GA — Postgres's own benchmark sweep
+  ([`docs/03-architecture/01-document-storage.md`](https://github.com/Byline-CMS/bylinecms.dev/blob/develop/docs/03-architecture/01-document-storage.md#indicative-benchmarks))
+  has no MySQL counterpart yet. Tracked in
+  [issue #53](https://github.com/Byline-CMS/bylinecms.dev/issues/53).
+- **MariaDB support** — see "Engine floor" above. Tracked in
+  [issue #54](https://github.com/Byline-CMS/bylinecms.dev/issues/54).
+
+## License
+
+MPL-2.0

--- a/packages/db-mysql/package.json
+++ b/packages/db-mysql/package.json
@@ -71,6 +71,8 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.4",
+    "@byline/auth": "workspace:*",
+    "@byline/client": "workspace:*",
     "@byline/db-conformance": "workspace:*",
     "@types/node": "^26.1.1",
     "chokidar": "^5.0.0",

--- a/packages/db-mysql/package.json
+++ b/packages/db-mysql/package.json
@@ -66,7 +66,6 @@
     "@byline/core": "workspace:*",
     "drizzle-orm": "^0.45.2",
     "mysql2": "^3.23.1",
-    "npm-run-all": "^4.1.5",
     "uuid": "^14.0.1"
   },
   "devDependencies": {
@@ -79,6 +78,7 @@
     "chokidar-cli": "^3.0.0",
     "dotenv": "^17.4.2",
     "drizzle-kit": "^0.31.10",
+    "npm-run-all": "^4.1.5",
     "tsc-alias": "^1.9.1",
     "tsx": "^4.23.1",
     "typescript": "^7.0.2",

--- a/packages/db-mysql/src/modules/audit/audit-queries.ts
+++ b/packages/db-mysql/src/modules/audit/audit-queries.ts
@@ -224,7 +224,7 @@ function toEntryFromActivityRow(row: ActivityRow): AuditLogEntry {
     // `occurred_at` is NOT NULL on both UNION legs (`documentVersions.created_at`,
     // `auditLog.occurred_at`), so the shared `toDate`'s `null` branch is
     // unreachable here — the cast reflects that, not an assumption.
-    occurredAt: toDate(row.occurred_at) as Date,
+    occurredAt: toDate(row.occurred_at, 'occurred_at') as Date,
   }
 }
 

--- a/packages/db-mysql/src/modules/storage/normalize-row.ts
+++ b/packages/db-mysql/src/modules/storage/normalize-row.ts
@@ -63,7 +63,10 @@ export function normalizeRow(row: Record<string, unknown>): UnifiedFieldValue {
     thumbnail_generated: normalizeTinyIntBoolean(row.thumbnail_generated),
     cascade_delete: normalizeTinyIntBoolean(row.cascade_delete),
     value_date: toDateOnly(row.value_date as string | null | undefined),
-    value_timestamp_tz: toDate(row.value_timestamp_tz as string | null | undefined),
+    value_timestamp_tz: toDate(
+      row.value_timestamp_tz as string | null | undefined,
+      'value_timestamp_tz'
+    ),
   } as unknown as UnifiedFieldValue
 }
 

--- a/packages/db-mysql/src/modules/storage/normalize-row.ts
+++ b/packages/db-mysql/src/modules/storage/normalize-row.ts
@@ -70,21 +70,20 @@ export function normalizeRow(row: Record<string, unknown>): UnifiedFieldValue {
  * node-postgres's own default parser for a `date` column. It doesn't.
  * node-postgres's default `date` parser is `postgres-date` (see its
  * `index.js:16-17`, whose own comment reads "Force YYYY-MM-DD dates to be
- * parsed as local time"), so pg's `normalize-row.ts` being an identity cast
- * means that adapter returns **local** midnight, not UTC midnight — on any
- * host not running in UTC, the same stored `date` value materialises as a
- * different `Date` (potentially a different calendar day once rendered)
- * depending on which adapter served it.
+ * parsed as local time") — that mismatch is the reason the UTC-vs-local
+ * question was raised in the first place. It's moot in practice, though:
+ * pg's `normalize-row.ts` bypasses `postgres-date` entirely (drizzle-orm's
+ * node-postgres session installs an identity `getTypeParser` for `DATE`, so
+ * that default parser never runs on this read path), and as of task 13b
+ * pg's own `toDateOnly` anchors at UTC midnight too, for the same
+ * determinism reason: host-local midnight would make the same stored `date`
+ * value materialise as a different calendar day depending on which host
+ * served it.
  *
- * UTC midnight is defensible on its own terms — deterministic across hosts,
- * where pg's local-midnight parse is host-timezone-dependent — but choosing
- * between the two properly needs temporal fixtures in the shared
- * `@byline/db-conformance` suite (today's `field-types.ts` only asserts
- * `attachment.fileSize`, never a temporal value) and a non-UTC CI leg to
- * prove either adapter's behaviour under a host offset — neither exists
- * yet. So this stays exactly as it is: **elected, pending adjudication** —
- * do not change this behaviour without that groundwork; see the PR 3
- * tracking note.
+ * **Ruling (project owner, task 13b): settled.** Both adapters return a
+ * `Date` at UTC midnight for `date` fields — verified together, via the
+ * shared `@byline/db-conformance` `field-types.ts` fixtures, under both
+ * `TZ=UTC` and `TZ=Asia/Bangkok`. This is no longer provisional.
  */
 function toDateOnly(value: string | Date | null | undefined): Date | null {
   if (value == null) return null

--- a/packages/db-mysql/src/modules/storage/normalize-row.ts
+++ b/packages/db-mysql/src/modules/storage/normalize-row.ts
@@ -14,11 +14,17 @@ import { toDate } from './storage-utils.js'
  * Canonicalise a raw UNION ALL driver row to the shared `UnifiedFieldValue`
  * contract before it reaches `extractFlattenedFieldValue`. Mirrors
  * `packages/db-postgres/src/modules/storage/normalize-row.ts`, whose pg
- * counterpart is an identity cast — the mysql2 driver needs real
- * canonicalisation, verified against a live MySQL 9.7.1 server rather than
- * assumed (mysql2's declared types are a hypothesis, not fact — see
- * `src/index.ts`'s boot-check comment for the prior instance of this on
- * this program):
+ * counterpart also coerces `value_date` / `value_timestamp_tz` to `Date`
+ * (as of task 13b — see that file's docblock for the pg-specific evidence)
+ * but is otherwise closer to an identity cast: the mysql2 driver needs
+ * substantially more canonicalisation below, verified against a live
+ * MySQL 9.7.1 server rather than assumed (mysql2's declared types are a
+ * hypothesis, not fact — see `src/index.ts`'s boot-check comment for the
+ * prior instance of this on this program). `value_time` is deliberately
+ * left untouched on both adapters — a bare time-of-day has no calendar
+ * date or time zone to normalise, and the task-13b "converge on Date"
+ * ruling explicitly excludes it (see the `time` fixture in
+ * `packages/db-conformance/src/suites/field-types.ts`):
  *
  *   - `TINYINT(1)` → `boolean`. mysql2 returns a JS `number` (`0`/`1`) for
  *     `TINYINT(1)` columns selected through a raw query, not a `boolean` —
@@ -82,13 +88,42 @@ export function normalizeRow(row: Record<string, unknown>): UnifiedFieldValue {
  *
  * **Ruling (project owner, task 13b): settled.** Both adapters return a
  * `Date` at UTC midnight for `date` fields — verified together, via the
- * shared `@byline/db-conformance` `field-types.ts` fixtures, under both
- * `TZ=UTC` and `TZ=Asia/Bangkok`. This is no longer provisional.
+ * shared `@byline/db-conformance` `field-types.ts` fixtures, under `TZ=UTC`
+ * and two non-UTC zones on both sides of it (`Asia/Bangkok`, `+07`, and
+ * `America/New_York`, a negative offset — a positive-only check can't
+ * distinguish a local-getter bug from a correct UTC one when the fixture's
+ * instant is itself UTC midnight). This is no longer provisional.
+ *
+ * This is the sole gate between the raw driver row and `ClientDocument`'s
+ * public `value_date` shape, so a malformed `DATE` string must not fall
+ * through as a silent `Invalid Date` — it throws instead, naming the raw
+ * value.
+ *
+ * The `value instanceof Date` branch is a defensive passthrough for a row
+ * assembled in-process rather than round-tripped through the driver — not
+ * exercised through the live UNION ALL read path today (mysql2's
+ * `typeCast` override always hands this function text, per the module
+ * docblock above). If a future driver change ever made this column arrive
+ * as a `Date` already, this function would trust it unchanged rather than
+ * re-normalising it to UTC midnight — and there's no safe way to
+ * re-normalise after the fact, because a bare `Date` carries no record of
+ * which midnight convention (UTC or host-local) produced it, so
+ * re-deriving the calendar day from either its UTC or local getters could
+ * silently pick the wrong one depending on the host's offset. Flagging
+ * this explicitly rather than adding a "normalisation" that would only be
+ * correct for some host timezones — mirrors the identical hazard comment
+ * on pg's `toDateOnly`.
  */
 function toDateOnly(value: string | Date | null | undefined): Date | null {
   if (value == null) return null
   if (value instanceof Date) return value
-  return new Date(`${value}T00:00:00.000Z`)
+  const date = new Date(`${value}T00:00:00.000Z`)
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(
+      `normalizeRow: value_date is not a parseable date — got ${JSON.stringify(value)}`
+    )
+  }
+  return date
 }
 
 /**

--- a/packages/db-mysql/src/modules/storage/storage-commands.ts
+++ b/packages/db-mysql/src/modules/storage/storage-commands.ts
@@ -272,6 +272,27 @@ export class DocumentCommands implements IDocumentCommands {
       // 2. Create the document version. The id is minted here (app-side
       // UUIDv7), so the row is constructed in JS below rather than
       // re-`SELECT`ed — MySQL has no `RETURNING`.
+      //
+      // `created_at`/`updated_at` are passed explicitly rather than left to
+      // the column's `DEFAULT CURRENT_TIMESTAMP(6)` — unlike, say,
+      // `CollectionCommands.create`'s approximated timestamps above, where
+      // the small gap between app-side capture and DB-side evaluation is
+      // genuinely inconsequential. Here it is not: `occurred_at` on this row
+      // is a value the shared `db-conformance` audit activity-feed fixture
+      // (and any other caller windowing on `created_at`) treats as
+      // authoritative to derive query boundaries from the very `Date` this
+      // method returns. Leaving the column to the DB default means the
+      // *returned* timestamp (captured here, before the INSERT is even sent)
+      // and the *persisted* timestamp (evaluated by the MySQL server when the
+      // statement executes) are two independent clock reads that can diverge
+      // under load — confirmed live: under CPU contention this measured a
+      // 1–6ms gap between the two, enough to push a boundary row outside an
+      // inclusive `<=` window derived from the approximated value and
+      // intermittently fail `filters by date range on occurred_at`
+      // (`packages/db-conformance/src/suites/audit.ts`). Writing the same
+      // `Date` instance to the column that gets returned makes the two
+      // identical by construction — there is no longer a second clock to
+      // drift against.
       const documentVersionId = uuidv7()
       const createdAt = new Date()
       await tx.insert(documentVersions).values({
@@ -282,6 +303,8 @@ export class DocumentCommands implements IDocumentCommands {
         event_type: params.action ?? 'create',
         status: params.status ?? 'draft',
         created_by: params.createdBy ?? null,
+        created_at: createdAt,
+        updated_at: createdAt,
       })
       const documentVersion = {
         id: documentVersionId,

--- a/packages/db-mysql/src/modules/storage/storage-commands.ts
+++ b/packages/db-mysql/src/modules/storage/storage-commands.ts
@@ -99,6 +99,20 @@ export class CollectionCommands implements ICollectionCommands {
     const version = opts?.version ?? 1
     const singular = config.labels.singular || path
     const plural = config.labels.plural || `${path}s`
+    // `created_at`/`updated_at` are written explicitly rather than left to
+    // the column's `DEFAULT CURRENT_TIMESTAMP(6)` — an earlier version of
+    // this method approximated them with a request-time `Date` instead
+    // (reasoning: "no caller in this adapter's current scope depends on
+    // the authoritative value"), which is the exact reasoning that held for
+    // `DocumentCommands.createDocumentVersion` right up until a
+    // `db-conformance` fixture started windowing on `created_at` and an
+    // intermittent few-millisecond gap between the app-side capture and the
+    // DB-side `CURRENT_TIMESTAMP(6)` evaluation turned into a real flake —
+    // see that method's `created_at`/`updated_at` comment below for the
+    // live-server evidence. Writing the same `Date` instance to the column
+    // that gets returned makes the two identical by construction instead of
+    // two independent clock reads that can drift under load.
+    const now = new Date()
     await this.db.insert(collections).values({
       id,
       path,
@@ -106,14 +120,14 @@ export class CollectionCommands implements ICollectionCommands {
       plural,
       config,
       version,
+      created_at: now,
+      updated_at: now,
       ...(opts?.schemaHash !== undefined ? { schema_hash: opts.schemaHash } : {}),
     })
     // `.returning()` has no MySQL equivalent — every value here is already
-    // known (app-generated id, caller-supplied config), so the row is
-    // constructed in JS rather than re-`SELECT`ed. `created_at`/`updated_at`
-    // are DB defaults (`CURRENT_TIMESTAMP(6)`); approximated with the
-    // request-time `Date` since no caller in this adapter's current scope
-    // depends on the authoritative DB-assigned value.
+    // known (app-generated id, caller-supplied config, and the `created_at`
+    // / `updated_at` just written above), so the row is constructed in JS
+    // rather than re-`SELECT`ed.
     return [
       {
         id,
@@ -123,8 +137,8 @@ export class CollectionCommands implements ICollectionCommands {
         config,
         version,
         schema_hash: opts?.schemaHash ?? null,
-        created_at: new Date(),
-        updated_at: new Date(),
+        created_at: now,
+        updated_at: now,
       },
     ]
   }

--- a/packages/db-mysql/src/modules/storage/storage-commands.ts
+++ b/packages/db-mysql/src/modules/storage/storage-commands.ts
@@ -288,10 +288,9 @@ export class DocumentCommands implements IDocumentCommands {
       // re-`SELECT`ed — MySQL has no `RETURNING`.
       //
       // `created_at`/`updated_at` are passed explicitly rather than left to
-      // the column's `DEFAULT CURRENT_TIMESTAMP(6)` — unlike, say,
-      // `CollectionCommands.create`'s approximated timestamps above, where
-      // the small gap between app-side capture and DB-side evaluation is
-      // genuinely inconsequential. Here it is not: `occurred_at` on this row
+      // the column's `DEFAULT CURRENT_TIMESTAMP(6)` — the same explicit-write
+      // fix `CollectionCommands.create` above now also carries, for the same
+      // underlying reason it was found here first: `occurred_at` on this row
       // is a value the shared `db-conformance` audit activity-feed fixture
       // (and any other caller windowing on `created_at`) treats as
       // authoritative to derive query boundaries from the very `Date` this

--- a/packages/db-mysql/src/modules/storage/storage-queries.ts
+++ b/packages/db-mysql/src/modules/storage/storage-queries.ts
@@ -2154,8 +2154,8 @@ export class DocumentQueries implements IDocumentQueries {
       // mysql2 driver hands DATETIME columns back as strings here, not
       // `Date` (see `toDate`'s docstring, `storage-utils.ts`), confirmed
       // live: an un-coerced `as Date` cast was lying at the type level.
-      created_at: toDate(row.created_at as string) as Date,
-      updated_at: toDate(row.updated_at as string) as Date,
+      created_at: toDate(row.created_at as string, 'created_at') as Date,
+      updated_at: toDate(row.updated_at as string, 'updated_at') as Date,
       created_by: row.created_by as string,
       change_summary: row.change_summary as string,
       source_locale: (row.source_locale as string | null) ?? null,

--- a/packages/db-mysql/src/modules/storage/storage-utils.ts
+++ b/packages/db-mysql/src/modules/storage/storage-utils.ts
@@ -42,11 +42,28 @@ export const getFirstOrThrow =
  * separator is the correct interpretation, not an assumed one. Tolerant of
  * `null`/`undefined` and of the value already being a `Date` (defensive —
  * not expected on this path, but cheap to allow and keeps callers simple).
+ *
+ * This is the sole gate between the raw driver row and three different
+ * public contract shapes (`normalizeRow`'s `value_timestamp_tz`,
+ * `findDocuments`'s `created_at`/`updated_at`, and the audit log's
+ * `occurredAt`), so a malformed value must not fall through as a silent
+ * `Invalid Date` — it throws instead (task 13b §M2; see
+ * `packages/db-postgres/src/modules/storage/normalize-row.ts`'s `toDate`
+ * for the pg-side equivalent of this guard). `context` is optional and
+ * purely cosmetic — it names which column the caller is coercing in the
+ * thrown message; omitted call sites still get a safe, if less specific,
+ * error instead of a silently wrong `Date`.
  */
-export function toDate(value: string | Date | null | undefined): Date | null {
+export function toDate(value: string | Date | null | undefined, context?: string): Date | null {
   if (value == null) return null
   if (value instanceof Date) return value
-  return new Date(`${value.replace(' ', 'T')}Z`)
+  const date = new Date(`${value.replace(' ', 'T')}Z`)
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(
+      `toDate: ${context ?? 'value'} is not a parseable timestamp — got ${JSON.stringify(value)}`
+    )
+  }
+  return date
 }
 
 /**

--- a/packages/db-mysql/src/modules/storage/tests/dialect-pins.integration.test.ts
+++ b/packages/db-mysql/src/modules/storage/tests/dialect-pins.integration.test.ts
@@ -274,10 +274,46 @@ describe('MySQL dialect pins (live database)', () => {
     // a binary collation. See `findDocuments`' query-search site and
     // `packages/db-mysql/src/modules/storage/tests/storage-queries.test.ts`'s
     // "query (LIKE admin search)" test for the full end-to-end behavioural
-    // pin through `findDocuments`; this is the tight, direct-SQL smoke.
-    it('LIKE matches a stored value across case and accent variants', async () => {
-      const rows = await queryRows(rawPool, "SELECT ('Ünïcödé' LIKE ?) as matched", ['unicode'])
-      expect(Number(first(rows).matched)).toBe(1)
+    // pin through `findDocuments`.
+    //
+    // This test reads a real row through `byline_store_text.value` rather
+    // than comparing two SQL string literals — an earlier version of this
+    // test ran `SELECT ('Ünïcödé' LIKE ?) as matched`, which pins the
+    // *connection's* default collation (`collation_connection`, derived
+    // from the pool's `charset`), not the column's. Re-collating `value`
+    // to a binary collation would leave that version green while breaking
+    // the exact behaviour it claimed to pin — this version would catch it,
+    // because the comparison now happens against the actual indexed
+    // column.
+    it('LIKE matches a stored value in byline_store_text across case and accent variants', async () => {
+      const testCollection: CollectionDefinition = {
+        path: `like-collation-pin-${timestamp}`,
+        labels: { singular: 'LikeCollationThing', plural: 'LikeCollationThings' },
+        fields: [{ name: 'title', type: 'text' }],
+      }
+      testDb = setupTestDB([testCollection])
+      const collectionId = first(
+        await testDb.commandBuilders.collections.create(testCollection.path, testCollection)
+      ).id
+      await testDb.commandBuilders.documents.createDocumentVersion({
+        collectionId,
+        collectionVersion: 1,
+        collectionConfig: testCollection,
+        action: 'create',
+        documentData: { title: 'Ünïcödé Sample' },
+        locale: 'all',
+        status: 'draft',
+      })
+
+      const rows = await queryRows(
+        rawPool,
+        'SELECT value FROM byline_store_text WHERE field_name = ? AND value LIKE ?',
+        ['title', '%unicode sample%']
+      )
+      expect(rows).toHaveLength(1)
+      expect(first(rows).value).toBe('Ünïcödé Sample')
+
+      await testDb.commandBuilders.collections.delete(collectionId)
     })
   })
 })

--- a/packages/db-mysql/src/modules/storage/tests/dialect-pins.integration.test.ts
+++ b/packages/db-mysql/src/modules/storage/tests/dialect-pins.integration.test.ts
@@ -1,0 +1,283 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+/**
+ * MySQL-specific dialect properties the shared `@byline/db-conformance`
+ * suite cannot express, because they pin behaviour the Postgres adapter
+ * either doesn't have (collation choices) or expresses differently (its own
+ * `COLLATE "C"` / native `numeric` type). Each pin below exists because a
+ * real, live-server-verified property depends on a specific schema choice
+ * in `packages/db-mysql/src/database/schema/{index,common}.ts` — see each
+ * test's comment for the column/config it pins and why.
+ */
+
+import { type CollectionDefinition, generateKeyBetween, generateNKeysBetween } from '@byline/core'
+import type mysql from 'mysql2/promise'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { setupTestDB, teardownTestDB } from '../../../lib/test-helper.js'
+
+const timestamp = Date.now()
+
+function first<T>(rows: T[]): T {
+  const row = rows[0]
+  if (row == null) throw new Error('expected at least one row, got none')
+  return row
+}
+
+async function queryRows(pool: mysql.Pool, sql: string, params: unknown[]): Promise<any[]> {
+  const [rows] = await pool.query(sql, params)
+  return rows as any[]
+}
+
+describe('MySQL dialect pins (live database)', () => {
+  let testDb: ReturnType<typeof setupTestDB>
+  let rawPool: mysql.Pool
+
+  beforeAll(() => {
+    testDb = setupTestDB()
+    rawPool = testDb.pool
+  })
+
+  afterAll(async () => {
+    await teardownTestDB()
+  })
+
+  describe('order_key sort parity', () => {
+    // `byline_documents.order_key` is `varcharByteSorted` (`ascii_bin`)
+    // specifically so `ORDER BY order_key` in SQL agrees with plain
+    // JavaScript string comparison — the fractional-index algorithm in
+    // `@byline/core` (`generateKeyBetween`) is designed against byte-wise
+    // ordering, and MySQL's database-default collation
+    // (`utf8mb4_0900_ai_ci`) does not agree with JS on every key (e.g.
+    // `'Zz'` vs `'a0'` sort oppositely under the two collations). This test
+    // builds a realistic, mixed-structure key spread — not just a single
+    // initial batch, but keys inserted "between" existing ones the way a
+    // real drag-and-drop reorder would generate them — shuffles the insert
+    // order, and asserts the database's own `ORDER BY` agrees with the JS
+    // sort of the exact same key strings.
+    it('DB ORDER BY order_key matches JS string sort over the generateKeyBetween alphabet', async () => {
+      const testCollection: CollectionDefinition = {
+        path: `order-key-pin-${timestamp}`,
+        labels: { singular: 'OrderKeyThing', plural: 'OrderKeyThings' },
+        fields: [{ name: 'title', type: 'text' }],
+      }
+      const collectionId = first(
+        await testDb.commandBuilders.collections.create(testCollection.path, testCollection)
+      ).id
+
+      // An initial batch of 8 keys (generateNKeysBetween bisects
+      // recursively, so this alone already mixes integer-part lengths and
+      // fraction lengths — a richer structure than a flat sequential
+      // batch), then interleave 7 more by generating a key strictly
+      // between each already-adjacent pair, the shape a real "drop between
+      // these two rows" reorder produces.
+      const initial = generateNKeysBetween(null, null, 8)
+      const interleaved = initial.slice(0, -1).map((key, i) => {
+        const next = initial[i + 1] as string
+        return generateKeyBetween(key, next)
+      })
+      const cleanKeys = [...initial, ...interleaved]
+
+      // Create one document per key, in shuffled order, so insertion order
+      // carries no information about sort order.
+      const shuffled = [...cleanKeys]
+      for (let i = shuffled.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1))
+        const tmp = shuffled[i]
+        shuffled[i] = shuffled[j] as string
+        shuffled[j] = tmp as string
+      }
+
+      for (const key of shuffled) {
+        const created = await testDb.commandBuilders.documents.createDocumentVersion({
+          collectionId,
+          collectionVersion: 1,
+          collectionConfig: testCollection,
+          action: 'create',
+          documentData: { title: key },
+          locale: 'all',
+          status: 'draft',
+        })
+        await testDb.commandBuilders.documents.setOrderKey({
+          document_id: created.document.document_id,
+          order_key: key,
+        })
+      }
+
+      const rows = await queryRows(
+        rawPool,
+        'SELECT id, order_key FROM byline_documents WHERE collection_id = ? ORDER BY order_key ASC',
+        [collectionId]
+      )
+      const dbOrderedKeys = rows.map((r) => r.order_key)
+      const jsSortedKeys = [...cleanKeys].sort()
+
+      expect(dbOrderedKeys).toEqual(jsSortedKeys)
+
+      await testDb.commandBuilders.collections.delete(collectionId)
+    })
+  })
+
+  describe('ascii_bin id equality', () => {
+    // Every id/FK column uses `uuidChar` — `CHAR(36) CHARACTER SET ascii
+    // COLLATE ascii_bin` — precisely so id comparisons are byte-wise
+    // (case-sensitive), the MySQL analogue of Postgres's native `uuid`
+    // type (which has no notion of a case-insensitive collation at all).
+    // MySQL's database-default collation (`utf8mb4_0900_ai_ci`) folds
+    // case, so without `ascii_bin` a case-flipped id would wrongly compare
+    // equal.
+    it('a CHAR(36) id differing only in case does not match', async () => {
+      const testCollection: CollectionDefinition = {
+        path: `ascii-bin-pin-${timestamp}`,
+        labels: { singular: 'AsciiBinThing', plural: 'AsciiBinThings' },
+        fields: [{ name: 'title', type: 'text' }],
+      }
+      const collectionId = first(
+        await testDb.commandBuilders.collections.create(testCollection.path, testCollection)
+      ).id
+      const created = await testDb.commandBuilders.documents.createDocumentVersion({
+        collectionId,
+        collectionVersion: 1,
+        collectionConfig: testCollection,
+        action: 'create',
+        documentData: { title: 'Ascii Bin' },
+        locale: 'all',
+        status: 'draft',
+      })
+      const documentId = created.document.document_id
+      expect(documentId).not.toBe(documentId.toUpperCase())
+
+      const exactMatch = await queryRows(rawPool, 'SELECT id FROM byline_documents WHERE id = ?', [
+        documentId,
+      ])
+      expect(exactMatch).toHaveLength(1)
+
+      const caseFlippedMatch = await queryRows(
+        rawPool,
+        'SELECT id FROM byline_documents WHERE id = ?',
+        [documentId.toUpperCase()]
+      )
+      expect(caseFlippedMatch).toHaveLength(0)
+
+      await testDb.commandBuilders.collections.delete(collectionId)
+    })
+  })
+
+  describe('DATETIME(6) UTC round-trip', () => {
+    // The mysql2 pool opens with `timezone: 'Z'` (see `src/index.ts` and
+    // `test-helper.ts`) so `Date` values are sent and received as UTC,
+    // without local-timezone reinterpretation at the connection layer —
+    // MySQL's `DATETIME` has no timezone-aware storage the way Postgres's
+    // `TIMESTAMPTZ` does, so this pool option is the entire mechanism.
+    // `fsp: 6` on `value_timestamp_tz` (`common.ts`'s `auditTimestamp`
+    // discipline, mirrored on the store table) matches pg's `TIMESTAMPTZ(6)`
+    // resolution.
+    it('writes a Date and reads back the identical instant', async () => {
+      const testCollection: CollectionDefinition = {
+        path: `datetime-utc-pin-${timestamp}`,
+        labels: { singular: 'DatetimeUtcThing', plural: 'DatetimeUtcThings' },
+        fields: [
+          { name: 'title', type: 'text' },
+          { name: 'atTime', type: 'datetime' },
+        ],
+      }
+      // `getDocumentById` resolves the collection definition from the set
+      // `queryBuilders` was constructed with — re-run `setupTestDB` with
+      // this test's collection so that lookup succeeds (mirrors the
+      // "Recreate queryBuilders when collections are provided" note in
+      // `test-helper.ts`).
+      testDb = setupTestDB([testCollection])
+      const collectionId = first(
+        await testDb.commandBuilders.collections.create(testCollection.path, testCollection)
+      ).id
+      const expected = new Date('2026-05-04T03:02:01.456Z')
+      const created = await testDb.commandBuilders.documents.createDocumentVersion({
+        collectionId,
+        collectionVersion: 1,
+        collectionConfig: testCollection,
+        action: 'create',
+        documentData: { title: 'UTC round-trip', atTime: expected },
+        locale: 'all',
+        status: 'draft',
+      })
+
+      const doc = await testDb.queryBuilders.documents.getDocumentById({
+        collection_id: collectionId,
+        document_id: created.document.document_id,
+        locale: 'all',
+      })
+
+      const value = doc?.fields?.atTime
+      expect(value).toBeInstanceOf(Date)
+      expect((value as Date).getTime()).toBe(expected.getTime())
+
+      await testDb.commandBuilders.collections.delete(collectionId)
+    })
+  })
+
+  describe('DECIMAL precision preservation', () => {
+    // The pool opens with `decimalNumbers: false` (`src/index.ts`,
+    // `test-helper.ts`) so `DECIMAL` columns arrive as strings rather than
+    // JS `number`s — MySQL/JS float coercion would silently lose precision
+    // on money/decimal values otherwise, matching pg's `numeric` handling
+    // (node-postgres also returns `numeric` as a string by default).
+    it('returns a decimal field value as a string, not a JS number', async () => {
+      const testCollection: CollectionDefinition = {
+        path: `decimal-pin-${timestamp}`,
+        labels: { singular: 'DecimalThing', plural: 'DecimalThings' },
+        fields: [
+          { name: 'title', type: 'text' },
+          { name: 'price', type: 'decimal' },
+        ],
+      }
+      testDb = setupTestDB([testCollection])
+      const collectionId = first(
+        await testDb.commandBuilders.collections.create(testCollection.path, testCollection)
+      ).id
+      const created = await testDb.commandBuilders.documents.createDocumentVersion({
+        collectionId,
+        collectionVersion: 1,
+        collectionConfig: testCollection,
+        action: 'create',
+        documentData: { title: 'Decimal', price: '19.99' },
+        locale: 'all',
+        status: 'draft',
+      })
+
+      const doc = await testDb.queryBuilders.documents.getDocumentById({
+        collection_id: collectionId,
+        document_id: created.document.document_id,
+        locale: 'all',
+      })
+
+      expect(typeof doc?.fields?.price).toBe('string')
+      expect(doc?.fields?.price).toBe('19.99')
+
+      await testDb.commandBuilders.collections.delete(collectionId)
+    })
+  })
+
+  describe('LIKE case- and accent-insensitivity (elected divergence)', () => {
+    // The store `value` text columns keep the database's default
+    // `utf8mb4_0900_ai_ci` collation deliberately — unlike `order_key` /
+    // id columns, which are pinned to byte-wise collations for structural
+    // reasons, the *content* columns are left case- and accent-folding on
+    // purpose, so admin search (`LIKE`) matches more broadly than
+    // Postgres's `ILIKE` (case-only). This is an elected, spec-level
+    // divergence, not an oversight — do not "fix" it by pinning `value` to
+    // a binary collation. See `findDocuments`' query-search site and
+    // `packages/db-mysql/src/modules/storage/tests/storage-queries.test.ts`'s
+    // "query (LIKE admin search)" test for the full end-to-end behavioural
+    // pin through `findDocuments`; this is the tight, direct-SQL smoke.
+    it('LIKE matches a stored value across case and accent variants', async () => {
+      const rows = await queryRows(rawPool, "SELECT ('Ünïcödé' LIKE ?) as matched", ['unicode'])
+      expect(Number(first(rows).matched)).toBe(1)
+    })
+  })
+})

--- a/packages/db-mysql/src/modules/storage/tests/storage-document-tree.test.ts
+++ b/packages/db-mysql/src/modules/storage/tests/storage-document-tree.test.ts
@@ -318,7 +318,7 @@ describe('DocumentCommands tree mutations (mysql, live database)', () => {
         documentId: a,
         parentDocumentId: a,
       })
-    ).rejects.toThrow()
+    ).rejects.toMatchObject({ code: ErrorCodes.VALIDATION })
 
     // A is C's ancestor, so making A a child of C is a cycle — exercises the
     // `WITH RECURSIVE chain AS (...)` cycle guard.
@@ -328,7 +328,7 @@ describe('DocumentCommands tree mutations (mysql, live database)', () => {
         documentId: a,
         parentDocumentId: c,
       })
-    ).rejects.toThrow()
+    ).rejects.toMatchObject({ code: ErrorCodes.VALIDATION })
   })
 
   it('re-parents atomically — one edge row, updated in place', async () => {

--- a/packages/db-mysql/src/modules/storage/tests/storage-status-and-lifecycle.test.ts
+++ b/packages/db-mysql/src/modules/storage/tests/storage-status-and-lifecycle.test.ts
@@ -351,5 +351,34 @@ describe('DocumentCommands status/archive/soft-delete/order-key/delete-locale (m
       })
       expect(result).toBeNull()
     })
+
+    it('returns null when every version of the document has been soft-deleted', async () => {
+      // Distinct from the "wholly absent document" case above — this
+      // document genuinely exists and has version rows, but all of them
+      // carry `is_deleted = true`, so the `AND is_deleted = false` filter
+      // in `deleteDocumentLocale`'s current-version lookup excludes every
+      // one of them, the same guard it hits for an absent document.
+      const created = await testDb.commandBuilders.documents.createDocumentVersion({
+        collectionId,
+        collectionVersion: 1,
+        collectionConfig: PostsCollectionConfig,
+        action: 'create',
+        documentData: { title: { en: 'Soft-Deleted', es: 'Borrado', fr: 'Supprimé' } },
+        locale: 'all',
+        status: 'draft',
+      })
+      const documentId = created.document.document_id
+
+      const affected = await testDb.commandBuilders.documents.softDeleteDocument({
+        document_id: documentId,
+      })
+      expect(affected).toBe(1)
+
+      const result = await testDb.commandBuilders.documents.deleteDocumentLocale({
+        documentId,
+        locale: 'es',
+      })
+      expect(result).toBeNull()
+    })
   })
 })

--- a/packages/db-mysql/tests/boot-smoke.integration.test.ts
+++ b/packages/db-mysql/tests/boot-smoke.integration.test.ts
@@ -64,20 +64,26 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { type MySqlAdapter, mysqlAdapter } from '../src/index.js'
 import { assertTestDatabase } from '../src/lib/test-db.js'
 
-// `initBylineCore()` registers two process-global singletons
-// (`registerServerConfig`, `defineBylineCore` — see
-// `packages/core/src/config/config.ts`), keyed on `globalThis` symbols so
+// `initBylineCore()` registers three process-global singletons —
+// `registerServerConfig` and `defineBylineCore` (`packages/core/src/config/
+// config.ts`), plus `defineLogger` (`packages/core/src/lib/logger.ts`,
+// called at `core.ts:230`) — each keyed on its own `globalThis` symbol so
 // every copy of the module graph shares the same state. This suite closes
-// its pool in `afterAll`, so those globals must be reset afterward — this
-// file's mysql run is `isolate: false, maxWorkers: 1` and sorts before
+// its pool in `afterAll`, so all three globals must be reset afterward —
+// this file's mysql run is `isolate: false, maxWorkers: 1` and sorts before
 // `conformance.integration.test.ts`, so leaving them pointed at a dead pool
-// would poison whichever later file in this run resolves `getServerConfig()`
-// / `getBylineCore()`. There is no public reset API (nothing in this
-// codebase has needed one before this file), so this reaches into the same
-// two symbols `packages/core/src/config/config-hooks.test.node.ts` uses for
-// the identical purpose: snapshot before init, restore after teardown.
+// (or a logger closure holding one) would poison whichever later file in
+// this run resolves `getServerConfig()` / `getBylineCore()` / `getLogger()`.
+// The logger leak is inert today — nothing else in this package calls
+// `getLogger()` — but resetting all three keeps the claim here accurate
+// rather than describing two out of three. There is no public reset API
+// (nothing in this codebase has needed one before this file), so this
+// reaches into the same symbols `packages/core/src/config/
+// config-hooks.test.node.ts` uses for the identical purpose: snapshot
+// before init, restore after teardown.
 const SERVER_CONFIG_KEY = Symbol.for('__byline_server_config__')
 const BYLINE_CORE_KEY = Symbol.for('__byline_core__')
+const BYLINE_LOGGER_KEY = Symbol.for('__byline_logger__')
 
 function createBootSmokeCollection(suffix: string) {
   return defineCollection({
@@ -106,6 +112,7 @@ function createBootSmokeCollection(suffix: string) {
 describe('MySQL end-to-end boot smoke (initBylineCore composition, live database)', () => {
   let previousServerConfig: unknown
   let previousBylineCore: unknown
+  let previousLogger: unknown
   let db: MySqlAdapter
   let core: BylineCore
   let client: BylineClient
@@ -119,6 +126,7 @@ describe('MySQL end-to-end boot smoke (initBylineCore composition, live database
     const globals = globalThis as Record<PropertyKey, unknown>
     previousServerConfig = globals[SERVER_CONFIG_KEY]
     previousBylineCore = globals[BYLINE_CORE_KEY]
+    previousLogger = globals[BYLINE_LOGGER_KEY]
 
     definition = createBootSmokeCollection(`${Date.now()}`)
 
@@ -174,6 +182,8 @@ describe('MySQL end-to-end boot smoke (initBylineCore composition, live database
     else globals[SERVER_CONFIG_KEY] = previousServerConfig
     if (previousBylineCore === undefined) delete globals[BYLINE_CORE_KEY]
     else globals[BYLINE_CORE_KEY] = previousBylineCore
+    if (previousLogger === undefined) delete globals[BYLINE_LOGGER_KEY]
+    else globals[BYLINE_LOGGER_KEY] = previousLogger
   })
 
   it('survives create → read back → update → publish → read published → list → delete', async () => {

--- a/packages/db-mysql/tests/boot-smoke.integration.test.ts
+++ b/packages/db-mysql/tests/boot-smoke.integration.test.ts
@@ -1,0 +1,159 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+/**
+ * End-to-end boot smoke — task 13, §E.
+ *
+ * The conformance suite (`tests/conformance.integration.test.ts`) and the
+ * per-adapter unit tests (`src/modules/**\/tests/*.test.ts`) exercise
+ * `mysqlAdapter` in isolation, calling its commands/queries directly. Real
+ * usage never does that: an app calls `initBylineCore()` with a `db`
+ * adapter, then talks to `@byline/client` — a different composition, with
+ * its own layer of collection resolution, hooks, and lifecycle services
+ * sitting on top of the adapter.
+ *
+ * This test proves that composition boots and holds together against a
+ * MySQL-backed core: `defineServerConfig` (the same registration
+ * `initBylineCore()` performs) + `mysqlAdapter` + `createBylineClient`,
+ * then a realistic document lifecycle through the public
+ * `@byline/client` API — create, read back, update, publish, read
+ * published, list, delete — the same surface `apps/webapp` exercises
+ * through the admin UI. Mirrors
+ * `packages/client/tests/fixtures/setup.ts` (the Postgres equivalent of
+ * this composition), swapping `pgAdapter` for `mysqlAdapter`.
+ *
+ * What this does NOT exercise: the TanStack Start host adapter, the admin
+ * UI, or auth/session wiring — those are framework-specific layers above
+ * `@byline/client` this task's scope doesn't reach. What it DOES prove is
+ * that nothing in `@byline/client`'s lifecycle/hook/collection-resolution
+ * layer assumes a Postgres-shaped adapter.
+ */
+
+import { createSuperAdminContext } from '@byline/auth'
+import { type BylineClient, createBylineClient } from '@byline/client'
+import { defineCollection, defineServerConfig, defineWorkflow } from '@byline/core'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { type MySqlAdapter, mysqlAdapter } from '../src/index.js'
+import { assertTestDatabase } from '../src/lib/test-db.js'
+
+function createBootSmokeCollection(suffix: string) {
+  return defineCollection({
+    path: `boot-smoke-${suffix}`,
+    labels: { singular: 'BootSmokeDoc', plural: 'BootSmokeDocs' },
+    workflow: defineWorkflow({
+      draft: { label: 'Draft', verb: 'Revert to Draft' },
+      published: { label: 'Published', verb: 'Publish' },
+      archived: { label: 'Archived', verb: 'Archive' },
+    }),
+    useAsPath: 'title',
+    fields: [
+      { name: 'title', type: 'text', label: 'Title' },
+      { name: 'summary', type: 'textArea', label: 'Summary', optional: true },
+    ],
+  })
+}
+
+describe('MySQL end-to-end boot smoke (initBylineCore composition, live database)', () => {
+  let db: MySqlAdapter
+  let client: BylineClient
+  let collectionId: string
+  let definition: ReturnType<typeof createBootSmokeCollection>
+
+  beforeAll(async () => {
+    const connectionString = process.env.BYLINE_DB_MYSQL_CONNECTION_STRING
+    assertTestDatabase(connectionString)
+
+    definition = createBootSmokeCollection(`${Date.now()}`)
+
+    // The same construction `apps/webapp/byline/server.config.ts` performs
+    // (`mysqlAdapter(...)` in place of `pgAdapter(...)`), followed by
+    // `defineServerConfig` — the registration step `initBylineCore()`
+    // performs internally so `getCollectionDefinition()` resolves at
+    // runtime for lifecycle hooks and path/slug derivation.
+    db = mysqlAdapter({
+      connectionString: connectionString as string,
+      collections: [definition],
+      defaultContentLocale: 'en',
+    })
+
+    defineServerConfig({
+      db,
+      serverURL: 'http://localhost:3000',
+      i18n: {
+        interface: { defaultLocale: 'en', locales: ['en'] },
+        content: { defaultLocale: 'en', locales: ['en'] },
+      },
+      collections: [definition],
+    })
+
+    const [row] = await db.commands.collections.create(definition.path, definition)
+    if (!row) throw new Error(`Failed to create test collection '${definition.path}'`)
+    collectionId = row.id as string
+
+    client = createBylineClient({
+      db,
+      collections: [definition],
+      requestContext: createSuperAdminContext({ id: 'boot-smoke-super-admin' }),
+    })
+  }, 30_000)
+
+  afterAll(async () => {
+    try {
+      await db.commands.collections.delete(collectionId)
+    } catch (error) {
+      console.error('Failed to clean up boot-smoke test collection:', error)
+    }
+    await db.pool.end()
+  })
+
+  it('survives create → read back → update → publish → read published → list → delete', async () => {
+    const handle = client.collection(definition.path)
+
+    // create
+    const created = await handle.create(
+      { title: 'Boot Smoke Doc', summary: 'first draft' },
+      { path: 'boot-smoke-doc' }
+    )
+    expect(created.documentId).toBeTruthy()
+    expect(created.documentVersionId).toBeTruthy()
+
+    // read back — a fresh draft isn't visible under the client's default
+    // `status: 'published'` mode, so this opts into `status: 'any'`, the
+    // same way an admin caller would.
+    const afterCreate = await handle.findById(created.documentId, { status: 'any' })
+    expect(afterCreate?.fields.title).toBe('Boot Smoke Doc')
+    expect(afterCreate?.fields.summary).toBe('first draft')
+    expect(afterCreate?.status).toBe('draft')
+
+    // update — a new immutable version, still draft.
+    await handle.update(created.documentId, { title: 'Boot Smoke Doc', summary: 'second draft' })
+    const afterUpdate = await handle.findById(created.documentId, { status: 'any' })
+    expect(afterUpdate?.fields.summary).toBe('second draft')
+    expect(afterUpdate?.status).toBe('draft')
+
+    // publish
+    await handle.changeStatus(created.documentId, 'published')
+
+    // read published — the client's default read mode, no `status` override.
+    const published = await handle.findById(created.documentId)
+    expect(published?.fields.summary).toBe('second draft')
+    expect(published?.status).toBe('published')
+
+    // list — the published document surfaces in the default find().
+    const listed = await handle.find()
+    expect(listed.docs.map((d) => d.id)).toContain(created.documentId)
+
+    // delete — soft delete; the document disappears from every read mode.
+    await handle.delete(created.documentId)
+    const afterDelete = await handle.findById(created.documentId, { status: 'any' })
+    expect(afterDelete).toBeNull()
+    const listedAfterDelete = await handle.find({ status: 'any' })
+    expect(listedAfterDelete.docs.map((d) => d.id)).not.toContain(created.documentId)
+  })
+})

--- a/packages/db-mysql/tests/boot-smoke.integration.test.ts
+++ b/packages/db-mysql/tests/boot-smoke.integration.test.ts
@@ -18,29 +18,66 @@
  * sitting on top of the adapter.
  *
  * This test proves that composition boots and holds together against a
- * MySQL-backed core: `defineServerConfig` (the same registration
- * `initBylineCore()` performs) + `mysqlAdapter` + `createBylineClient`,
- * then a realistic document lifecycle through the public
- * `@byline/client` API — create, read back, update, publish, read
- * published, list, delete — the same surface `apps/webapp` exercises
- * through the admin UI. Mirrors
+ * MySQL-backed core. It calls the **actual** `initBylineCore()` — not a
+ * hand-rolled approximation of it — against `mysqlAdapter`, so the boot
+ * half genuinely exercises `ensureCollections()` (collection row
+ * reconciliation) and `discoverCounterGroups()` (counter-sequence
+ * registration) through the adapter, not just the lifecycle half sitting
+ * on top of it. An earlier version of this file called `defineServerConfig`
+ * directly and created the collection row by hand via
+ * `db.commands.collections.create` — that only registers the global config
+ * singleton (`defineServerConfig` is `registerServerConfig(resolveServerConfig(...))`,
+ * nothing more; see `packages/core/src/config/config.ts`) and skips every
+ * other step `initBylineCore()` performs (`validateTreeAuditCapability`,
+ * `ensureCollections`, `discoverCounterGroups`, `backfillSourceLocales` —
+ * see `packages/core/src/core.ts`), so it never actually proved those steps
+ * work against MySQL despite the docblock's claim to the contrary. Fixed
+ * here: the boot-smoke collection carries a `counter` field so
+ * `discoverCounterGroups()` has a real group to register (a collection with
+ * no counter field makes it a no-op — see
+ * `packages/core/src/services/discover-counter-groups.ts`), and the create
+ * step asserts the allocated value, so counter-sequence emulation is
+ * actually exercised end-to-end, not just invoked and ignored.
+ *
+ * Then a realistic document lifecycle through the public `@byline/client`
+ * API — create, read back, update, publish, read published, list, delete —
+ * the same surface `apps/webapp` exercises through the admin UI. Mirrors
  * `packages/client/tests/fixtures/setup.ts` (the Postgres equivalent of
- * this composition), swapping `pgAdapter` for `mysqlAdapter`.
+ * this composition), swapping `pgAdapter` for `mysqlAdapter` — that fixture
+ * also calls `defineServerConfig` rather than `initBylineCore()`, so this
+ * file is deliberately *not* a copy of it for the boot half.
  *
  * What this does NOT exercise: the TanStack Start host adapter, the admin
  * UI, or auth/session wiring — those are framework-specific layers above
  * `@byline/client` this task's scope doesn't reach. What it DOES prove is
- * that nothing in `@byline/client`'s lifecycle/hook/collection-resolution
+ * that `initBylineCore()`'s full boot sequence — collection reconciliation
+ * and counter-group discovery included — completes against a MySQL adapter,
+ * and that nothing in `@byline/client`'s lifecycle/hook/collection-resolution
  * layer assumes a Postgres-shaped adapter.
  */
 
 import { createSuperAdminContext } from '@byline/auth'
 import { type BylineClient, createBylineClient } from '@byline/client'
-import { defineCollection, defineServerConfig, defineWorkflow } from '@byline/core'
+import { type BylineCore, defineCollection, defineWorkflow, initBylineCore } from '@byline/core'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
 import { type MySqlAdapter, mysqlAdapter } from '../src/index.js'
 import { assertTestDatabase } from '../src/lib/test-db.js'
+
+// `initBylineCore()` registers two process-global singletons
+// (`registerServerConfig`, `defineBylineCore` — see
+// `packages/core/src/config/config.ts`), keyed on `globalThis` symbols so
+// every copy of the module graph shares the same state. This suite closes
+// its pool in `afterAll`, so those globals must be reset afterward — this
+// file's mysql run is `isolate: false, maxWorkers: 1` and sorts before
+// `conformance.integration.test.ts`, so leaving them pointed at a dead pool
+// would poison whichever later file in this run resolves `getServerConfig()`
+// / `getBylineCore()`. There is no public reset API (nothing in this
+// codebase has needed one before this file), so this reaches into the same
+// two symbols `packages/core/src/config/config-hooks.test.node.ts` uses for
+// the identical purpose: snapshot before init, restore after teardown.
+const SERVER_CONFIG_KEY = Symbol.for('__byline_server_config__')
+const BYLINE_CORE_KEY = Symbol.for('__byline_core__')
 
 function createBootSmokeCollection(suffix: string) {
   return defineCollection({
@@ -55,12 +92,22 @@ function createBootSmokeCollection(suffix: string) {
     fields: [
       { name: 'title', type: 'text', label: 'Title' },
       { name: 'summary', type: 'textArea', label: 'Summary', optional: true },
+      // Gives `discoverCounterGroups()` (run inside `initBylineCore()`) a
+      // real group to register against MySQL's `ensureCounterGroup` — a
+      // collection with no `counter` field makes that pass a documented
+      // no-op (`discoverCounterGroups` returns early on an empty group
+      // set), which would leave the boot half's counter-sequence claim
+      // unverified even after switching to a real `initBylineCore()` call.
+      { name: 'sequenceId', type: 'counter', group: `boot-smoke-counters-${suffix}` },
     ],
   })
 }
 
 describe('MySQL end-to-end boot smoke (initBylineCore composition, live database)', () => {
+  let previousServerConfig: unknown
+  let previousBylineCore: unknown
   let db: MySqlAdapter
+  let core: BylineCore
   let client: BylineClient
   let collectionId: string
   let definition: ReturnType<typeof createBootSmokeCollection>
@@ -69,32 +116,43 @@ describe('MySQL end-to-end boot smoke (initBylineCore composition, live database
     const connectionString = process.env.BYLINE_DB_MYSQL_CONNECTION_STRING
     assertTestDatabase(connectionString)
 
+    const globals = globalThis as Record<PropertyKey, unknown>
+    previousServerConfig = globals[SERVER_CONFIG_KEY]
+    previousBylineCore = globals[BYLINE_CORE_KEY]
+
     definition = createBootSmokeCollection(`${Date.now()}`)
 
-    // The same construction `apps/webapp/byline/server.config.ts` performs
-    // (`mysqlAdapter(...)` in place of `pgAdapter(...)`), followed by
-    // `defineServerConfig` — the registration step `initBylineCore()`
-    // performs internally so `getCollectionDefinition()` resolves at
-    // runtime for lifecycle hooks and path/slug derivation.
     db = mysqlAdapter({
       connectionString: connectionString as string,
       collections: [definition],
       defaultContentLocale: 'en',
     })
 
-    defineServerConfig({
+    // The actual boot sequence — not a hand-rolled approximation. Runs
+    // `ensureCollections()` (creates the `boot-smoke-*` collection row —
+    // no separate `db.commands.collections.create` call needed) and
+    // `discoverCounterGroups()` (registers the `boot-smoke-counters-*`
+    // sequence) against this MySQL adapter, among the other boot steps in
+    // `packages/core/src/core.ts`.
+    core = await initBylineCore({
       db,
       serverURL: 'http://localhost:3000',
       i18n: {
-        interface: { defaultLocale: 'en', locales: ['en'] },
+        // Empty interface locale set — `validateTranslations()` (run
+        // inside `initBylineCore()`) skips its translations-bundle
+        // requirement entirely when `locales` is empty (see
+        // `packages/core/src/services/i18n-validator.ts`: "hosts that
+        // don't mount the admin UI ... can omit translations entirely").
+        // This suite exercises the document-lifecycle/adapter composition,
+        // not the admin UI, so it deliberately doesn't mount one rather
+        // than pulling in `@byline/i18n` just to satisfy the validator.
+        interface: { defaultLocale: 'en', locales: [] },
         content: { defaultLocale: 'en', locales: ['en'] },
       },
       collections: [definition],
     })
 
-    const [row] = await db.commands.collections.create(definition.path, definition)
-    if (!row) throw new Error(`Failed to create test collection '${definition.path}'`)
-    collectionId = row.id as string
+    collectionId = core.getCollectionRecord(definition.path).collectionId
 
     client = createBylineClient({
       db,
@@ -110,12 +168,20 @@ describe('MySQL end-to-end boot smoke (initBylineCore composition, live database
       console.error('Failed to clean up boot-smoke test collection:', error)
     }
     await db.pool.end()
+
+    const globals = globalThis as Record<PropertyKey, unknown>
+    if (previousServerConfig === undefined) delete globals[SERVER_CONFIG_KEY]
+    else globals[SERVER_CONFIG_KEY] = previousServerConfig
+    if (previousBylineCore === undefined) delete globals[BYLINE_CORE_KEY]
+    else globals[BYLINE_CORE_KEY] = previousBylineCore
   })
 
   it('survives create → read back → update → publish → read published → list → delete', async () => {
     const handle = client.collection(definition.path)
 
-    // create
+    // create — also proves discoverCounterGroups()'s registered sequence is
+    // actually usable: `sequenceId` is allocator-assigned, never supplied
+    // by the caller.
     const created = await handle.create(
       { title: 'Boot Smoke Doc', summary: 'first draft' },
       { path: 'boot-smoke-doc' }
@@ -130,6 +196,9 @@ describe('MySQL end-to-end boot smoke (initBylineCore composition, live database
     expect(afterCreate?.fields.title).toBe('Boot Smoke Doc')
     expect(afterCreate?.fields.summary).toBe('first draft')
     expect(afterCreate?.status).toBe('draft')
+    const sequenceId = (afterCreate?.fields as Record<string, unknown> | undefined)?.sequenceId
+    expect(Number.isInteger(sequenceId)).toBe(true)
+    expect(sequenceId as number).toBeGreaterThan(0)
 
     // update — a new immutable version, still draft.
     await handle.update(created.documentId, { title: 'Boot Smoke Doc', summary: 'second draft' })

--- a/packages/db-mysql/tests/boot-smoke.integration.test.ts
+++ b/packages/db-mysql/tests/boot-smoke.integration.test.ts
@@ -49,11 +49,16 @@
  *
  * What this does NOT exercise: the TanStack Start host adapter, the admin
  * UI, or auth/session wiring — those are framework-specific layers above
- * `@byline/client` this task's scope doesn't reach. What it DOES prove is
- * that `initBylineCore()`'s full boot sequence — collection reconciliation
- * and counter-group discovery included — completes against a MySQL adapter,
- * and that nothing in `@byline/client`'s lifecycle/hook/collection-resolution
- * layer assumes a Postgres-shaped adapter.
+ * `@byline/client` this task's scope doesn't reach. The boot-smoke
+ * collection carries a `beforeCreate` hook (below) that mutates `summary`,
+ * asserted on the create step, so the hook layer isn't pure no-op dispatch
+ * here — but only that one slot is exercised; `afterCreate`, `beforeUpdate`,
+ * `afterUpdate`, and the rest of `CollectionHooks` are not. What it DOES
+ * prove is that `initBylineCore()`'s full boot sequence — collection
+ * reconciliation and counter-group discovery included — completes against a
+ * MySQL adapter, and that nothing in `@byline/client`'s
+ * lifecycle/hook/collection-resolution layer assumes a Postgres-shaped
+ * adapter.
  */
 
 import { createSuperAdminContext } from '@byline/auth'
@@ -106,6 +111,15 @@ function createBootSmokeCollection(suffix: string) {
       // unverified even after switching to a real `initBylineCore()` call.
       { name: 'sequenceId', type: 'counter', group: `boot-smoke-counters-${suffix}` },
     ],
+    // Proves the hook layer actually dispatches through a MySQL-backed
+    // `initBylineCore()` composition, not just that it's wired and no-ops —
+    // see the module docblock's "What this does NOT exercise" note. Only
+    // `beforeCreate` is covered; asserted below on the create step.
+    hooks: {
+      beforeCreate: ({ data }) => {
+        data.summary = `${data.summary} (hook-mutated)`
+      },
+    },
   })
 }
 
@@ -204,7 +218,10 @@ describe('MySQL end-to-end boot smoke (initBylineCore composition, live database
     // same way an admin caller would.
     const afterCreate = await handle.findById(created.documentId, { status: 'any' })
     expect(afterCreate?.fields.title).toBe('Boot Smoke Doc')
-    expect(afterCreate?.fields.summary).toBe('first draft')
+    // '(hook-mutated)' only appears here if the collection's `beforeCreate`
+    // hook actually ran and its mutation reached persistence — proves the
+    // hook layer dispatches through this MySQL-backed composition.
+    expect(afterCreate?.fields.summary).toBe('first draft (hook-mutated)')
     expect(afterCreate?.status).toBe('draft')
     const sequenceId = (afterCreate?.fields as Record<string, unknown> | undefined)?.sequenceId
     expect(Number.isInteger(sequenceId)).toBe(true)

--- a/packages/db-mysql/vitest.config.ts
+++ b/packages/db-mysql/vitest.config.ts
@@ -3,9 +3,9 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig(({ mode }) => {
   // Unit:        vitest run --mode=node          → *.test.node.ts
   // Integration: vitest run --mode=integration   → **/*.test.ts under src/**/tests/
-  //              plus tests/**/*.test.ts — the conformance entry that will
-  //              run the shared @byline/db-conformance storage suite once
-  //              the storage/query modules land (Tasks 8-12).
+  //              plus tests/**/*.test.ts — the conformance entry
+  //              (tests/conformance.integration.test.ts) that runs the
+  //              shared @byline/db-conformance storage suite.
   const isIntegration = mode === 'integration'
   const testFiles = isIntegration
     ? ['src/**/tests/**/*.test.ts', 'tests/**/*.test.ts']
@@ -33,17 +33,6 @@ export default defineConfig(({ mode }) => {
             fileParallelism: false,
             maxWorkers: 1,
             isolate: false,
-            // TODO(Task 13): remove once the conformance entry lands.
-            // There is no `tests/` directory yet (`globalSetup` /
-            // `setupFiles` above point at files that don't exist until
-            // Task 13 lands the shared @byline/db-conformance suite
-            // entry), so `vitest run --mode=integration` currently
-            // matches zero test files and exits 1 with "No test files
-            // found" — which turns `pnpm test:integration` (and CI, which
-            // runs it at the repo root) red for a condition that isn't a
-            // failure, just "nothing to run yet." `passWithNoTests`
-            // makes an empty run exit 0 instead.
-            passWithNoTests: true,
           }
         : {}),
     },

--- a/packages/db-postgres/package.json
+++ b/packages/db-postgres/package.json
@@ -72,7 +72,6 @@
     "@byline/admin": "workspace:*",
     "@byline/core": "workspace:*",
     "drizzle-orm": "^0.45.2",
-    "npm-run-all": "^4.1.5",
     "pg": "^8.22.0",
     "uuid": "^14.0.1"
   },
@@ -85,6 +84,7 @@
     "chokidar-cli": "^3.0.0",
     "dotenv": "^17.4.2",
     "drizzle-kit": "^0.31.10",
+    "npm-run-all": "^4.1.5",
     "tsc-alias": "^1.9.1",
     "tsx": "^4.23.1",
     "typescript": "^7.0.2",

--- a/packages/db-postgres/src/modules/storage/normalize-row.ts
+++ b/packages/db-postgres/src/modules/storage/normalize-row.ts
@@ -15,7 +15,10 @@ import type { UnifiedFieldValue } from '@byline/core'
  * one deliberate coercion: `value_date` and `value_timestamp_tz` are turned
  * into real `Date` instances (see `toDateOnly` / `toDate` below) so this
  * adapter matches `@byline/db-mysql`'s temporal shape — see the "converge on
- * Date" ruling this module implements. Mirrors
+ * Date" ruling this module implements. `value_time` is left untouched on
+ * purpose — a bare time-of-day has no calendar date or time zone to
+ * normalise, and the task-13b ruling explicitly excludes it (see the `time`
+ * fixture in `packages/db-conformance/src/suites/field-types.ts`). Mirrors
  * `packages/db-mysql/src/modules/storage/normalize-row.ts`, whose mysql
  * counterpart has to canonicalise far more (tinyint booleans, JSON columns,
  * DATE/DATETIME arriving as strings for a different reason — see that
@@ -40,11 +43,36 @@ export function normalizeRow(row: Record<string, unknown>): UnifiedFieldValue {
  * (host-local midnight would make the same stored row shift calendar day
  * across deployments). Mirrors `@byline/db-mysql`'s `toDateOnly`, which
  * carries the full ruling history — see that file. Both adapters now agree.
+ *
+ * This is the sole gate between the raw driver row and `ClientDocument`'s
+ * public `value_date` shape, so a malformed input (a non-ISO `DateStyle`
+ * on the session, a BC-era date, a year past 9999) must not fall through
+ * as a silent `Invalid Date` — it throws instead, naming the raw value.
+ *
+ * The `value instanceof Date` branch is a defensive passthrough for a row
+ * assembled in-process rather than round-tripped through the driver — not
+ * exercised through the live UNION ALL read path today (Postgres always
+ * hands this column back as text there; see the module docblock). If a
+ * future driver/session change ever made this column arrive as a `Date`
+ * already, this function would trust it unchanged rather than
+ * re-normalising it to UTC midnight — and there's no safe way to
+ * re-normalise after the fact, because a bare `Date` carries no record of
+ * which midnight convention (UTC or host-local) produced it, so
+ * re-deriving the calendar day from either its UTC or local getters could
+ * silently pick the wrong one depending on the host's offset. Flagging
+ * this explicitly rather than adding a "normalisation" that would only be
+ * correct for some host timezones.
  */
 function toDateOnly(value: string | Date | null | undefined): Date | null {
   if (value == null) return null
   if (value instanceof Date) return value
-  return new Date(`${value}T00:00:00.000Z`)
+  const date = new Date(`${value}T00:00:00.000Z`)
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(
+      `normalizeRow: value_date is not a parseable date — got ${JSON.stringify(value)}`
+    )
+  }
+  return date
 }
 
 /**
@@ -79,9 +107,32 @@ function toDateOnly(value: string | Date | null | undefined): Date | null {
  * (microseconds) but a JS `Date` only holds milliseconds, so coercion
  * truncates sub-millisecond precision. That loss is unavoidable through this
  * API, not a bug in this function.
+ *
+ * This is the sole gate between the raw driver row and `ClientDocument`'s
+ * public `value_timestamp_tz` shape — the §C evidence above only shows the
+ * *offset* is always present, not that every string this function will
+ * ever see is parseable. A non-ISO `DateStyle` on the session, a BC-era
+ * timestamp, or a year past 9999 would otherwise fall through as a silent
+ * `Invalid Date`, so this throws instead, naming the raw value.
+ *
+ * The `value instanceof Date` branch is a defensive passthrough for a row
+ * assembled in-process rather than round-tripped through the driver — not
+ * exercised through the live UNION ALL read path today (confirmed above:
+ * the identity type parser always hands this function text). Unlike
+ * `toDateOnly`'s UTC-midnight anchor, there's no analogous "which
+ * convention" ambiguity here — a `Date` already denotes one absolute
+ * instant regardless of how it was constructed — so passing it through
+ * unchanged is safe as written; noted for the same reason as
+ * `toDateOnly`'s hazard comment, so both sites read the same way.
  */
 function toDate(value: string | Date | null | undefined): Date | null {
   if (value == null) return null
   if (value instanceof Date) return value
-  return new Date(value)
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(
+      `normalizeRow: value_timestamp_tz is not a parseable timestamp — got ${JSON.stringify(value)}`
+    )
+  }
+  return date
 }

--- a/packages/db-postgres/src/modules/storage/normalize-row.ts
+++ b/packages/db-postgres/src/modules/storage/normalize-row.ts
@@ -9,12 +9,79 @@
 import type { UnifiedFieldValue } from '@byline/core'
 
 /**
- * Canonicalise a raw UNION ALL driver row to the shared UnifiedFieldValue
- * contract. For pg this codifies current behaviour (identity for most
- * columns): BIGINT file_size may arrive as string (tolerated by the type),
- * numeric/decimal arrives as string, timestamptz arrives as Date.
- * The MySQL adapter's counterpart absorbs tinyint(1)→boolean etc.
+ * Canonicalise a raw UNION ALL driver row to the shared `UnifiedFieldValue`
+ * contract. For pg this is mostly identity (BIGINT `file_size` may arrive as
+ * a string, tolerated by the type; numeric/decimal arrives as a string) with
+ * one deliberate coercion: `value_date` and `value_timestamp_tz` are turned
+ * into real `Date` instances (see `toDateOnly` / `toDate` below) so this
+ * adapter matches `@byline/db-mysql`'s temporal shape — see the "converge on
+ * Date" ruling this module implements. Mirrors
+ * `packages/db-mysql/src/modules/storage/normalize-row.ts`, whose mysql
+ * counterpart has to canonicalise far more (tinyint booleans, JSON columns,
+ * DATE/DATETIME arriving as strings for a different reason — see that
+ * file's docblock).
  */
 export function normalizeRow(row: Record<string, unknown>): UnifiedFieldValue {
-  return row as unknown as UnifiedFieldValue
+  return {
+    ...row,
+    value_date: toDateOnly(row.value_date as string | Date | null | undefined),
+    value_timestamp_tz: toDate(row.value_timestamp_tz as string | Date | null | undefined),
+  } as unknown as UnifiedFieldValue
+}
+
+/**
+ * `'2026-01-15'` (Postgres `date` text, no time-of-day component) → a `Date`
+ * at **UTC** midnight for that calendar date.
+ *
+ * A `date` column carries no time zone identity at all — Postgres always
+ * renders it as a bare `YYYY-MM-DD` string, confirmed live against
+ * `byline_store_datetime.value_date` — so there is no offset to lose and no
+ * ambiguity to resolve; UTC midnight is simply the deterministic choice
+ * (host-local midnight would make the same stored row shift calendar day
+ * across deployments). Mirrors `@byline/db-mysql`'s `toDateOnly`, which
+ * carries the full ruling history — see that file. Both adapters now agree.
+ */
+function toDateOnly(value: string | Date | null | undefined): Date | null {
+  if (value == null) return null
+  if (value instanceof Date) return value
+  return new Date(`${value}T00:00:00.000Z`)
+}
+
+/**
+ * A `value_timestamp_tz` UNION ALL cell → a real `Date`.
+ *
+ * This looks like it should be ambiguous — `storage-store-manifest.ts`'s
+ * `pgNullCast()` casts the six store tables that don't own this column to
+ * `NULL::timestamp` (no time zone), and `drizzle-orm`'s node-postgres
+ * session installs a `getTypeParser` override that returns the driver's raw
+ * wire text unparsed for `TIMESTAMPTZ`/`TIMESTAMP`/`DATE` on every query
+ * (see that module's docblock, and `packages/core/src/storage/
+ * storage-row-types.ts`, for the fuller mechanism). Naively, six
+ * `timestamp`-typed NULL branches against one `timestamptz`-typed real
+ * branch would sound like the projected column loses its offset.
+ *
+ * It doesn't. Confirmed live (`byline_store_datetime`, `SET TIME ZONE
+ * 'Asia/Bangkok'`, and `pg_cast`): Postgres's set-operation type resolution
+ * picks `timestamp with time zone` as the UNION's common type, not
+ * `timestamp` — because `timestamp → timestamptz` is registered in
+ * `pg_cast` with `castcontext = 'i'` (implicit), so the six `NULL::timestamp`
+ * branches are implicitly promoted to `timestamptz` to match the one real
+ * branch, rather than the real branch being narrowed down to match them.
+ * The driver therefore always receives (and passes through unparsed) text
+ * carrying an explicit UTC offset, e.g. `'2024-01-15 03:00:00+00'` under a
+ * UTC session or `'2024-01-15 10:00:00+07'` under an `Asia/Bangkok` one for
+ * the same stored instant — verified to resolve to the same instant in both
+ * cases. `new Date(...)` parses that shape (space-separated, 2-digit or
+ * `HH:MM` offset) correctly in this runtime; no manual offset handling is
+ * needed or attempted here.
+ *
+ * Precision note: Postgres stores this column as `timestamptz(6)`
+ * (microseconds) but a JS `Date` only holds milliseconds, so coercion
+ * truncates sub-millisecond precision. That loss is unavoidable through this
+ * API, not a bug in this function.
+ */
+function toDate(value: string | Date | null | undefined): Date | null {
+  if (value == null) return null
+  if (value instanceof Date) return value
+  return new Date(value)
 }

--- a/packages/db-postgres/src/modules/storage/storage-queries.ts
+++ b/packages/db-postgres/src/modules/storage/storage-queries.ts
@@ -1877,8 +1877,9 @@ export class DocumentQueries implements IDocumentQueries {
 
     const { rows }: { rows: Record<string, unknown>[] } = await this.db.execute(query)
     // Canonicalise the raw UNION ALL driver rows at the ingestion boundary —
-    // see normalizeRow's docstring for what pg's driver leaves as-is
-    // (BIGINT/decimal-as-string, timestamptz-as-Date).
+    // see normalizeRow's docstring for the full picture: BIGINT/decimal
+    // stay strings (identity), but `value_date` / `value_timestamp_tz` are
+    // coerced to `Date` there, not left as the driver's raw text.
     return rows.map(normalizeRow)
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -684,9 +684,6 @@ importers:
       mysql2:
         specifier: ^3.23.1
         version: 3.23.1(@types/node@26.1.1)
-      npm-run-all:
-        specifier: ^4.1.5
-        version: 4.1.5
       uuid:
         specifier: ^14.0.1
         version: 14.0.1
@@ -718,6 +715,9 @@ importers:
       drizzle-kit:
         specifier: ^0.31.10
         version: 0.31.10
+      npm-run-all:
+        specifier: ^4.1.5
+        version: 4.1.5
       tsc-alias:
         specifier: ^1.9.1
         version: 1.9.1
@@ -742,9 +742,6 @@ importers:
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@types/pg@8.20.0)(mysql2@3.23.1(@types/node@26.1.1))(pg@8.22.0)
-      npm-run-all:
-        specifier: ^4.1.5
-        version: 4.1.5
       pg:
         specifier: ^8.22.0
         version: 8.22.0
@@ -776,6 +773,9 @@ importers:
       drizzle-kit:
         specifier: ^0.31.10
         version: 0.31.10
+      npm-run-all:
+        specifier: ^4.1.5
+        version: 4.1.5
       tsc-alias:
         specifier: ^1.9.1
         version: 1.9.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -694,6 +694,12 @@ importers:
       '@biomejs/biome':
         specifier: 2.5.4
         version: 2.5.4
+      '@byline/auth':
+        specifier: workspace:*
+        version: link:../auth
+      '@byline/client':
+        specifier: workspace:*
+        version: link:../client
       '@byline/db-conformance':
         specifier: workspace:*
         version: link:../db-conformance

--- a/specs/2026-07-24-db-mysql-adapter-design.md
+++ b/specs/2026-07-24-db-mysql-adapter-design.md
@@ -38,6 +38,15 @@ the companion analysis document — it is explicitly not part of this design).
 > conversion below (Section 1) also turned out to be wrong: mysql2 hands `DATETIME`/`DATE`
 > columns back as strings on this adapter's UNION ALL read path, not as `Date` objects, and
 > the adapter coerces them explicitly (`packages/db-mysql/src/modules/storage/normalize-row.ts`).
+> A third correction, added later: this design also decided `field_path` at `VARCHAR(512)`,
+> with the store tables' `(document_version_id, field_path, locale)` unique key sized at
+> ≈2,124 bytes. Task 8's implementation ruling restored `field_path` to `VARCHAR(500)` —
+> matching the Postgres adapter's bound exactly, and avoiding an `ER_DATA_TOO_LONG` trap on
+> `parent_path` (a prefix of `field_path`, and too narrow at the old bound) — which puts that
+> unique key at 2076 bytes, not 2124. The actual binding constraint against InnoDB's
+> 3072-byte cap is a different index: `idx_text_path_value` (`field_path` plus a 191-char
+> prefix of `value`), at 2764 bytes. See `packages/db-mysql/src/database/schema/index.ts`'s
+> `baseStoreColumns` comment and `schema-pins.test.node.ts`, which pins both figures.
 
 ## Decisions made during brainstorming
 
@@ -178,7 +187,7 @@ with a message naming the floor and the reason (LATERAL joins).
 | `jsonb` | `JSON` | mysql2 parses on read. The adapter uses no jsonb *operators* in SQL today (JSON values are opaque payloads), so parity is trivial |
 | `timestamptz` | `DATETIME(6)` | UTC by convention: pool `timezone: 'Z'`; all writes/reads UTC |
 | `text` (unindexed) | `TEXT` | |
-| `text` / `varchar` (indexed) | `VARCHAR(n)` with explicit length | InnoDB unique-index key cap is 3072 bytes; utf8mb4 costs 4 bytes/char. `field_path` is pinned at `VARCHAR(512)` utf8mb4 — with `CHAR(36)` ascii id + `VARCHAR(10)` locale, the store tables' `(document_version_id, field_path, locale)` unique key totals ≈ 2,124 bytes < 3,072 |
+| `text` / `varchar` (indexed) | `VARCHAR(n)` with explicit length | InnoDB index key cap is 3072 bytes; utf8mb4 costs 4 bytes/char. `field_path` is pinned at `VARCHAR(500)` utf8mb4 (see the correction note above) — with `CHAR(36)` ascii id + `VARCHAR(10)` locale, the store tables' `(document_version_id, field_path, locale)` unique key totals 2076 bytes; the tightest, binding constraint is actually the non-unique `idx_text_path_value` index at 2764 bytes < 3,072 |
 | `varchar(...) COLLATE "C"` (`order_key`) | `VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin` | Byte-wise ordering preserved — the fractional-index invariant (`generateKeyBetween` agrees with DB sort) holds |
 | `boolean` | `TINYINT(1)` | Normalised to boolean in `normalizeRow` |
 | `real` | `FLOAT` / `DOUBLE` | Match current precision choices column-by-column |
@@ -316,7 +325,7 @@ port surface.
 3. **REPEATABLE READ leakage** — any code path that opens a transaction outside
    `withTransaction` would get MySQL's default isolation; the adapter routes all
    transaction opening through `TXManagerImpl`, which sets READ COMMITTED.
-4. **utf8mb4 index-key budget** — pinned lengths (`field_path` 512) are asserted by
+4. **utf8mb4 index-key budget** — pinned lengths (`field_path` 500) are asserted by
    a schema test so a future column addition to the unique key cannot silently
    exceed 3,072 bytes.
 5. **Conformance-suite extraction fidelity** — the Phase 1 gate (db-postgres passes

--- a/specs/2026-07-24-db-mysql-adapter-design.md
+++ b/specs/2026-07-24-db-mysql-adapter-design.md
@@ -26,6 +26,19 @@ Drizzle ORM remains the development-time schema-management, generation, and migr
 tool for both adapters (the decision to keep or replace it is analysed separately in
 the companion analysis document — it is explicitly not part of this design).
 
+> **Correction (post-implementation, 2026-07-25):** this section originally decided
+> `DATETIME(3)` (millisecond) timestamps. The shipped adapter uses `DATETIME(6)`
+> (microsecond) instead, matching the Postgres adapter's
+> `timestamp(name, { precision: 6, withTimezone: true })` convention exactly — millisecond
+> resolution let two statements issued back-to-back on a fast local connection collide on
+> an identical `CURRENT_TIMESTAMP(3)` value, which is a real correctness gap for anything
+> that orders or windows by these columns (see `packages/db-mysql/src/database/schema/common.ts`'s
+> `auditTimestamp`). Every `DATETIME(3)` mention below is corrected to `DATETIME(6)`
+> accordingly. Separately, the "mysql2 does this natively" claim about `DATETIME` → `Date`
+> conversion below (Section 1) also turned out to be wrong: mysql2 hands `DATETIME`/`DATE`
+> columns back as strings on this adapter's UNION ALL read path, not as `Date` objects, and
+> the adapter coerces them explicitly (`packages/db-mysql/src/modules/storage/normalize-row.ts`).
+
 ## Decisions made during brainstorming
 
 | Question | Decision |
@@ -38,7 +51,7 @@ the companion analysis document — it is explicitly not part of this design).
 | Transaction plumbing | `DBManagerImpl` / `TXManagerImpl` (~90 lines) are **duplicated** per adapter, not shared — they are small and driver-typed; genericising over two Drizzle dialect types buys nothing behavioural |
 | Isolation level | The MySQL adapter opens transactions at **READ COMMITTED** explicitly (MySQL's default is REPEATABLE READ), so locking behaviour matches the Postgres adapter's assumptions and avoids gap-lock surprises |
 | Counters | Table-emulated sequences via the `LAST_INSERT_ID(expr)` atomic-increment idiom (MySQL has no `CREATE SEQUENCE`) |
-| Timestamps | `DATETIME(3)`, UTC by convention (pool `timezone: 'Z'`). `TIMESTAMP` rejected (2038 range limit) |
+| Timestamps | `DATETIME(6)`, UTC by convention (pool `timezone: 'Z'`). `TIMESTAMP` rejected (2038 range limit) |
 | Drizzle-free analysis | Separate recommendation-grade document; not a committed phase |
 
 ## Section 1 — shared-code extraction (Phase 1, behaviour-preserving)
@@ -83,8 +96,9 @@ absorbed:
   arriving as a string — already tolerated by `UnifiedFieldValue`'s
   `number | string | null` type).
 - mysql2: `TINYINT(1)` → boolean, `DECIMAL` → string (matching pg's `numeric`
-  behaviour), `DATETIME(3)` → `Date` (mysql2 does this natively when `dateStrings`
-  is off), `JSON` → parsed object.
+  behaviour), `DATETIME(6)` → string, coerced to `Date` explicitly by the adapter's
+  `normalizeRow` (not, as originally assumed here, something mysql2 does natively —
+  see the correction note above), `JSON` → parsed object.
 
 The seam is a **normalisation contract, not an abstraction layer**: adapters still
 write their own SQL; they just promise that rows handed to shared restore code are
@@ -162,7 +176,7 @@ with a message naming the floor and the reason (LATERAL joins).
 |---|---|---|
 | `uuid` | `CHAR(36) CHARACTER SET ascii COLLATE ascii_bin` | Decided above. All ids app-generated UUIDv7 |
 | `jsonb` | `JSON` | mysql2 parses on read. The adapter uses no jsonb *operators* in SQL today (JSON values are opaque payloads), so parity is trivial |
-| `timestamptz` | `DATETIME(3)` | UTC by convention: pool `timezone: 'Z'`; all writes/reads UTC |
+| `timestamptz` | `DATETIME(6)` | UTC by convention: pool `timezone: 'Z'`; all writes/reads UTC |
 | `text` (unindexed) | `TEXT` | |
 | `text` / `varchar` (indexed) | `VARCHAR(n)` with explicit length | InnoDB unique-index key cap is 3072 bytes; utf8mb4 costs 4 bytes/char. `field_path` is pinned at `VARCHAR(512)` utf8mb4 — with `CHAR(36)` ascii id + `VARCHAR(10)` locale, the store tables' `(document_version_id, field_path, locale)` unique key totals ≈ 2,124 bytes < 3,072 |
 | `varchar(...) COLLATE "C"` (`order_key`) | `VARCHAR(128) CHARACTER SET ascii COLLATE ascii_bin` | Byte-wise ordering preserved — the fractional-index invariant (`generateKeyBetween` agrees with DB sort) holds |


### PR DESCRIPTION
Phase 2, PR 3 of 3 — the final PR of the MySQL-adapter program. Tasks 13 and 15 of the [adapter plan](https://github.com/Byline-CMS/bylinecms.dev/blob/develop/specs/2026-07-24-db-mysql-adapter-plan.md), plus an unplanned temporal convergence and a real bug found while closing out.

Closes #42. Follows #49 (schema), #50 (adapter), #51 (CI service container).

## ⚠️ Breaking change to `@byline/db-postgres`

**`date` and `datetime` field values now arrive as `Date` objects rather than raw driver strings.** `date` anchors to **UTC midnight**. `time` is unchanged and remains a string.

If you read a temporal field value and do string operations on it — or hand it to a date parser expecting a string — check those call sites. Released as a **minor** on the 4.x line rather than a major: these values were previously undocumented raw driver output, and `packages/core/src/storage/storage-row-types.ts` already typed them `Date | string`, so consumers written to handle both shapes are unaffected. All 16 lockstep packages go 4.7.0 → 4.8.0.

## How this was found

The conformance suite asserted **no temporal value at all** — it checked `attachment.fileSize` and nothing time-shaped. That single blind spot had already let three defects through this program:

- `datetime`/`date` values silently returning strings instead of `Date` objects, surviving two code reviews
- `value_time` generated as `TIME(0)`, truncating fractional seconds against a spec saying `TIME(3)`
- a `toDateOnly` docblock claiming Postgres parity it never had

So Task 13 added temporal fixtures. They immediately found that the two adapters didn't just disagree about midnight — they returned **different types**, and the Postgres side was the outlier. Two mechanisms compound: `pgNullCast()` casts absent temporal columns to a TZ-less `timestamp` so the seven-way UNION ALL type-aligns, and drizzle's node-postgres session installs a `getTypeParser` override returning the identity function for `DATE`/`TIMESTAMP`/`TIMESTAMPTZ`. Postgres never parsed them.

The fixtures were first written **representation-tolerant** — asserting the calendar date survives without asserting which type or which midnight — because encoding a preference in a test would have pre-empted a decision that wasn't the implementer's to make. Once ruled, they were tightened to assert `instanceof Date` and the UTC calendar date, and the tolerance helpers deleted.

## A real bug, not a flaky test

An intermittent conformance failure (`filters by date range on occurred_at`, returning 2 or 0 where 3 was expected) root-caused to MySQL's `createDocumentVersion` returning a client-side `new Date()` as the version's `created_at` while the column itself took the server's `DEFAULT CURRENT_TIMESTAMP(6)`. Two independent clock reads that drift under load — **the adapter was reporting a timestamp that didn't match the row it had just written.**

Reproduced under matched CPU load (11/20 runs failed), fixed by removing the second clock rather than widening the window, verified 40/40 under the same load and 30/30 idle. The same pattern was then found surviving in `CollectionCommands.create`, justified in a comment with verbatim the reasoning that had just failed — also fixed.

## Also in here

- **MySQL dialect pins** — `order_key` DB sort vs. JS string sort over the `generateKeyBetween` alphabet, `ascii_bin` case-sensitive id equality, `DATETIME(6)` UTC round-trip, DECIMAL-as-string, and the elected `LIKE` accent-insensitivity divergence pinned against a real stored value.
- **A boot smoke through the real `initBylineCore()`** — collection reconciliation, counter-group discovery (asserted via an allocator-assigned `sequenceId`), translation validation, a `beforeCreate` hook whose mutation is verified to survive persistence, and a seven-step lifecycle through `@byline/client`.
- **A case-variant path fixture** pinning `/About` and `/about` as distinct documents on both adapters — today's behaviour, so that #48's proposed change is made knowingly rather than drifting in per-dialect.
- **Docs** — the adapter README (engine floor, UUID/timestamp conventions, counters emulation, and an honest "differences from the Postgres adapter" section), a storage-reference adapters note, and three design-spec corrections where the spec no longer matched what shipped.
- **Follow-ups filed:** #52 (`@byline/search-mysql`), #53 (storage benchmark), #54 (MariaDB, deferred), #55 (non-UTC CI leg + 8.0/latest matrix), #56 (`DatePicker` click-through and consumer blast radius).

## Verification

- `db-mysql` 201/201 integration, 280/280 unit · `db-postgres` **177/177** · `core` 843/843
- Identical results under `TZ=UTC` and `TZ=America/New_York` — a negative-offset zone, chosen because `+07` cannot discriminate a local-getter bug for a UTC-midnight instant
- `pnpm docs:check` (43 docs, 432 links), `git diff --check`, `typecheck` 30/30, `lint` 18/18, `knip` clean

## Notes for review

- The temporal coercion's safety under a non-UTC session was the one Critical-severity risk here. It was verified twice against a live database: `timestamp → timestamptz` is an implicit cast (`pg_cast` `castcontext='i'`), the projected UNION column resolves to `timestamp with time zone`, and the rendered text carries an offset — so a direct parse is safe and `pgNullCast` needed no change. The `+07`, `+05:45` and `-05` renderings all parse to the identical instant.
- Every temporal coercion on both adapters now throws on unparseable input rather than producing a silent `Invalid Date` in `ClientDocument.fields`.
- `npm-run-all` moved from production `dependencies` to `devDependencies` in **both** adapters — it is only used by the `dev` script, and this is the first published release of `db-mysql`.