### PR TITLE
feat(search): add portable analysis contracts

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -16,6 +16,7 @@
       "@byline/host-tanstack-start",
       "@byline/i18n",
       "@byline/richtext-lexical",
+      "@byline/search-analysis",
       "@byline/search-postgres",
       "@byline/storage-local",
       "@byline/storage-s3",

--- a/.changeset/search-analysis-contracts.md
+++ b/.changeset/search-analysis-contracts.md
@@ -1,0 +1,13 @@
+---
+"@byline/core": minor
+"@byline/client": minor
+"@byline/search-analysis": minor
+---
+
+Added provider-neutral lexical matching contracts and
+`@byline/search-analysis`, a portable multilingual analysis and query-planning
+package. The analyzer preserves exact terms, validates locale declarations,
+uses ICU word boundaries, protects domain identifiers, emits optional
+language-specific variants and Han bigrams, and records a stable fingerprint
+for reindex decisions. Collection and zone search now pass explicit all/any,
+minimum-should-match, and phrase intent to search providers.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ Byline CMS — an open-source, AI-first headless CMS. Currently at a stable v4.x
 | `packages/ui` | `@byline/ui` | Framework-agnostic React primitives — Button, Input, Modal, Drawer, Table, Alert, icons, datepicker, generic `DraggableSortable`. No CMS concepts; importable independent of admin. Single barrel at `@byline/ui/react`. |
 | `packages/i18n` | `@byline/i18n` | Admin-interface translation system — `TranslationBundle` types, `mergeTranslations`, ICU formatter, locale resolution. React surface (`I18nProvider`, `useTranslation`, `LanguageMenu`) at `@byline/i18n/react`. Built-in `byline-admin` bundle (EN/FR) + `adminTranslations({ locales })` factory at `@byline/i18n/admin`. |
 | `packages/richtext-lexical` | `@byline/richtext-lexical` | Lexical-based richtext editor adapter |
+| `packages/search-analysis` | `@byline/search-analysis` | Portable multilingual lexical analysis and backend-neutral query planning — NFKC normalization, locale resolution, protected identifiers, ICU word segmentation, language expansion hooks, Han bigrams, analyzer fingerprints, and SQL-safe physical tokens |
 | `packages/search-postgres` | `@byline/search-postgres` | Built-in Postgres full-text `SearchProvider` driver — weighted `tsvector` index; owns its own schema (numbered SQL migrations); reuses the host pg pool. See "Search & Retrieval" below |
 | `packages/ai` | `@byline/ai` | AI subsystem — provider-agnostic execution (OpenAI / Google / Anthropic) for `executeInstruction`, `generateStructured`, and Lexical-node `patch` (streaming + non-streaming). Browser-safe root entry; SDK-backed execution behind `@byline/ai/server`; editor plugins at `@byline/ai/plugins/{text,lexical}`. See `packages/ai/README.md` |
 | `packages/cli` | `@byline/cli` | Guided installer that adds Byline to an existing TanStack Start app (`byline init`, `doctor`, …) |
@@ -196,9 +197,16 @@ the forward-looking landscape for the unbuilt phases is
 
 - **Interface & types**: `SearchProvider` (`capabilities` + `upsert` / `remove` /
   `search` / `reindex?`), the type-enriched `SearchDocument` (a role-tagged
-  `SearchField[]` projection), `SearchQuery` / `SearchResults`, and `SearchCapabilities`
+  `SearchField[]` projection), `SearchQuery` / `SearchResults`, provider-neutral
+  `SearchMatching`, and `SearchCapabilities`
   live in `packages/core/src/@types/search-types.ts`. The provider is a pure index
   **sink** — it never reads source documents.
+- **Portable analysis**: `@byline/search-analysis` owns the optional
+  backend-neutral token and query-plan layer: search-only NFKC normalization,
+  validated locale/script fallback, protected identifiers, ICU word boundaries,
+  exact-preserving language expansions, Han bigrams, SQL-safe physical token
+  encoding, and analyzer fingerprints for reindex compatibility. The current
+  Postgres driver remains on its native analyzer until its explicit adapter phase.
 - **Collection search config**: `CollectionDefinition.search = { body?, facets?, filters?, zones? }`
   (`SearchFieldDecl = string | { field, boost? }`). The implementor names fields by
   the part they play; core derives each field's type from the schema. Nothing auto-pulled.

--- a/docs/05-reading-and-delivery/07-search.md
+++ b/docs/05-reading-and-delivery/07-search.md
@@ -27,6 +27,7 @@ Companions:
 - [Collections](../04-collections/index.md) — the collection `search` config and the lifecycle hooks that maintain the index.
 - [Authentication & Authorization](../06-auth-and-security/01-authn-authz.md) — the `collections.<path>.reindex` ability and the `beforeRead` row-scoping that search honours.
 - [Search and document extraction strategy](./08-search-extraction-strategy.md) — forward-looking landscape + tiered strategy for Phases 3–4 (attachment extraction, external drivers).
+- [Portable multilingual search analysis](./09-multilingual-search-analysis.md) — the portable lexical-analysis and query-plan contracts that adapters can implement without changing the `SearchProvider` seam.
 
 ## Overview
 
@@ -109,6 +110,14 @@ interface SearchCapabilities {
   bm25: boolean           // IDF-aware ranking
   weighting: boolean      // per-field SearchField.boost
   highlights: boolean     // matched-snippet highlighting
+  lexical?: {             // detailed matching/analysis support
+    nativeAnalysis: boolean
+    portableAnalysis: boolean
+    allTerms: boolean
+    anyTerms: boolean
+    minimumShouldMatch: boolean
+    phrase: boolean
+  }
 }
 ```
 
@@ -404,6 +413,10 @@ Search is a first-class `@byline/client` method, parallel to `find()`.
 ```ts
 const results = await client.collection('docs').search({
   query: 'fractional indexing',
+  matching: {
+    operator: 'all',     // every analyzed concept must match
+    phrase: 'auto',      // quoted spans become phrase constraints
+  },
   locale,                // defaults to the client default
   status: 'published',   // defaults to published
   where,                 // accepted; not yet applied by the Postgres driver
@@ -421,7 +434,12 @@ const results = await client.collection('docs').search({
 
 `CollectionHandle.search()` asserts the collection `read` ability, scopes to the
 collection + `published` by default, and delegates to `provider.search()`. It
-accepts `status: 'any'`, but the framework lifecycle indexes published views
+passes the same optional `matching` policy as zone search: `operator` is
+`'all'` or `'any'`, `minimumShouldMatch` refines `'any'`, and `phrase` is
+`'auto'`, `'required'`, or `'off'`. Existing providers can ignore this additive
+field during the compatibility window and should declare detailed support in
+`capabilities.lexical`.
+It accepts `status: 'any'`, but the framework lifecycle indexes published views
 only, so this does not make drafts appear in the built-in index; it only relaxes
 the provider filter for rows a custom indexing path may have supplied. It
 returns the **lightweight hit tier** — `title`, `path`, `score`, and

--- a/docs/05-reading-and-delivery/09-multilingual-search-analysis.md
+++ b/docs/05-reading-and-delivery/09-multilingual-search-analysis.md
@@ -1,0 +1,153 @@
+---
+title: "Portable Multilingual Search Analysis"
+path: "multilingual-search-analysis"
+summary: "The backend-neutral lexical matching, token analysis, query-plan, physical encoding, and analyzer-fingerprint contracts shared by Byline search providers."
+---
+
+# Portable Multilingual Search Analysis
+
+Companions:
+- [Search & Retrieval](./07-search.md) — the provider seam, index lifecycle, query surfaces, authorization, and current PostgreSQL implementation.
+- [Search & Document Extraction](./08-search-extraction-strategy.md) — the separate attachment-extraction pipeline whose text will feed the same search projection.
+- [Client SDK](./01-client-sdk.md) — the collection and zone search APIs that accept the matching policy.
+
+:::note[Foundation phase]
+`@byline/search-analysis` and the additive `SearchQuery.matching` contract are
+available. The current `@byline/search-postgres` provider still uses its native
+PostgreSQL configuration and query parser; this phase does not change existing
+index contents, ranking, migrations, or query results. A later adapter phase
+will opt into portable analysis explicitly and require a reindex.
+:::
+
+## Why this is a separate package
+
+`SearchProvider` remains the stable storage and retrieval seam. It accepts
+original `SearchDocument` projections and returns ranked `SearchResults`.
+Multilingual lexical analysis is a different concern: it converts original text
+and query intent into a deterministic logical representation before an adapter
+chooses its physical index syntax.
+
+The ownership boundaries are:
+
+| Owner | Responsibility |
+|---|---|
+| `@byline/core` | Public matching intent and provider capability declarations |
+| `@byline/client` | Pass matching intent from collection and zone calls without interpretation |
+| `@byline/search-analysis` | Normalization, locale resolution, token classes, grouped query plans, fingerprints, and SQL-safe token encoding |
+| Search adapter | Physical schema, persistence, query translation, ranking, highlights, and operational compatibility checks |
+
+This split keeps the portable behavior independently testable. It also avoids
+forcing Solr, OpenSearch, or another engine with a strong native analyzer to
+store application-produced tokens. Providers declare whether they use native
+analysis, portable analysis, or can expose both modes.
+
+## Matching intent
+
+Collection and zone search accept:
+
+```ts
+interface SearchMatching {
+  operator?: 'all' | 'any'
+  minimumShouldMatch?: number
+  phrase?: 'auto' | 'required' | 'off'
+}
+```
+
+The defaults are conservative: every analyzed concept must match, and quoted
+spans retain phrase intent. `minimumShouldMatch` is a positive integer and is
+only valid with `operator: 'any'`. `phrase: 'required'` makes the complete
+non-empty query an ordered phrase; `phrase: 'off'` disables even explicitly
+quoted phrase constraints.
+
+These options describe product behavior rather than backend syntax. An adapter
+must translate them faithfully or advertise the missing feature through
+`SearchCapabilities.lexical`.
+
+## Analysis pipeline
+
+`createPortableSearchAnalyzer()` applies a versioned sequence:
+
+1. Normalize search text with Unicode NFKC and locale-insensitive lowercase.
+   The source document remains unchanged. Logical tokens retain UTF-16 ranges
+   into both normalized and original text, including compatibility expansions.
+2. Resolve a usable locale. A valid declared locale wins; otherwise the
+   analyzer detects Thai, Japanese, Korean, Lao, Khmer, Myanmar, or Han script,
+   then uses the configured fallback.
+3. Extract identifiers before general word segmentation. URLs, email
+   addresses, mentions, hashtags, SKUs, versions, and selected technical terms
+   such as `C++`, `C#`, and `Node.js` remain single logical terms.
+4. Segment remaining words with the Node.js runtime's ICU-backed
+   `Intl.Segmenter`.
+5. Run optional locale-aware expansion plug-ins. Stems, lemmas, and normalized
+   variants augment their exact source token and never replace it.
+6. Emit overlapping Han bigrams as an ordered, low-weight fallback while
+   retaining the exact segmented terms.
+
+The analyzer is synchronous and CPU-local. It does no I/O, document extraction,
+database access, or model inference. Attachment extraction remains a separate
+phase; the resulting text enters this same pipeline only when a published
+version is indexed.
+
+## Logical query plans
+
+`analyzeQuery()` returns a `PortableQueryPlan`, not a database query string.
+Every user concept has separate exact, stem, lemma, normalized, identifier, and
+gram arrays. Alternatives stay grouped under their source concept so an adapter
+can express:
+
+```text
+(exact OR stem OR lemma) AND (exact OR stem OR lemma)
+```
+
+without accidentally flattening all expansions into one broad OR query.
+Quoted and required phrases refer to ordered concept indexes. Han grams remain
+ordered sequences rather than independent alternatives. This structure is the
+portable contract that PostgreSQL and MySQL translators will share.
+
+## Physical SQL tokens
+
+Logical terms can contain punctuation, non-Latin scripts, or only one
+character. SQL full-text parsers may discard or split those values differently.
+`encodeSqlToken()` therefore provides a separate physical representation:
+
+- lowercase ASCII alphanumeric output;
+- distinct prefixes for exact, stem, lemma, normalized, identifier, and gram
+  terms;
+- enough encoded characters for a one-character source term to clear common
+  minimum-token limits; and
+- deterministic SHA-256 fallback for terms above the configured length.
+
+The codec is an adapter building block, not the public search vocabulary.
+Adapters store original text for display and highlights and use encoded terms
+only in their portable index projection.
+
+## Fingerprints and reindexing
+
+Every analyzer exposes an `analyzerFingerprint`. It includes the portable
+pipeline versions, relevant options, the Node.js ICU version, and every
+language-expander fingerprint. An adapter that stores portable terms must
+persist this value as index metadata and compare it at startup.
+
+A mismatch means stored terms and query terms may no longer be comparable.
+Startup should report the mismatch clearly, and an explicit reindex should
+replace the projection and stored fingerprint. Adapters must not silently mix
+fingerprints within one active index.
+
+## Adapter rollout
+
+The implementation sequence keeps each phase reviewable:
+
+1. Add these contracts and analyzer conformance cases without changing the
+   existing PostgreSQL provider.
+2. Add a versioned portable schema and query translator to
+   `@byline/search-postgres`, retaining native mode as a compatibility option.
+3. Extract shared provider conformance tests for matching semantics,
+   capabilities, published-only lifecycle behavior, locale isolation, and
+   fingerprint mismatch/reindex behavior.
+4. Complete `@byline/search-mysql` against the same query plans and conformance
+   suite, with MySQL-specific schema and full-text translation.
+5. Adapt the existing Solr implementation, normally using Solr's native
+   analyzers while mapping the public matching contract and capability report.
+
+PostgreSQL and MySQL migrations remain independent streams owned by their
+provider packages. No search migration belongs in a database storage adapter.

--- a/docs/05-reading-and-delivery/index.md
+++ b/docs/05-reading-and-delivery/index.md
@@ -29,3 +29,7 @@ it efficiently.
   (Postgres full-text search built in, vector / hybrid as external drivers),
   shipped collection/zone search, hydration, and post-ranking authorization,
   exposed through the Client SDK surfaces developers build site search on.
+- [Portable Multilingual Search Analysis](./09-multilingual-search-analysis.md)
+  — the backend-neutral token, matching, query-plan, and analyzer-fingerprint
+  contracts that prepare PostgreSQL and MySQL for consistent multilingual
+  behavior.

--- a/packages/client/src/collection-handle.ts
+++ b/packages/client/src/collection-handle.ts
@@ -248,6 +248,7 @@ export class CollectionHandle<TFields extends Record<string, any> = Record<strin
     }
     const results = await provider.search({
       query: options.query,
+      matching: options.matching,
       collectionPath: this.definition.path,
       locale: options.locale ?? this.client.defaultLocale,
       status: readMode,

--- a/packages/client/src/search.ts
+++ b/packages/client/src/search.ts
@@ -264,6 +264,7 @@ export async function zoneSearch(
 
   const results = await provider.search({
     query: options.query,
+    matching: options.matching,
     zone: options.zone,
     locale: options.locale ?? client.defaultLocale,
     status: readMode,

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -22,6 +22,7 @@ import type {
   RichTextToTextFn,
   SearchFacetBucket,
   SearchHit,
+  SearchMatching,
   SearchProvider,
   ServerConfig,
   SlugifierFn,
@@ -230,6 +231,8 @@ interface StatusControls {
 export interface CollectionSearchOptions extends BeforeReadControls {
   /** Free-text query string. */
   query: string
+  /** Provider-neutral term and phrase matching semantics. */
+  matching?: SearchMatching
   /** Restrict to a single content locale (defaults to the client default). */
   locale?: string
   /** Read mode — `'published'` (default) or `'any'`. */
@@ -263,6 +266,8 @@ export interface CollectionSearchOptions extends BeforeReadControls {
 export interface ZoneSearchOptions extends BeforeReadControls {
   /** Free-text query string. */
   query: string
+  /** Provider-neutral term and phrase matching semantics. */
+  matching?: SearchMatching
   /** The zone (named cross-collection scope) to search. */
   zone: string
   /** Restrict to a single content locale (defaults to the client default). */

--- a/packages/client/tests/unit/enforcement.test.node.ts
+++ b/packages/client/tests/unit/enforcement.test.node.ts
@@ -525,6 +525,46 @@ describe('CollectionHandle enforcement', () => {
     })
   })
 
+  describe('search query contracts', () => {
+    it('passes lexical matching intent through collection and zone search', async () => {
+      const providerSearch = vi.fn().mockResolvedValue({ hits: [], total: 0 })
+      const client = createBylineClient({
+        db: mockDb(),
+        collections: [postsCollection],
+        requestContext: createSuperAdminContext(),
+        search: {
+          capabilities: {},
+          upsert: vi.fn(),
+          remove: vi.fn(),
+          search: providerSearch,
+        } as any,
+      })
+
+      await client.collection('posts').search({
+        query: 'forest restoration',
+        matching: { operator: 'any', minimumShouldMatch: 1, phrase: 'off' },
+      })
+      await client.search({
+        query: '"forest restoration"',
+        zone: 'posts',
+        matching: { operator: 'all', phrase: 'required' },
+      })
+
+      expect(providerSearch).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          matching: { operator: 'any', minimumShouldMatch: 1, phrase: 'off' },
+        })
+      )
+      expect(providerSearch).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          matching: { operator: 'all', phrase: 'required' },
+        })
+      )
+    })
+  })
+
   describe('beforeRead predicates fail closed', () => {
     it.each([
       [{ typoedOwner: 'alice' }, 'unknown field'],

--- a/packages/core/src/@types/search-types.ts
+++ b/packages/core/src/@types/search-types.ts
@@ -160,6 +160,35 @@ export interface SearchDocument {
 // Query surface
 // ---------------------------------------------------------------------------
 
+/** How independently analyzed query concepts combine for lexical matching. */
+export type SearchTermOperator = 'all' | 'any'
+
+/**
+ * Phrase behavior for a lexical query:
+ *
+ * - `auto` — quoted spans are phrases; unquoted text follows `operator`.
+ * - `required` — the complete non-empty query is also required as a phrase.
+ * - `off` — do not create phrase constraints, including for quoted spans.
+ */
+export type SearchPhraseMode = 'auto' | 'required' | 'off'
+
+/**
+ * Provider-neutral lexical matching intent. Providers translate this into
+ * their native query syntax; it is product behavior, not a ranking hint.
+ */
+export interface SearchMatching {
+  /** Whether every concept or any concept must match. Defaults to `all`. */
+  operator?: SearchTermOperator
+  /**
+   * Require at least this many concepts when `operator` is `any`.
+   * Providers that cannot express this advertise that limitation through
+   * `capabilities.lexical.minimumShouldMatch`.
+   */
+  minimumShouldMatch?: number
+  /** Phrase handling. Defaults to `auto`. */
+  phrase?: SearchPhraseMode
+}
+
 /**
  * A search request. Either collection-scoped (`collectionPath`) for
  * homogeneous results, or zone-scoped (`zone`) for heterogeneous
@@ -168,6 +197,11 @@ export interface SearchDocument {
 export interface SearchQuery {
   /** The free-text query string. */
   query: string
+  /**
+   * Explicit lexical matching semantics. Defaults to all concepts required
+   * with quoted spans treated as phrases.
+   */
+  matching?: SearchMatching
   /**
    * Cross-collection scope — every collection indexed into this zone.
    * Mutually exclusive with `collectionPath` in practice.
@@ -269,6 +303,24 @@ export interface SearchCapabilities {
   weighting: boolean
   /** Matched-snippet highlighting in results. */
   highlights: boolean
+  /**
+   * Detailed lexical capabilities. Optional during the compatibility window
+   * for existing third-party providers; new providers should declare it.
+   */
+  lexical?: {
+    /** The backend applies its own language analyzer to original text. */
+    nativeAnalysis: boolean
+    /** The backend can index application-produced portable logical tokens. */
+    portableAnalysis: boolean
+    /** Supports `matching.operator: 'all'`. */
+    allTerms: boolean
+    /** Supports `matching.operator: 'any'`. */
+    anyTerms: boolean
+    /** Supports `matching.minimumShouldMatch`. */
+    minimumShouldMatch: boolean
+    /** Supports ordered phrase constraints. */
+    phrase: boolean
+  }
 }
 
 /**

--- a/packages/search-analysis/CHANGELOG.md
+++ b/packages/search-analysis/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @byline/search-analysis

--- a/packages/search-analysis/README.md
+++ b/packages/search-analysis/README.md
@@ -1,0 +1,45 @@
+# @byline/search-analysis
+
+Portable multilingual lexical analysis and backend-neutral query planning for
+Byline CMS search providers.
+
+The package owns logical search behavior:
+
+- search-only NFKC normalization with original-text offsets;
+- declared-locale validation and script-based fallback;
+- identifier extraction before word segmentation;
+- ICU-backed `Intl.Segmenter` word boundaries;
+- exact-preserving language expansion hooks;
+- overlapping Han bigrams;
+- grouped query concepts and phrase intent; and
+- a parser-safe SQL token codec.
+
+It does not own a search index or query a database. PostgreSQL, MySQL, Solr,
+and future providers translate the logical analysis into their own physical
+representations.
+
+```ts
+import { createPortableSearchAnalyzer, encodeSqlToken } from '@byline/search-analysis'
+
+const analyzer = createPortableSearchAnalyzer({
+  defaultLocale: 'en',
+  hanLocale: 'zh',
+})
+
+const text = analyzer.analyzeText({
+  text: 'ฐานข้อมูล Node.js 数据库',
+  locale: 'th',
+})
+
+const query = analyzer.analyzeQuery({
+  query: '"forest restoration" database',
+  locale: 'en',
+  matching: { operator: 'all', phrase: 'auto' },
+})
+
+const physical = text.tokens.map((token) => encodeSqlToken(token))
+```
+
+Original content remains authoritative. Analyzer output is a disposable,
+versioned projection; `analyzer.fingerprint` changes when behavior that can
+affect indexed terms changes.

--- a/packages/search-analysis/package.json
+++ b/packages/search-analysis/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@byline/search-analysis",
+  "private": false,
+  "license": "MPL-2.0",
+  "version": "4.8.0",
+  "engines": {
+    "node": ">=20.9.0"
+  },
+  "description": "Portable multilingual lexical analysis and query planning for Byline CMS search providers",
+  "keywords": [
+    "cms",
+    "headless cms",
+    "search",
+    "multilingual",
+    "tokenization"
+  ],
+  "homepage": "https://github.com/Byline-CMS/bylinecms.dev",
+  "bugs": {
+    "url": "https://github.com/Byline-CMS/bylinecms.dev/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Byline-CMS/bylinecms.dev.git",
+    "directory": "packages/search-analysis"
+  },
+  "type": "module",
+  "main": "dist/index.js",
+  "index": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "sideEffects": false,
+  "scripts": {
+    "dev": "chokidar 'src/**/*' -c 'npm-run-all build'",
+    "build": "tsc -p tsconfig.json && tsc-alias",
+    "clean": "node scripts/clean.js node_modules dist build .turbo",
+    "lint": "biome check --write --unsafe --diagnostic-level=error",
+    "test": "vitest run --mode=node",
+    "test:watch": "vitest --mode=node",
+    "typecheck": "tsc --noEmit"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist"
+  ],
+  "dependencies": {
+    "@byline/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "2.5.4",
+    "@types/node": "^26.1.1",
+    "chokidar": "^5.0.0",
+    "chokidar-cli": "^3.0.0",
+    "npm-run-all": "^4.1.5",
+    "tsc-alias": "^1.9.1",
+    "typescript": "^7.0.2",
+    "vitest": "^4.1.10"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  }
+}

--- a/packages/search-analysis/scripts/clean.js
+++ b/packages/search-analysis/scripts/clean.js
@@ -1,0 +1,5 @@
+import { rmSync } from 'node:fs'
+
+for (const target of process.argv.slice(2)) {
+  rmSync(target, { recursive: true, force: true })
+}

--- a/packages/search-analysis/src/analyzer.test.node.ts
+++ b/packages/search-analysis/src/analyzer.test.node.ts
@@ -1,0 +1,142 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import { createPortableSearchAnalyzer, resolveMatching } from './analyzer.js'
+import { detectSearchLocale, resolveSearchLocale } from './locale.js'
+import { normalizeForSearch } from './normalize.js'
+import type { SearchTokenExpander } from './types.js'
+
+describe('portable search analysis', () => {
+  it('normalizes compatibility forms while preserving original UTF-16 ranges', () => {
+    const normalized = normalizeForSearch('A ﬃ Ｂ')
+
+    expect(normalized.value).toBe('a ffi b')
+    expect(normalized.originalRange(2, 5)).toEqual({ start: 2, end: 3 })
+
+    const analyzed = createPortableSearchAnalyzer().analyzeText({ text: 'A ﬃ Ｂ' })
+    expect(analyzed.exactTokens.map(({ value, start, end }) => ({ value, start, end }))).toEqual([
+      { value: 'a', start: 0, end: 1 },
+      { value: 'ffi', start: 2, end: 3 },
+      { value: 'b', start: 4, end: 5 },
+    ])
+  })
+
+  it('prefers a valid declared locale and otherwise falls back through script detection', () => {
+    expect(resolveSearchLocale('ภาษาไทย', 'en-US')).toBe('en-US')
+    expect(resolveSearchLocale('ภาษาไทย', 'not_a_locale')).toBe('th')
+    expect(detectSearchLocale('한국어')).toBe('ko')
+    expect(detectSearchLocale('日本語です')).toBe('ja')
+    expect(detectSearchLocale('数据库')).toBe('zh')
+    expect(detectSearchLocale('数据库', 'ja')).toBe('ja')
+  })
+
+  it('extracts protected identifiers before word segmentation', () => {
+    const analyzed = createPortableSearchAnalyzer().analyzeText({
+      text: 'See HTTPS://Example.com/a). mail Tést@Example.com SKU-42 v1.2.3 C++ C# Node.js @ผู้ใช้ #หัวข้อ',
+    })
+
+    expect(
+      analyzed.identifierTokens.map(({ identifierKind, value }) => ({
+        identifierKind,
+        value,
+      }))
+    ).toEqual([
+      { identifierKind: 'url', value: 'https://example.com/a' },
+      { identifierKind: 'email', value: 'tést@example.com' },
+      { identifierKind: 'sku', value: 'sku-42' },
+      { identifierKind: 'version', value: 'v1.2.3' },
+      { identifierKind: 'technical', value: 'c++' },
+      { identifierKind: 'technical', value: 'c#' },
+      { identifierKind: 'technical', value: 'node.js' },
+      { identifierKind: 'mention', value: '@ผู้ใช้' },
+      { identifierKind: 'hashtag', value: '#หัวข้อ' },
+    ])
+    expect(analyzed.exactTokens.map((token) => token.value)).toContain('see')
+    expect(analyzed.exactTokens.map((token) => token.value)).toContain('mail')
+  })
+
+  it('emits ordered overlapping Han bigrams without replacing exact terms', () => {
+    const analyzed = createPortableSearchAnalyzer().analyzeText({ text: '数据库' })
+
+    expect(analyzed.exactTokens.map((token) => token.value).join('')).toBe('数据库')
+    expect(analyzed.gramTokens.map((token) => token.value)).toEqual(['数据', '据库'])
+    expect(analyzed.gramTokens.map((token) => token.position)).toEqual([0, 0])
+  })
+
+  it('groups exact and expanded variants by concept and retains quoted phrase intent', () => {
+    const expander: SearchTokenExpander = {
+      fingerprint: 'english-test1',
+      supports: (locale) => locale.startsWith('en'),
+      expand: (token) => (token.value === 'running' ? [{ kind: 'stem', value: 'run' }] : []),
+    }
+    const analyzer = createPortableSearchAnalyzer({ expanders: [expander] })
+    const plan = analyzer.analyzeQuery({
+      query: '"Running Fast" Node.js',
+      locale: 'en',
+      matching: { operator: 'any', minimumShouldMatch: 2 },
+    })
+
+    expect(plan.matching).toEqual({
+      operator: 'any',
+      phrase: 'auto',
+      minimumShouldMatch: 2,
+    })
+    expect(plan.concepts).toHaveLength(3)
+    expect(plan.concepts[0]?.exactTokens[0]?.value).toBe('running')
+    expect(plan.concepts[0]?.stemTokens[0]?.value).toBe('run')
+    expect(plan.concepts[2]?.identifierTokens[0]?.value).toBe('node.js')
+    expect(plan.phrases).toEqual([{ conceptIndexes: [0, 1], explicit: true }])
+    expect(plan.concepts[0]?.exactTokens[0]).toMatchObject({ start: 1, end: 8, position: 0 })
+    expect(plan.concepts[2]?.identifierTokens[0]).toMatchObject({
+      start: 15,
+      end: 22,
+      position: 2,
+    })
+    expect(plan.analyzerFingerprint).toContain('english-test1')
+  })
+
+  it('can require or disable phrase semantics explicitly', () => {
+    const analyzer = createPortableSearchAnalyzer()
+
+    expect(
+      analyzer.analyzeQuery({
+        query: 'forest restoration',
+        matching: { phrase: 'required' },
+      }).phrases
+    ).toEqual([{ conceptIndexes: [0, 1], explicit: false }])
+    expect(
+      analyzer.analyzeQuery({
+        query: '"forest restoration"',
+        matching: { phrase: 'off' },
+      }).phrases
+    ).toEqual([])
+  })
+
+  it('fingerprints every option that can change indexed terms', () => {
+    const baseline = createPortableSearchAnalyzer().fingerprint
+    const locale = createPortableSearchAnalyzer({ defaultLocale: 'th' }).fingerprint
+    const han = createPortableSearchAnalyzer({ hanLocale: 'ja' }).fingerprint
+    const grams = createPortableSearchAnalyzer({ hanBigrams: false }).fingerprint
+
+    expect(new Set([baseline, locale, han, grams]).size).toBe(4)
+    expect(baseline).toContain(`icu${process.versions.icu}`)
+  })
+})
+
+describe('matching policy', () => {
+  it('applies conservative defaults', () => {
+    expect(resolveMatching(undefined)).toEqual({ operator: 'all', phrase: 'auto' })
+  })
+
+  it('rejects invalid minimum-should-match policies', () => {
+    expect(() => resolveMatching({ operator: 'any', minimumShouldMatch: 0 })).toThrow(RangeError)
+    expect(() => resolveMatching({ operator: 'all', minimumShouldMatch: 1 })).toThrow(TypeError)
+  })
+})

--- a/packages/search-analysis/src/analyzer.ts
+++ b/packages/search-analysis/src/analyzer.ts
@@ -1,0 +1,373 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import type { SearchMatching } from '@byline/core'
+
+import { extractIdentifierSpans, maskIdentifierSpans } from './identifiers.js'
+import { canonicalSegmenterLocale, resolveSearchLocale } from './locale.js'
+import { normalizeForSearch, type SearchNormalization } from './normalize.js'
+import type {
+  AnalyzedText,
+  AnalyzeQueryInput,
+  AnalyzeTextInput,
+  LogicalToken,
+  PortableQueryPlan,
+  PortableSearchAnalyzer,
+  PortableSearchAnalyzerOptions,
+  QueryConcept,
+  QueryPhrase,
+  ResolvedSearchMatching,
+  SearchTokenExpander,
+} from './types.js'
+
+const PIPELINE_VERSION = 'portable1'
+const NORMALIZATION_VERSION = 'nfkc-lower1'
+const LOCALE_VERSION = 'locale1'
+const IDENTIFIER_VERSION = 'identifiers1'
+const GRAM_VERSION = 'han-bigram1'
+
+const wordSegmenters = new Map<string, Intl.Segmenter>()
+
+function wordSegmenter(locale: string): Intl.Segmenter {
+  let segmenter = wordSegmenters.get(locale)
+  if (segmenter == null) {
+    segmenter = new Intl.Segmenter(locale, { granularity: 'word' })
+    wordSegmenters.set(locale, segmenter)
+  }
+  return segmenter
+}
+
+export function createPortableSearchAnalyzer(
+  options: PortableSearchAnalyzerOptions = {}
+): PortableSearchAnalyzer {
+  return new PortableSearchAnalyzerImpl(options)
+}
+
+class PortableSearchAnalyzerImpl implements PortableSearchAnalyzer {
+  readonly fingerprint: string
+
+  private readonly defaultLocale: string
+  private readonly hanLocale: 'zh' | 'ja'
+  private readonly hanBigrams: boolean
+  private readonly expanders: readonly SearchTokenExpander[]
+
+  constructor(options: PortableSearchAnalyzerOptions) {
+    this.defaultLocale = canonicalSegmenterLocale(options.defaultLocale) ?? 'en'
+    this.hanLocale = options.hanLocale ?? 'zh'
+    this.hanBigrams = options.hanBigrams ?? true
+    this.expanders = options.expanders ?? []
+    this.fingerprint = [
+      PIPELINE_VERSION,
+      NORMALIZATION_VERSION,
+      `icu${process.versions.icu ?? 'unknown'}`,
+      LOCALE_VERSION,
+      `default-${this.defaultLocale}`,
+      `han-${this.hanLocale}`,
+      IDENTIFIER_VERSION,
+      this.hanBigrams ? GRAM_VERSION : 'han-bigram0',
+      ...this.expanders.map(
+        (expander, index) => `expander${index}-${encodeURIComponent(expander.fingerprint)}`
+      ),
+    ].join('+')
+  }
+
+  analyzeText(input: AnalyzeTextInput): AnalyzedText {
+    const normalization = normalizeForSearch(input.text)
+    const locale = resolveSearchLocale(
+      normalization.value,
+      input.locale,
+      this.defaultLocale,
+      this.hanLocale
+    )
+    const identifiers = extractIdentifierSpans(normalization.value)
+    const masked = maskIdentifierSpans(normalization.value, identifiers)
+
+    const sourceTokens: LogicalToken[] = []
+    for (const segment of wordSegmenter(locale).segment(masked)) {
+      if (!segment.isWordLike || segment.segment.length === 0) continue
+      sourceTokens.push(
+        logicalToken(
+          'exact',
+          segment.segment,
+          segment.index,
+          segment.index + segment.segment.length,
+          sourceTokens.length,
+          locale,
+          normalization
+        )
+      )
+    }
+
+    for (const identifier of identifiers) {
+      const token = logicalToken(
+        'identifier',
+        identifier.value,
+        identifier.start,
+        identifier.end,
+        0,
+        locale,
+        normalization
+      )
+      token.identifierKind = identifier.kind
+      sourceTokens.push(token)
+    }
+
+    sourceTokens.sort(
+      (a, b) => a.normalizedStart - b.normalizedStart || a.normalizedEnd - b.normalizedEnd
+    )
+    sourceTokens.forEach((token, position) => {
+      token.position = position
+    })
+
+    const derivedTokens: LogicalToken[] = []
+    for (const token of sourceTokens) {
+      if (token.kind !== 'exact') continue
+      for (const expander of this.expanders) {
+        if (!expander.supports(locale)) continue
+        for (const expansion of expander.expand(token)) {
+          if (expansion.value.length === 0 || expansion.value === token.value) continue
+          derivedTokens.push({ ...token, kind: expansion.kind, value: expansion.value })
+        }
+      }
+    }
+
+    const gramTokens = this.hanBigrams
+      ? buildHanBigrams(masked, locale, normalization, sourceTokens)
+      : []
+    const exactTokens = sourceTokens.filter((token) => token.kind === 'exact')
+    const identifierTokens = sourceTokens.filter((token) => token.kind === 'identifier')
+
+    return {
+      original: input.text,
+      normalized: normalization.value,
+      locale,
+      tokens: [...sourceTokens, ...derivedTokens, ...gramTokens],
+      exactTokens,
+      derivedTokens,
+      identifierTokens,
+      gramTokens,
+      analyzerFingerprint: this.fingerprint,
+    }
+  }
+
+  analyzeQuery(input: AnalyzeQueryInput): PortableQueryPlan {
+    const matching = resolveMatching(input.matching)
+    const full = this.analyzeText({ text: input.query, locale: input.locale })
+    const parts = splitQueryParts(input.query)
+    const concepts: QueryConcept[] = []
+    const phrases: QueryPhrase[] = []
+    const gramSequences: LogicalToken[][] = []
+
+    for (const part of parts) {
+      const analyzed = this.analyzeText({ text: part.text, locale: full.locale })
+      const normalizedBase = normalizeForSearch(input.query.slice(0, part.start)).value.length
+      const partConceptIndexes: number[] = []
+      const sourceTokens = [...analyzed.exactTokens, ...analyzed.identifierTokens].sort(
+        (a, b) => a.position - b.position
+      )
+
+      for (const source of sourceTokens) {
+        const conceptIndex = concepts.length
+        const queryToken = (token: LogicalToken): LogicalToken =>
+          rebaseQueryToken(token, part.start, normalizedBase, conceptIndex)
+        partConceptIndexes.push(conceptIndex)
+        concepts.push({
+          index: conceptIndex,
+          position: conceptIndex,
+          exactTokens: source.kind === 'exact' ? [queryToken(source)] : [],
+          stemTokens: analyzed.derivedTokens
+            .filter((token) => token.kind === 'stem' && token.position === source.position)
+            .map(queryToken),
+          lemmaTokens: analyzed.derivedTokens
+            .filter((token) => token.kind === 'lemma' && token.position === source.position)
+            .map(queryToken),
+          normalizedTokens: analyzed.derivedTokens
+            .filter((token) => token.kind === 'normalized' && token.position === source.position)
+            .map(queryToken),
+          identifierTokens: source.kind === 'identifier' ? [queryToken(source)] : [],
+          gramTokens: analyzed.gramTokens
+            .filter(
+              (token) =>
+                token.normalizedStart >= source.normalizedStart &&
+                token.normalizedEnd <= source.normalizedEnd
+            )
+            .map(queryToken),
+        })
+      }
+
+      if (analyzed.gramTokens.length > 0) {
+        gramSequences.push(
+          analyzed.gramTokens.map((token) =>
+            rebaseQueryToken(token, part.start, normalizedBase, token.position)
+          )
+        )
+      }
+      if (matching.phrase !== 'off' && part.quoted && partConceptIndexes.length > 0) {
+        phrases.push({ conceptIndexes: partConceptIndexes, explicit: true })
+      }
+    }
+
+    if (matching.phrase === 'required' && concepts.length > 0) {
+      phrases.length = 0
+      phrases.push({
+        conceptIndexes: concepts.map((concept) => concept.index),
+        explicit: false,
+      })
+    }
+
+    return {
+      original: input.query,
+      normalized: full.normalized,
+      locale: full.locale,
+      concepts,
+      phrases,
+      gramSequences,
+      matching,
+      analyzerFingerprint: this.fingerprint,
+    }
+  }
+}
+
+function logicalToken(
+  kind: LogicalToken['kind'],
+  value: string,
+  normalizedStart: number,
+  normalizedEnd: number,
+  position: number,
+  locale: string,
+  normalization: SearchNormalization
+): LogicalToken {
+  const original = normalization.originalRange(normalizedStart, normalizedEnd)
+  return {
+    kind,
+    value,
+    normalizedStart,
+    normalizedEnd,
+    start: original.start,
+    end: original.end,
+    position,
+    locale,
+  }
+}
+
+function buildHanBigrams(
+  text: string,
+  locale: string,
+  normalization: SearchNormalization,
+  sourceTokens: readonly LogicalToken[]
+): LogicalToken[] {
+  const grams: LogicalToken[] = []
+  for (const match of text.matchAll(/\p{Script=Han}+/gu)) {
+    const run = match[0]
+    const runStart = match.index
+    if (run == null || runStart == null) continue
+    const characters: Array<{ value: string; start: number; end: number }> = []
+    let offset = 0
+    for (const value of run) {
+      const start = runStart + offset
+      offset += value.length
+      characters.push({ value, start, end: runStart + offset })
+    }
+    for (let index = 0; index + 1 < characters.length; index++) {
+      const first = characters[index]
+      const second = characters[index + 1]
+      if (first == null || second == null) continue
+      const containingToken = sourceTokens.find(
+        (token) => token.normalizedStart <= first.start && token.normalizedEnd >= first.end
+      )
+      const previousPosition = sourceTokens.findLastIndex(
+        (token) => token.normalizedStart <= first.start
+      )
+      const position = containingToken?.position ?? Math.max(0, previousPosition)
+      grams.push(
+        logicalToken(
+          'gram',
+          first.value + second.value,
+          first.start,
+          second.end,
+          position,
+          locale,
+          normalization
+        )
+      )
+    }
+  }
+  return grams
+}
+
+export function resolveMatching(matching: SearchMatching | undefined): ResolvedSearchMatching {
+  const operator = matching?.operator ?? 'all'
+  const phrase = matching?.phrase ?? 'auto'
+  const minimumShouldMatch = matching?.minimumShouldMatch
+
+  if (
+    minimumShouldMatch != null &&
+    (!Number.isSafeInteger(minimumShouldMatch) || minimumShouldMatch < 1)
+  ) {
+    throw new RangeError('minimumShouldMatch must be a positive safe integer')
+  }
+  if (operator === 'all' && minimumShouldMatch != null) {
+    throw new TypeError("minimumShouldMatch is only valid with operator: 'any'")
+  }
+
+  return {
+    operator,
+    phrase,
+    ...(minimumShouldMatch != null ? { minimumShouldMatch } : {}),
+  }
+}
+
+interface QueryPart {
+  text: string
+  start: number
+  quoted: boolean
+}
+
+/** Split balanced ASCII-quoted spans while treating unmatched quotes as text. */
+function splitQueryParts(query: string): QueryPart[] {
+  const parts: QueryPart[] = []
+  let cursor = 0
+
+  while (cursor < query.length) {
+    const open = query.indexOf('"', cursor)
+    if (open < 0) {
+      pushPart(parts, query.slice(cursor), cursor, false)
+      break
+    }
+    const close = query.indexOf('"', open + 1)
+    if (close < 0) {
+      pushPart(parts, query.slice(cursor).replaceAll('"', ' '), cursor, false)
+      break
+    }
+    pushPart(parts, query.slice(cursor, open), cursor, false)
+    pushPart(parts, query.slice(open + 1, close), open + 1, true)
+    cursor = close + 1
+  }
+
+  return parts
+}
+
+function pushPart(parts: QueryPart[], text: string, start: number, quoted: boolean): void {
+  if (text.trim().length > 0) parts.push({ text, start, quoted })
+}
+
+function rebaseQueryToken(
+  token: LogicalToken,
+  originalBase: number,
+  normalizedBase: number,
+  position: number
+): LogicalToken {
+  return {
+    ...token,
+    normalizedStart: token.normalizedStart + normalizedBase,
+    normalizedEnd: token.normalizedEnd + normalizedBase,
+    start: token.start + originalBase,
+    end: token.end + originalBase,
+    position,
+  }
+}

--- a/packages/search-analysis/src/identifiers.ts
+++ b/packages/search-analysis/src/identifiers.ts
@@ -1,0 +1,108 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import type { SearchIdentifierKind } from './types.js'
+
+export interface IdentifierSpan {
+  kind: SearchIdentifierKind
+  value: string
+  start: number
+  end: number
+}
+
+interface IdentifierRule {
+  kind: SearchIdentifierKind
+  pattern: RegExp
+  value?: (match: string) => string
+}
+
+const RULES: readonly IdentifierRule[] = [
+  {
+    kind: 'url',
+    pattern: /https?:\/\/[^\s<>"']+/giu,
+    value: trimUrlPunctuation,
+  },
+  {
+    kind: 'email',
+    pattern: /[\p{L}\p{N}._%+-]+@[\p{L}\p{N}.-]+\.[\p{L}]{2,}/giu,
+  },
+  {
+    kind: 'technical',
+    pattern: /(?:^|(?<=[^\p{L}\p{N}_]))(?:c\+\+|c#|node\.js)(?=$|[^\p{L}\p{N}_])/giu,
+  },
+  {
+    kind: 'sku',
+    pattern: /\b[\p{L}]{2,}[-_]\d+\b/giu,
+  },
+  {
+    kind: 'version',
+    pattern: /\bv?\d+(?:\.\d+){1,3}(?:-[\p{L}\p{N}.-]+)?\b/giu,
+  },
+  {
+    kind: 'mention',
+    pattern: /@[\p{L}\p{M}\p{N}_]+/gu,
+  },
+  {
+    kind: 'hashtag',
+    pattern: /#[\p{L}\p{M}\p{N}_]+/gu,
+  },
+]
+
+const TRAILING_URL_PUNCTUATION = /[.,;:!?]+$/u
+const TRAILING_URL_BRACKETS = /[)\]}]+$/u
+
+function trimUrlPunctuation(value: string): string {
+  let trimmed = value.replace(TRAILING_URL_PUNCTUATION, '')
+  while (TRAILING_URL_BRACKETS.test(trimmed)) {
+    const final = trimmed.at(-1)
+    const opening = final === ')' ? '(' : final === ']' ? '[' : '{'
+    const closing = final
+    const openingCount = [...trimmed].filter((char) => char === opening).length
+    const closingCount = [...trimmed].filter((char) => char === closing).length
+    if (closingCount <= openingCount) break
+    trimmed = trimmed.slice(0, -1)
+  }
+  return trimmed
+}
+
+/**
+ * Extract non-overlapping domain identifiers in rule-priority order. The input
+ * is already search-normalized, so every emitted value is canonical.
+ */
+export function extractIdentifierSpans(text: string): IdentifierSpan[] {
+  const spans: IdentifierSpan[] = []
+
+  for (const rule of RULES) {
+    rule.pattern.lastIndex = 0
+    for (const match of text.matchAll(rule.pattern)) {
+      const matched = match[0]
+      const matchStart = match.index
+      if (matched == null || matchStart == null) continue
+      const value = rule.value?.(matched) ?? matched
+      if (value.length === 0) continue
+      const start = matchStart
+      const end = start + value.length
+      if (spans.some((span) => start < span.end && end > span.start)) continue
+      spans.push({ kind: rule.kind, value, start, end })
+    }
+  }
+
+  return spans.sort((a, b) => a.start - b.start || b.end - a.end)
+}
+
+/** Replace identifier spans with equal-length spaces so word offsets survive. */
+export function maskIdentifierSpans(text: string, spans: readonly IdentifierSpan[]): string {
+  if (spans.length === 0) return text
+  const characters = text.split('')
+  for (const span of spans) {
+    for (let index = span.start; index < span.end; index++) {
+      if (characters[index] !== '\n') characters[index] = ' '
+    }
+  }
+  return characters.join('')
+}

--- a/packages/search-analysis/src/index.ts
+++ b/packages/search-analysis/src/index.ts
@@ -1,0 +1,36 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+export { createPortableSearchAnalyzer, resolveMatching } from './analyzer.js'
+export {
+  canonicalSegmenterLocale,
+  detectSearchLocale,
+  resolveSearchLocale,
+} from './locale.js'
+export { normalizeForSearch, type SearchNormalization } from './normalize.js'
+export {
+  encodeSqlToken,
+  encodeSqlTokens,
+  type SqlTokenCodecOptions,
+} from './sql-token-codec.js'
+export type {
+  AnalyzedText,
+  AnalyzeQueryInput,
+  AnalyzeTextInput,
+  LogicalToken,
+  LogicalTokenKind,
+  PortableQueryPlan,
+  PortableSearchAnalyzer,
+  PortableSearchAnalyzerOptions,
+  QueryConcept,
+  QueryPhrase,
+  ResolvedSearchMatching,
+  SearchIdentifierKind,
+  SearchTokenExpander,
+  SearchTokenExpansion,
+} from './types.js'

--- a/packages/search-analysis/src/locale.ts
+++ b/packages/search-analysis/src/locale.ts
@@ -1,0 +1,59 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+const SCRIPT_LOCALES: ReadonlyArray<readonly [RegExp, string]> = [
+  [/\p{Script=Thai}/u, 'th'],
+  [/\p{Script=Hiragana}|\p{Script=Katakana}/u, 'ja'],
+  [/\p{Script=Hangul}/u, 'ko'],
+  [/\p{Script=Lao}/u, 'lo'],
+  [/\p{Script=Khmer}/u, 'km'],
+  [/\p{Script=Myanmar}/u, 'my'],
+]
+
+/** Return one canonical locale when `Intl.Segmenter` supports the candidate. */
+export function canonicalSegmenterLocale(candidate: string | undefined): string | undefined {
+  if (!candidate) return undefined
+  try {
+    const canonical = Intl.getCanonicalLocales(candidate)[0]
+    if (canonical == null) return undefined
+    return Intl.Segmenter.supportedLocalesOf([canonical]).length > 0 ? canonical : undefined
+  } catch {
+    return undefined
+  }
+}
+
+/** Script-based locale fallback for content without a usable declaration. */
+export function detectSearchLocale(
+  text: string,
+  hanLocale: 'zh' | 'ja' = 'zh'
+): string | undefined {
+  for (const [pattern, locale] of SCRIPT_LOCALES) {
+    if (pattern.test(text)) return locale
+  }
+  if (/\p{Script=Han}/u.test(text)) return hanLocale
+  return undefined
+}
+
+/**
+ * Declared locale wins, followed by script detection and the configured
+ * platform fallback. Every returned locale is canonical and Segmenter-safe.
+ */
+export function resolveSearchLocale(
+  text: string,
+  declaredLocale: string | undefined,
+  defaultLocale = 'en',
+  hanLocale: 'zh' | 'ja' = 'zh'
+): string {
+  const declared = canonicalSegmenterLocale(declaredLocale)
+  if (declared != null) return declared
+
+  const detected = canonicalSegmenterLocale(detectSearchLocale(text, hanLocale))
+  if (detected != null) return detected
+
+  return canonicalSegmenterLocale(defaultLocale) ?? 'en'
+}

--- a/packages/search-analysis/src/normalize.ts
+++ b/packages/search-analysis/src/normalize.ts
@@ -1,0 +1,66 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+interface OriginalRange {
+  start: number
+  end: number
+}
+
+export interface SearchNormalization {
+  value: string
+  originalRange(normalizedStart: number, normalizedEnd: number): OriginalRange
+}
+
+const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: 'grapheme' })
+
+/**
+ * Search-only NFKC + locale-insensitive lowercase normalization with a compact
+ * normalized-to-original offset map. Grapheme-grain processing keeps combining
+ * sequences together while mapping compatibility expansions (for example `ﬃ`
+ * → `ffi`) back to their original span.
+ */
+export function normalizeForSearch(original: string): SearchNormalization {
+  const normalizedParts: string[] = []
+  const originalStarts: number[] = []
+  const originalEnds: number[] = []
+  const segments = [...graphemeSegmenter.segment(original)]
+
+  for (let index = 0; index < segments.length; index++) {
+    const segment = segments[index]
+    if (segment == null) continue
+    const originalStart = segment.index
+    const originalEnd = segments[index + 1]?.index ?? original.length
+    const normalized = segment.segment.normalize('NFKC').toLowerCase()
+    normalizedParts.push(normalized)
+    for (let offset = 0; offset < normalized.length; offset++) {
+      originalStarts.push(originalStart)
+      originalEnds.push(originalEnd)
+    }
+  }
+
+  const value = normalizedParts.join('')
+  return {
+    value,
+    originalRange(normalizedStart, normalizedEnd) {
+      if (normalizedStart < 0 || normalizedEnd < normalizedStart || normalizedEnd > value.length) {
+        throw new RangeError(
+          `Normalized range ${normalizedStart}..${normalizedEnd} is outside 0..${value.length}`
+        )
+      }
+      if (normalizedStart === normalizedEnd) {
+        const boundary =
+          originalStarts[normalizedStart] ?? originalEnds[normalizedStart - 1] ?? original.length
+        return { start: boundary, end: boundary }
+      }
+      return {
+        start: originalStarts[normalizedStart] ?? original.length,
+        end: originalEnds[normalizedEnd - 1] ?? original.length,
+      }
+    },
+  }
+}

--- a/packages/search-analysis/src/sql-token-codec.test.node.ts
+++ b/packages/search-analysis/src/sql-token-codec.test.node.ts
@@ -1,0 +1,55 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import { encodeSqlToken } from './sql-token-codec.js'
+import type { LogicalTokenKind } from './types.js'
+
+describe('SQL token codec', () => {
+  it.each([
+    ['exact', 'a'],
+    ['exact', 'ฐานข้อมูล'],
+    ['gram', '数据'],
+    ['identifier', 'https://example.com/a'],
+  ] satisfies Array<[LogicalTokenKind, string]>)(
+    'encodes a %s token as parser-safe lowercase ASCII',
+    (kind, value) => {
+      const encoded = encodeSqlToken({ kind, value })
+
+      expect(encoded).toMatch(/^[a-z0-9]+$/)
+      expect(encoded.length).toBeGreaterThan(3)
+    }
+  )
+
+  it('keeps logical token classes physically distinct', () => {
+    const exact = encodeSqlToken({ kind: 'exact', value: 'database' })
+    const stem = encodeSqlToken({ kind: 'stem', value: 'database' })
+    const gram = encodeSqlToken({ kind: 'gram', value: 'database' })
+
+    expect(new Set([exact, stem, gram]).size).toBe(3)
+  })
+
+  it('hashes long terms deterministically within the configured bound', () => {
+    const token = { kind: 'identifier' as const, value: `https://example.com/${'x'.repeat(500)}` }
+    const first = encodeSqlToken(token, { maxLength: 32 })
+
+    expect(first).toHaveLength(32)
+    expect(encodeSqlToken(token, { maxLength: 32 })).toBe(first)
+    expect(encodeSqlToken({ ...token, value: `${token.value}y` }, { maxLength: 32 })).not.toBe(
+      first
+    )
+  })
+
+  it('rejects empty values and unsafe length limits', () => {
+    expect(() => encodeSqlToken({ kind: 'exact', value: '' })).toThrow(TypeError)
+    expect(() => encodeSqlToken({ kind: 'exact', value: 'term' }, { maxLength: 15 })).toThrow(
+      RangeError
+    )
+  })
+})

--- a/packages/search-analysis/src/sql-token-codec.ts
+++ b/packages/search-analysis/src/sql-token-codec.ts
@@ -1,0 +1,77 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import { createHash } from 'node:crypto'
+
+import type { LogicalToken, LogicalTokenKind } from './types.js'
+
+const BASE32_ALPHABET = 'abcdefghijklmnopqrstuvwxyz234567'
+
+const KIND_PREFIX: Readonly<Record<LogicalTokenKind, string>> = {
+  exact: 'ex',
+  stem: 'st',
+  lemma: 'le',
+  normalized: 'no',
+  identifier: 'id',
+  gram: 'gr',
+}
+
+export interface SqlTokenCodecOptions {
+  /**
+   * Maximum physical term length before a SHA-256 representation is used.
+   * The default stays well below common SQL full-text parser limits.
+   */
+  maxLength?: number
+}
+
+/**
+ * Encode a logical token as lowercase ASCII alphanumeric text. Kind prefixes
+ * prevent exact/stem/gram collisions and ensure even one-character source
+ * terms exceed MySQL's default minimum token length.
+ */
+export function encodeSqlToken(
+  token: Pick<LogicalToken, 'kind' | 'value'>,
+  options: SqlTokenCodecOptions = {}
+): string {
+  if (token.value.length === 0) throw new TypeError('Cannot encode an empty search token')
+
+  const prefix = KIND_PREFIX[token.kind]
+  const encoded = `${prefix}${base32(new TextEncoder().encode(token.value))}`
+  const maxLength = options.maxLength ?? 80
+  if (!Number.isSafeInteger(maxLength) || maxLength < 16) {
+    throw new RangeError('SQL token maxLength must be a safe integer of at least 16')
+  }
+  if (encoded.length <= maxLength) return encoded
+
+  const digest = createHash('sha256').update(token.value, 'utf8').digest()
+  return `${prefix}h${base32(digest)}`.slice(0, maxLength)
+}
+
+export function encodeSqlTokens(
+  tokens: readonly Pick<LogicalToken, 'kind' | 'value'>[],
+  options: SqlTokenCodecOptions = {}
+): string[] {
+  return tokens.map((token) => encodeSqlToken(token, options))
+}
+
+function base32(bytes: Uint8Array): string {
+  let value = 0
+  let bits = 0
+  let output = ''
+
+  for (const byte of bytes) {
+    value = (value << 8) | byte
+    bits += 8
+    while (bits >= 5) {
+      output += BASE32_ALPHABET[(value >>> (bits - 5)) & 31]
+      bits -= 5
+    }
+  }
+  if (bits > 0) output += BASE32_ALPHABET[(value << (5 - bits)) & 31]
+  return output
+}

--- a/packages/search-analysis/src/types.ts
+++ b/packages/search-analysis/src/types.ts
@@ -1,0 +1,147 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import type { SearchMatching, SearchPhraseMode, SearchTermOperator } from '@byline/core'
+
+/** Portable logical token classes. Physical backend representations are separate. */
+export type LogicalTokenKind = 'exact' | 'stem' | 'lemma' | 'normalized' | 'identifier' | 'gram'
+
+/** Domain category attached to an identifier token for diagnostics and tuning. */
+export type SearchIdentifierKind =
+  | 'url'
+  | 'email'
+  | 'mention'
+  | 'hashtag'
+  | 'sku'
+  | 'version'
+  | 'technical'
+
+/**
+ * One logical term produced by portable analysis. All offsets use UTF-16
+ * string indexes, matching `Intl.Segmenter` and JavaScript `slice`.
+ */
+export interface LogicalToken {
+  kind: LogicalTokenKind
+  value: string
+  /** Offset into normalized search text. */
+  normalizedStart: number
+  /** Exclusive offset into normalized search text. */
+  normalizedEnd: number
+  /** Offset into the original, unmodified input. */
+  start: number
+  /** Exclusive offset into the original, unmodified input. */
+  end: number
+  /** Source-order position; expansions retain their source token's position. */
+  position: number
+  locale: string
+  identifierKind?: SearchIdentifierKind
+}
+
+/** Result of analyzing one original text value. */
+export interface AnalyzedText {
+  original: string
+  normalized: string
+  locale: string
+  tokens: LogicalToken[]
+  exactTokens: LogicalToken[]
+  derivedTokens: LogicalToken[]
+  identifierTokens: LogicalToken[]
+  gramTokens: LogicalToken[]
+  analyzerFingerprint: string
+}
+
+/** A variant emitted by an optional language-specific token expander. */
+export interface SearchTokenExpansion {
+  kind: 'stem' | 'lemma' | 'normalized'
+  value: string
+}
+
+/**
+ * Plug-in point for stemming, lemmatization, or language-specific normalized
+ * variants. Expansion augments exact terms; it never replaces them.
+ */
+export interface SearchTokenExpander {
+  /** Stable family/version component included in the analyzer fingerprint. */
+  readonly fingerprint: string
+  supports(locale: string): boolean
+  expand(token: LogicalToken): readonly SearchTokenExpansion[]
+}
+
+/** One user concept with its recall alternatives kept together. */
+export interface QueryConcept {
+  index: number
+  position: number
+  exactTokens: LogicalToken[]
+  stemTokens: LogicalToken[]
+  lemmaTokens: LogicalToken[]
+  normalizedTokens: LogicalToken[]
+  identifierTokens: LogicalToken[]
+  /**
+   * Ordered grams that can act as low-weight fallback for this concept.
+   * They are a sequence, not independent OR alternatives.
+   */
+  gramTokens: LogicalToken[]
+}
+
+/** Ordered concept indexes that form a phrase constraint or boost. */
+export interface QueryPhrase {
+  conceptIndexes: number[]
+  explicit: boolean
+}
+
+/** Resolved matching policy with analyzer defaults applied. */
+export interface ResolvedSearchMatching {
+  operator: SearchTermOperator
+  phrase: SearchPhraseMode
+  minimumShouldMatch?: number
+}
+
+/**
+ * Backend-neutral lexical query plan. Adapters translate concept alternatives,
+ * phrase order, and gram fallback into native query syntax.
+ */
+export interface PortableQueryPlan {
+  original: string
+  normalized: string
+  locale: string
+  concepts: QueryConcept[]
+  phrases: QueryPhrase[]
+  /** Ordered fallback grams, including grams that cross word boundaries. */
+  gramSequences: LogicalToken[][]
+  matching: ResolvedSearchMatching
+  analyzerFingerprint: string
+}
+
+export interface AnalyzeTextInput {
+  text: string
+  /** Declared field/document locale. Invalid or unsupported values fall back safely. */
+  locale?: string
+}
+
+export interface AnalyzeQueryInput {
+  query: string
+  locale?: string
+  matching?: SearchMatching
+}
+
+export interface PortableSearchAnalyzer {
+  readonly fingerprint: string
+  analyzeText(input: AnalyzeTextInput): AnalyzedText
+  analyzeQuery(input: AnalyzeQueryInput): PortableQueryPlan
+}
+
+export interface PortableSearchAnalyzerOptions {
+  /** Fallback after declared locale and script detection. Defaults to `en`. */
+  defaultLocale?: string
+  /** Locale chosen for otherwise ambiguous Han-only text. Defaults to `zh`. */
+  hanLocale?: 'zh' | 'ja'
+  /** Emit overlapping Han bigrams. Defaults to true. */
+  hanBigrams?: boolean
+  /** Optional exact-preserving language expansion stages. */
+  expanders?: readonly SearchTokenExpander[]
+}

--- a/packages/search-analysis/tsconfig.json
+++ b/packages/search-analysis/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "target": "es2024",
+    "allowJs": true,
+    "resolveJsonModule": true,
+    "moduleDetection": "force",
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noFallthroughCasesInSwitch": true,
+    "module": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "sourceMap": false,
+    "declaration": true,
+    "declarationMap": false,
+    "lib": ["es2024"],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}

--- a/packages/search-analysis/vitest.config.ts
+++ b/packages/search-analysis/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig(({ mode }) => {
+  const testFiles = mode === 'node' ? ['**/*.test.node.ts'] : ['**/*.test.ts']
+
+  return {
+    test: {
+      environment: 'node',
+      include: testFiles,
+      reporter: 'verbose',
+      globals: true,
+    },
+  }
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1068,6 +1068,37 @@ importers:
         specifier: ^4.1.10
         version: 4.1.10(@types/node@26.1.1)(happy-dom@20.10.6)(jsdom@29.1.1)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.7)(sass@1.101.0)(stylus@0.62.0(supports-color@5.5.0))(tsx@4.23.1)(yaml@2.9.0))
 
+  packages/search-analysis:
+    dependencies:
+      '@byline/core':
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      '@biomejs/biome':
+        specifier: 2.5.4
+        version: 2.5.4
+      '@types/node':
+        specifier: ^26.1.1
+        version: 26.1.1
+      chokidar:
+        specifier: ^5.0.0
+        version: 5.0.0
+      chokidar-cli:
+        specifier: ^3.0.0
+        version: 3.0.0
+      npm-run-all:
+        specifier: ^4.1.5
+        version: 4.1.5
+      tsc-alias:
+        specifier: ^1.9.1
+        version: 1.9.1
+      typescript:
+        specifier: ^7.0.2
+        version: 7.0.2
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@26.1.1)(happy-dom@20.10.6)(jsdom@29.1.1)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.7)(sass@1.101.0)(stylus@0.62.0(supports-color@5.5.0))(tsx@4.23.1)(yaml@2.9.0))
+
   packages/search-postgres:
     dependencies:
       '@byline/core':


### PR DESCRIPTION
## What

- add provider-neutral `SearchMatching` semantics and detailed lexical capability declarations in `@byline/core`, passed through by both collection and zone search
- add the publishable `@byline/search-analysis` package with NFKC normalization and source offsets, locale/script resolution, protected identifiers, ICU segmentation, exact-preserving expansion hooks, Han bigrams, grouped query plans, analyzer fingerprints, and SQL-safe physical token encoding
- add analyzer/codec conformance-focused tests, release metadata, and developer documentation for the adapter rollout

## Why

PostgreSQL, MySQL, and external search engines need one explicit product-level matching contract and a shared logical analysis representation without moving storage/query concerns into core. This establishes that boundary before either SQL adapter changes its physical index.

## Compatibility and impact

This is an additive foundation phase. `SearchProvider` and `SearchDocument` remain unchanged. The existing `@byline/search-postgres` adapter continues to use its native PostgreSQL analyzer and query parser, so this PR adds no search migration, reindex, ranking change, or runtime behavior change for the default webapp configuration. Existing third-party providers may omit the new optional `capabilities.lexical` field during the compatibility window.

The next reviewable phase can add a versioned portable PostgreSQL schema/query translator, followed by shared provider conformance coverage and the MySQL provider.

## Validation

- `pnpm byline:generate:check`
- `pnpm docs:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm knip` (exit 0; existing ignored warnings only)
- `pnpm build:packages`
- `pnpm build --filter=@byline/search-analysis`
- `pnpm test`
- `pnpm test:integration` (PostgreSQL, client, search-postgres, and MySQL suites)
- `pnpm changeset status`
- `git diff --check`

Commit includes the required DCO `Signed-off-by` trailer and no other signature or co-author trailer.