### PR TITLE
docs(db-mysql): documented preliminary status, plus pool tuning and seed-script fixes

### DIFF
--- a/.changeset/db-mysql-adapter.md
+++ b/.changeset/db-mysql-adapter.md
@@ -3,7 +3,20 @@
 "@byline/db-postgres": minor
 ---
 
-Added `@byline/db-mysql`, Byline's second database adapter. `mysqlAdapter()` implements
+Added `@byline/db-mysql`, Byline's second database adapter — **published as preliminary,
+not as fully supported MySQL support.** The storage layer is complete and proven: it
+passes the entire shared `@byline/db-conformance` behavioural suite, the same suite
+`@byline/db-postgres` passes, with identical results. What is missing is the surrounding
+ecosystem, and one gap needs stating plainly because it fails at boot rather than
+degrading quietly: **there is no MySQL search provider**, and `initBylineCore()` throws
+when a collection declares a `search` block with no provider registered. Byline's own
+reference application opts five collections into search, so a MySQL installation copying
+it will not start until a no-op provider is registered — `packages/db-mysql/README.md`
+gives the snippet. `byline init` also does not yet scaffold MySQL, and CI pins the 8.0
+engine floor so nothing exercises 9.x automatically. Treat this release as suitable for
+evaluation, prototypes, and installations that do not need search.
+
+`mysqlAdapter()` implements
 the same `IDbAdapter` contract as `@byline/db-postgres` over MySQL 8.0.14+ (InnoDB only;
 the boot check rejects older servers and MariaDB) and passes the same shared
 `@byline/db-conformance` suite the Postgres adapter runs, so document storage, versioning,

--- a/apps/webapp/.env.local.example
+++ b/apps/webapp/.env.local.example
@@ -38,6 +38,15 @@
 # postgres:// or postgresql:// scheme.
 BYLINE_DB_POSTGRES_CONNECTION_STRING=postgres://byline:byline@127.0.0.1:5432/byline_dev
 
+# MySQL alternative — only read when `byline/server.config.ts` is switched to
+# the `mysqlAdapter` (see the four "MySQL adapter" banners in that file). Set
+# alongside the Postgres string rather than instead of it; whichever adapter the
+# config builds is the one that reads its own variable. mysql2 parses this URL
+# natively, and the db_init scripts in packages/db-mysql parse the same string
+# to derive user / password / host / port / database. The `_dev`/`_test` suffix
+# guard applies here too.
+# BYLINE_DB_MYSQL_CONNECTION_STRING=mysql://byline:byline@127.0.0.1:3306/byline_dev
+
 # Optional pg connection pool tuning. Leave unset to use the adapter
 # defaults (max: 20, idleTimeoutMillis: 2000, connectionTimeoutMillis:
 # 30000). Worth tuning for serverless Postgres providers like Neon,

--- a/apps/webapp/byline/seed-admin.ts
+++ b/apps/webapp/byline/seed-admin.ts
@@ -16,4 +16,21 @@ async function run() {
   await seedAdmin()
 }
 
+// Exit explicitly rather than waiting for the event loop to drain. The
+// configured adapter's connection pool holds a live timer, so the process
+// stays alive long after the seed has committed:
+//
+//   • `pgAdapter` defaults `idleTimeoutMillis: 2000`, so on Postgres the pool
+//     goes quiet after ~2s and the script appeared to exit on its own.
+//   • `mysqlAdapter` leaves mysql2's defaults in place — `idleTimeout` 60s with
+//     `maxIdle` equal to `connectionLimit` — and mysql2's idle-sweep timer is
+//     not unref'd, so the script looks frozen even though the work is done.
+//
+// The `.catch` also matters: `run()` was previously called bare, so a rejected
+// seed surfaced as an unhandled rejection rather than a non-zero exit.
 run()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error(err)
+    process.exit(1)
+  })

--- a/apps/webapp/byline/seed-docs.ts
+++ b/apps/webapp/byline/seed-docs.ts
@@ -18,4 +18,13 @@ async function run() {
   await seedDocs()
 }
 
+// Exit explicitly — the adapter's pool holds a live timer, so the process does
+// not terminate on its own once the seed commits. See the fuller note in
+// `seed-admin.ts`; the short version is that `pgAdapter`'s 2-second idle
+// timeout masked this and mysql2's 60-second, non-unref'd idle sweep does not.
 run()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error(err)
+    process.exit(1)
+  })

--- a/apps/webapp/byline/seed.ts
+++ b/apps/webapp/byline/seed.ts
@@ -22,4 +22,13 @@ async function run() {
   await seedFaqFixture()
 }
 
+// Exit explicitly — the adapter's pool holds a live timer, so the process does
+// not terminate on its own once the seed commits. See the fuller note in
+// `seed-admin.ts`; the short version is that `pgAdapter`'s 2-second idle
+// timeout masked this and mysql2's 60-second, non-unref'd idle sweep does not.
 run()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error(err)
+    process.exit(1)
+  })

--- a/apps/webapp/byline/server.config.ts
+++ b/apps/webapp/byline/server.config.ts
@@ -20,6 +20,13 @@ import { getAdminBylineClient } from '@byline/client/server'
 import { type BylineCore, initBylineCore } from '@byline/core'
 import { pgAdapter } from '@byline/db-postgres'
 import { createAdminStore } from '@byline/db-postgres/admin'
+// ── MySQL adapter (end-to-end testing) ────────────────────────────────────────
+// Comment out the two `@byline/db-postgres` imports above and uncomment these
+// two, then follow the matching block in `buildBylineCore()` below. There are
+// FOUR coordinated edits in this file — the block below lists all of them.
+//
+// import { mysqlAdapter } from '@byline/db-mysql'
+// import { createAdminStore } from '@byline/db-mysql/admin'
 import { registerTanstackStartHostBridge } from '@byline/host-tanstack-start/integrations/host-bridge'
 import {
   lexicalEditorEmbedServer,
@@ -94,6 +101,72 @@ async function buildBylineCore(): Promise<BylineCore<AdminStore>> {
       : undefined,
   })
 
+  // ── MySQL adapter (end-to-end testing) ──────────────────────────────────────
+  //
+  // Swapping adapters takes FOUR edits in this file, all marked with this
+  // banner. Missing any one of them fails at boot or, worse, hands a mysql2
+  // pool to a Postgres-only driver:
+  //
+  //   1. the imports at the top of this file
+  //   2. this block — comment out the `pgAdapter({...})` call above, uncomment
+  //      the `mysqlAdapter({...})` call below
+  //   3. the `await migrate(db.pool, …)` call below — Postgres-only, must be
+  //      commented out
+  //   4. the `search:` entry in `initBylineCore()` — swap to the no-op provider
+  //      given at the end of this comment
+  //
+  // Prerequisites:
+  //
+  //   • `BYLINE_DB_MYSQL_CONNECTION_STRING` in `apps/webapp/.env.local` — see
+  //     `.env.local.example`. The MySQL container is `mysql/docker-compose.yml`
+  //     (`cd mysql && ./mysql.sh up -d`).
+  //   • a migrated database: `cd packages/db-mysql && pnpm drizzle:migrate`
+  //   • seed data if you want content to look at: `cd apps/webapp && pnpm tsx
+  //     byline/seed.ts` (it reads whichever adapter this file configures)
+  //
+  // const db = mysqlAdapter({
+  //   connectionString: process.env.BYLINE_DB_MYSQL_CONNECTION_STRING || '',
+  //   collections,
+  //   defaultContentLocale: i18n.content.defaultLocale,
+  //   // Pool tuning. Optional — `mysqlAdapter` ships the same defaults as
+  //   // `pgAdapter` (20 connections, 2s idle, 30s connect), so a managed provider
+  //   // that pauses idle databases gets the same cold-start headroom.
+  //   connectionLimit: process.env.BYLINE_DB_MYSQL_CONNECTION_LIMIT
+  //     ? Number(process.env.BYLINE_DB_MYSQL_CONNECTION_LIMIT)
+  //     : undefined,
+  //   idleTimeout: process.env.BYLINE_DB_MYSQL_IDLE_TIMEOUT_MILLIS
+  //     ? Number(process.env.BYLINE_DB_MYSQL_IDLE_TIMEOUT_MILLIS)
+  //     : undefined,
+  //   connectTimeout: process.env.BYLINE_DB_MYSQL_CONNECTION_TIMEOUT_MILLIS
+  //     ? Number(process.env.BYLINE_DB_MYSQL_CONNECTION_TIMEOUT_MILLIS)
+  //     : undefined,
+  // })
+  //
+  // Search is Postgres-only today (`@byline/search-postgres` has no MySQL
+  // counterpart — tracked as #52). Five collections opt into search via
+  // `CollectionDefinition.search`, and `validateSearchConfig` throws at boot if
+  // any collection opts in with no provider registered — so you cannot simply
+  // omit `search`. Register this no-op instead: it satisfies validation, and
+  // indexing / querying become silent no-ops rather than errors. The admin
+  // Reindex button and the docs search page will return nothing, which is the
+  // honest answer on MySQL.
+  //
+  // const noopSearch = {
+  //   capabilities: {
+  //     facets: false,
+  //     typoTolerance: false,
+  //     semantic: false,
+  //     bm25: false,
+  //     weighting: false,
+  //     highlights: false,
+  //   },
+  //   async upsert() {},
+  //   async remove() {},
+  //   async search() {
+  //     return { hits: [], total: 0 }
+  //   },
+  // }
+
   // Ensure the search-index schema before the provider serves any traffic.
   // The driver owns its schema (numbered SQL in `@byline/search-postgres`);
   // we apply it deliberately here rather than relying on `autoMigrate` so
@@ -102,6 +175,12 @@ async function buildBylineCore(): Promise<BylineCore<AdminStore>> {
   //
   // Wrapped defensively: a migration failure degrades search but must not take
   // down the whole app at boot — log loudly and continue.
+  //
+  // ── MySQL adapter (end-to-end testing), edit 3 of 4 ─────────────────────────
+  // Comment this whole `try/catch` out when running on MySQL. `migrate()` comes
+  // from `@byline/search-postgres` and expects a **pg** pool; on the MySQL
+  // adapter `db.pool` is a mysql2 pool, so leaving this in place fails inside
+  // the driver rather than anywhere informative.
   try {
     await migrate(db.pool, { log: (m) => console.log(m) })
   } catch (err) {
@@ -233,7 +312,12 @@ async function buildBylineCore(): Promise<BylineCore<AdminStore>> {
     // (no second connection); the search index lives in the same database.
     // Collections opt in via their `search` config; lifecycle
     // hooks maintain the index (see e.g. `collections/docs/hooks.ts`).
+    // ── MySQL adapter (end-to-end testing), edit 4 of 4 ───────────────────────
+    // On MySQL, comment the `postgresSearch(...)` line out and uncomment the
+    // `noopSearch` line — see the no-op provider defined in the adapter block
+    // above, and why omitting `search` entirely throws at boot.
     search: postgresSearch({ pool: db.pool, defaultLocale: i18n.content.defaultLocale }),
+    // search: noopSearch,
   })
 
   // Register admin-subsystem abilities (admin.users.*, admin.roles.*) on

--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -75,6 +75,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.4",
+    "@byline/db-mysql": "workspace:*",
     "@playwright/test": "^1.61.1",
     "@tailwindcss/vite": "4.3.3",
     "@tanstack/devtools-vite": "^0.8.1",

--- a/docs/03-architecture/01-document-storage.md
+++ b/docs/03-architecture/01-document-storage.md
@@ -64,6 +64,16 @@ over an `IDbAdapter` factory. Both adapters run the same 14 suites against their
 database; a change to the shared model that breaks either adapter's behaviour fails a
 conformance suite before it fails anything a consumer would notice.
 
+The Postgres adapter is the supported default. The MySQL adapter is **preliminary**: its
+storage layer passes the full conformance suite, but MySQL is not yet a fully supported
+Byline backend. There is no MySQL search provider, and because `initBylineCore()` refuses
+to start when a collection declares a `search` block with no provider registered, a MySQL
+installation needs the no-op provider the
+[`@byline/db-mysql` README](https://github.com/Byline-CMS/bylinecms.dev/blob/develop/packages/db-mysql/README.md#search-on-mysql)
+documents. `byline init` also scaffolds Postgres only. Choose MySQL for evaluation,
+prototypes, or installations that do not need search; choose Postgres for everything else
+until those gaps close.
+
 ## What happens when you save a document
 
 Before the reference sections, here is one document making the full round trip. Take a `news` collection with a localized `title`, a `category` relation, and a `content` blocks field, and suppose an editor saves the English version.

--- a/packages/db-mysql/README.md
+++ b/packages/db-mysql/README.md
@@ -1,5 +1,28 @@
 # @byline/db-mysql
 
+> **Status: preliminary.** This adapter is published so it can be evaluated and
+> exercised, not because MySQL is a fully supported Byline backend yet. The
+> storage layer is complete and proven — it passes the entire shared
+> `@byline/db-conformance` behavioural suite, the same suite `@byline/db-postgres`
+> passes, with identical results. What is missing is the surrounding ecosystem:
+>
+> - **No search provider.** `@byline/search-postgres` has no MySQL counterpart, and
+>   this is not merely a missing feature — `initBylineCore()` **throws at boot** if
+>   any collection declares `search` and no provider is registered. See
+>   [Search on MySQL](#search-on-mysql) below for the one-step workaround you will
+>   need. Tracked in
+>   [#52](https://github.com/Byline-CMS/bylinecms.dev/issues/52).
+> - **No CLI support.** `byline init` scaffolds a Postgres installation; wiring
+>   MySQL is a manual edit to your `server.config.ts`.
+> - **Narrower CI coverage than Postgres.** Continuous integration pins MySQL 8.0
+>   — the engine floor — so nothing yet exercises 9.x automatically, and no leg
+>   runs under a non-UTC timezone. Tracked in
+>   [#55](https://github.com/Byline-CMS/bylinecms.dev/issues/55).
+>
+> Treat it as suitable for evaluation, prototypes, and installations that do not
+> need search. The criteria for general availability are tracked in
+> [#58](https://github.com/Byline-CMS/bylinecms.dev/issues/58).
+
 MySQL adapter for Byline CMS — Drizzle schema, migrations, and the storage /
 queries / commands implementation behind `IDbAdapter`. It is Byline's second
 database adapter, alongside `@byline/db-postgres`. The subpath
@@ -193,10 +216,58 @@ databases, and a few divergences are real rather than papered over.
   onto the same shape in this release. See the changeset for what a
   consumer upgrading `@byline/db-postgres` needs to check.
 
+## Search on MySQL
+
+There is no MySQL search provider yet, and the absence is load-bearing rather
+than cosmetic: `validateSearchConfig` runs inside `initBylineCore()` and
+**throws** when any collection declares a `search` block but no provider is
+registered. Byline's own reference application opts five collections into
+search, so a MySQL installation that copies it fails at boot with an error that
+does not mention MySQL at all.
+
+Until `@byline/search-mysql` exists, register a no-op provider. It satisfies
+validation, and indexing and querying become silent no-ops rather than errors —
+the admin Reindex action and any search page return nothing, which is the honest
+answer on this adapter today:
+
+```ts
+const noopSearch = {
+  capabilities: {
+    facets: false,
+    typoTolerance: false,
+    semantic: false,
+    bm25: false,
+    weighting: false,
+    highlights: false,
+  },
+  async upsert() {},
+  async remove() {},
+  async search() {
+    return { hits: [], total: 0 }
+  },
+}
+
+await initBylineCore({
+  // …
+  db,
+  search: noopSearch,
+})
+```
+
+The alternative — removing the `search` block from every collection definition —
+also works, but it discards configuration you will want back when a provider
+lands. The no-op keeps your collections declarative and confines the workaround
+to one place.
+
 ## Not yet shipped
 
-- **`@byline/search-mysql`** — see "No search provider yet" above. Tracked in
-  [issue #52](https://github.com/Byline-CMS/bylinecms.dev/issues/52).
+- **`@byline/search-mysql`** — see [Search on MySQL](#search-on-mysql) above.
+  Tracked in [issue #52](https://github.com/Byline-CMS/bylinecms.dev/issues/52).
+- **CLI support.** `byline init` scaffolds a Postgres installation. Adding MySQL
+  to an existing project is a manual edit to `byline/server.config.ts` — swap
+  `pgAdapter` for `mysqlAdapter`, swap the `@byline/db-postgres/admin` import for
+  `@byline/db-mysql/admin`, drop the `@byline/search-postgres` migrate call, and
+  register the no-op search provider above.
 - **A MySQL storage-benchmark target.** The design spec flags view
   materialisation (the `ROW_NUMBER()` window inside a derived table, used
   by both current-version views) as a question to answer before this

--- a/packages/db-mysql/src/index.ts
+++ b/packages/db-mysql/src/index.ts
@@ -43,6 +43,9 @@ export const mysqlAdapter = ({
   collections,
   defaultContentLocale,
   connectionLimit = 20,
+  idleTimeout = 2000,
+  connectTimeout = 30000,
+  maxIdle,
 }: {
   connectionString: string
   collections: readonly CollectionDefinition[]
@@ -59,13 +62,48 @@ export const mysqlAdapter = ({
   defaultContentLocale: string
   /**
    * Maximum number of connections in the mysql2 pool. Defaults to 20. Tune
-   * via `BYLINE_DB_MYSQL_CONNECTION_LIMIT` in the host app.
+   * via `BYLINE_DB_MYSQL_CONNECTION_LIMIT` in the host app. Mirrors
+   * `pgAdapter`'s `max`.
    */
   connectionLimit?: number
+  /**
+   * Milliseconds an idle connection remains in the pool before being closed.
+   * Defaults to 2000, mirroring `pgAdapter`'s `idleTimeoutMillis`.
+   *
+   * mysql2's own default is 60000, which is why this is set explicitly rather
+   * than left to the driver: a long-lived idle sweep keeps a non-unref'd timer
+   * alive, so short-lived processes (seeds, migrations, one-shot scripts) appear
+   * to hang for a minute after their work commits instead of exiting. Matching
+   * the Postgres adapter's 2 seconds makes both adapters behave alike.
+   *
+   * Tune via `BYLINE_DB_MYSQL_IDLE_TIMEOUT_MILLIS`.
+   */
+  idleTimeout?: number
+  /**
+   * Milliseconds to wait for a new connection before erroring. Defaults to
+   * 30000, mirroring `pgAdapter`'s `connectionTimeoutMillis` — long enough to
+   * absorb the cold starts of managed providers that pause idle databases
+   * (Neon on the Postgres side; PlanetScale and Aiven behave similarly here),
+   * where the first connect after a sleep can take a second or more.
+   *
+   * Tune via `BYLINE_DB_MYSQL_CONNECTION_TIMEOUT_MILLIS`.
+   */
+  connectTimeout?: number
+  /**
+   * Maximum number of idle connections the pool retains. mysql2 defaults this
+   * to `connectionLimit`; left undefined here so that default stands. Exposed
+   * because it interacts with `idleTimeout` — mysql2 only sweeps connections
+   * beyond `maxIdle`, so raising the idle timeout without also lowering
+   * `maxIdle` keeps every connection warm. No `pgAdapter` equivalent.
+   */
+  maxIdle?: number
 }): MySqlAdapter => {
   const pool = mysql.createPool({
     uri: connectionString,
     connectionLimit,
+    idleTimeout,
+    connectTimeout,
+    ...(maxIdle != null ? { maxIdle } : {}),
     // Every DATETIME column is UTC by convention (spec §2). 'Z' stops
     // mysql2 from reinterpreting stored UTC values against the server's or
     // session's local timezone on the way in and out.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,6 +142,9 @@ importers:
       '@biomejs/biome':
         specifier: 2.5.4
         version: 2.5.4
+      '@byline/db-mysql':
+        specifier: workspace:*
+        version: link:../../packages/db-mysql
       '@playwright/test':
         specifier: ^1.61.1
         version: 1.61.1


### PR DESCRIPTION
Pre-release housekeeping ahead of 4.8.0. Ships `@byline/db-mysql` honestly as **preliminary** rather than as fully supported MySQL support, and fixes three things found while exercising the adapter end to end.

Part of #42. New tracking issue: #58.

## Why "preliminary"

The storage layer is complete and proven — full `@byline/db-conformance` parity with Postgres, 141/141. What is missing is the ecosystem around it, and one gap needs stating plainly because it **fails at boot rather than degrading quietly**:

`validateSearchConfig` throws inside `initBylineCore()` when a collection declares a `search` block and no provider is registered. Byline's reference application opts five collections into search, so a MySQL installation that copies it will not start — with an error that never mentions MySQL. Until `@byline/search-mysql` exists (#52), a no-op provider is required, and it is now documented with a copy-pasteable snippet rather than left for each adopter to work out.

The status is stated in three places, so it reaches people wherever they encounter the package:

- **`packages/db-mysql/README.md`** — a status banner at the top, and a new "Search on MySQL" section with the no-op provider
- **the changeset** — so it lands in the published changelog, not only in a file people read after installing
- **`docs/03-architecture/01-document-storage.md`** — Postgres is the supported default; choose MySQL for evaluation, prototypes, or installations that do not need search

**#58** tracks the criteria for general availability — a search provider, CLI adapter selection, and CI coverage matching Postgres — so the qualifier has a visible close condition instead of being open-ended.

## Fixes found while testing

**`mysqlAdapter` now exposes `idleTimeout` and `connectTimeout`**, defaulting to 2000ms and 30000ms to match `pgAdapter`'s `idleTimeoutMillis` / `connectionTimeoutMillis`. `maxIdle` is exposed too, since it gates whether `idleTimeout` sweeps anything.

This closes a real papercut: mysql2 defaults `idleTimeout` to 60s with `maxIdle` equal to `connectionLimit`, and its idle-sweep timer is not unref'd — so any short-lived process appeared to **hang for a minute** after its work had already committed. Postgres masked the same design by closing idle connections after 2s.

**The three seed scripts now exit explicitly.** They called `run()` bare and relied on the event loop draining, which worked on Postgres by accident. They also had no `.catch()`, so a failing seed surfaced as an unhandled rejection rather than a non-zero exit — a bug on **both** adapters, and one that would have let a CI wrapper read failure as success.

**`@byline/db-mysql` is now a `devDependency` of the reference webapp**, with `BYLINE_DB_MYSQL_CONNECTION_STRING` documented in `.env.local.example`, so the adapter can be swapped in for end-to-end testing without a manual install step.

## Verification

`pnpm docs:check` (43 documents, 433 links), `git diff --check`, `pnpm lint`, `pnpm typecheck` all clean. The seed-exit fix was verified by running `seed-admin.ts` against MySQL: exits in 1.16s with code 0, where it previously hung.

No behaviour change to `@byline/db-postgres`.