### PR TITLE
test(search): add provider conformance harness

### DIFF
--- a/.changeset/search-analysis-contracts.md
+++ b/.changeset/search-analysis-contracts.md
@@ -10,4 +10,6 @@ package. The analyzer preserves exact terms, validates locale declarations,
 uses ICU word boundaries, protects domain identifiers, emits optional
 language-specific variants and Han bigrams, and records a stable fingerprint
 for reindex decisions. Collection and zone search now pass explicit all/any,
-minimum-should-match, and phrase intent to search providers.
+minimum-should-match, and phrase intent to search providers. Search providers
+must declare their lexical capabilities and implement index clearing so every
+derived projection remains explicitly rebuildable.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,9 @@ jobs:
           cat > packages/client/.env.test <<EOF
           BYLINE_DB_POSTGRES_CONNECTION_STRING=$BYLINE_DB_POSTGRES_CONNECTION_STRING
           EOF
+          cat > packages/search-postgres/.env.test <<EOF
+          BYLINE_DB_POSTGRES_CONNECTION_STRING=$BYLINE_DB_POSTGRES_CONNECTION_STRING
+          EOF
           cat > packages/db-mysql/.env.test <<EOF
           BYLINE_DB_MYSQL_CONNECTION_STRING=$BYLINE_DB_MYSQL_CONNECTION_STRING
           EOF

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,7 @@ Byline CMS — an open-source, AI-first headless CMS. Currently at a stable v4.x
 | `packages/i18n` | `@byline/i18n` | Admin-interface translation system — `TranslationBundle` types, `mergeTranslations`, ICU formatter, locale resolution. React surface (`I18nProvider`, `useTranslation`, `LanguageMenu`) at `@byline/i18n/react`. Built-in `byline-admin` bundle (EN/FR) + `adminTranslations({ locales })` factory at `@byline/i18n/admin`. |
 | `packages/richtext-lexical` | `@byline/richtext-lexical` | Lexical-based richtext editor adapter |
 | `packages/search-analysis` | `@byline/search-analysis` | Portable multilingual lexical analysis and backend-neutral query planning — NFKC normalization, locale resolution, protected identifiers, ICU word segmentation, language expansion hooks, Han bigrams, analyzer fingerprints, and SQL-safe physical tokens |
+| `packages/search-conformance` | `@byline/search-conformance` | Private backend-neutral behavioral suite for `SearchProvider` adapters — capabilities, lifecycle/scoping, lexical matching, portable parser survival, weighting, and analyzer-fingerprint rebuild enforcement |
 | `packages/search-postgres` | `@byline/search-postgres` | Built-in Postgres full-text `SearchProvider` driver — weighted `tsvector` index; owns its own schema (numbered SQL migrations); reuses the host pg pool. See "Search & Retrieval" below |
 | `packages/ai` | `@byline/ai` | AI subsystem — provider-agnostic execution (OpenAI / Google / Anthropic) for `executeInstruction`, `generateStructured`, and Lexical-node `patch` (streaming + non-streaming). Browser-safe root entry; SDK-backed execution behind `@byline/ai/server`; editor plugins at `@byline/ai/plugins/{text,lexical}`. See `packages/ai/README.md` |
 | `packages/cli` | `@byline/cli` | Guided installer that adds Byline to an existing TanStack Start app (`byline init`, `doctor`, …) |
@@ -196,7 +197,7 @@ the forward-looking landscape for the unbuilt phases is
 `docs/05-reading-and-delivery/08-search-extraction-strategy.md`.
 
 - **Interface & types**: `SearchProvider` (`capabilities` + `upsert` / `remove` /
-  `search` / `reindex?`), the type-enriched `SearchDocument` (a role-tagged
+  `search` / `reindex`), the type-enriched `SearchDocument` (a role-tagged
   `SearchField[]` projection), `SearchQuery` / `SearchResults`, provider-neutral
   `SearchMatching`, and `SearchCapabilities`
   live in `packages/core/src/@types/search-types.ts`. The provider is a pure index
@@ -207,6 +208,11 @@ the forward-looking landscape for the unbuilt phases is
   exact-preserving language expansions, Han bigrams, SQL-safe physical token
   encoding, and analyzer fingerprints for safe rebuilds. The PostgreSQL driver
   uses this portable analysis exclusively.
+- **Conformance**: `@byline/search-conformance` owns the shared capability,
+  lifecycle/scoping, matching, parser-survival, weighting, and fingerprint
+  suites. `packages/search-postgres/tests/conformance.integration.test.ts`
+  runs the complete suite against live PostgreSQL; MySQL consumes the same
+  named suites during its port.
 - **Collection search config**: `CollectionDefinition.search = { body?, facets?, filters?, zones? }`
   (`SearchFieldDecl = string | { field, boost? }`). The implementor names fields by
   the part they play; core derives each field's type from the schema. Nothing auto-pulled.

--- a/apps/webapp/byline/server.config-mysql.ts
+++ b/apps/webapp/byline/server.config-mysql.ts
@@ -121,9 +121,18 @@ async function buildBylineCore(): Promise<BylineCore<AdminStore>> {
       bm25: false,
       weighting: false,
       highlights: false,
+      lexical: {
+        nativeAnalysis: false,
+        portableAnalysis: false,
+        allTerms: false,
+        anyTerms: false,
+        minimumShouldMatch: false,
+        phrase: false,
+      },
     },
     async upsert() {},
     async remove() {},
+    async reindex() {},
     async search() {
       return { hits: [], total: 0 }
     },

--- a/apps/webapp/byline/server.config.ts
+++ b/apps/webapp/byline/server.config.ts
@@ -159,9 +159,18 @@ async function buildBylineCore(): Promise<BylineCore<AdminStore>> {
   //     bm25: false,
   //     weighting: false,
   //     highlights: false,
+  //     lexical: {
+  //       nativeAnalysis: false,
+  //       portableAnalysis: false,
+  //       allTerms: false,
+  //       anyTerms: false,
+  //       minimumShouldMatch: false,
+  //       phrase: false,
+  //     },
   //   },
   //   async upsert() {},
   //   async remove() {},
+  //   async reindex() {},
   //   async search() {
   //     return { hits: [], total: 0 }
   //   },

--- a/docs/05-reading-and-delivery/07-search.md
+++ b/docs/05-reading-and-delivery/07-search.md
@@ -99,8 +99,8 @@ interface SearchProvider {
   remove(ref: { collectionPath: string; documentId: string; locale?: string }): Promise<void>
   /** Execute a query and return ranked hits. */
   search(query: SearchQuery): Promise<SearchResults>
-  /** Drop a collection's slice (or the whole index) — the clear half of a rebuild. */
-  reindex?(opts: { collectionPath?: string }): Promise<void>
+  /** Clear a collection's slice (or the whole index) — the first half of a rebuild. */
+  reindex(opts: { collectionPath?: string }): Promise<void>
 }
 
 interface SearchCapabilities {
@@ -110,7 +110,7 @@ interface SearchCapabilities {
   bm25: boolean           // IDF-aware ranking
   weighting: boolean      // per-field SearchField.boost
   highlights: boolean     // matched-snippet highlighting
-  lexical?: {             // detailed matching/analysis support
+  lexical: {              // detailed matching/analysis support
     nativeAnalysis: boolean
     portableAnalysis: boolean
     allTerms: boolean
@@ -137,6 +137,11 @@ interface SearchCapabilities {
 - **External drivers** implement the same interface. A vector driver embeds the
   text on `upsert` and runs ANN on `search`; a hybrid driver fuses scores. None
   touch the read path. (Planned — Phase 4.)
+- **Conformance** is executable rather than documentary:
+  `@byline/search-conformance` supplies backend-neutral capability, lifecycle,
+  scoping, matching, multilingual parser, weighting, and analyzer-fingerprint
+  suites. PostgreSQL runs the aggregate suite against its real test database;
+  MySQL will use the named suites incrementally during its port.
 
 ## The collection search config (shipped)
 

--- a/docs/05-reading-and-delivery/09-multilingual-search-analysis.md
+++ b/docs/05-reading-and-delivery/09-multilingual-search-analysis.md
@@ -145,8 +145,10 @@ The implementation sequence keeps each phase reviewable:
    schema and query translator, then rebuild the two owned installations from
    published content. **Shipped.**
 3. Extract shared provider conformance tests for matching semantics,
-   capabilities, published-only lifecycle behavior, locale isolation, and
-   fingerprint mismatch/reindex behavior.
+   capabilities, published-status filtering, locale isolation, and
+   fingerprint mismatch/reindex behavior. **Shipped in
+   `@byline/search-conformance`, with PostgreSQL as the first passing
+   adapter.**
 4. Complete `@byline/search-mysql` against the same query plans and conformance
    suite, with MySQL-specific schema and full-text translation.
 5. Adapt the existing Solr implementation, normally using Solr's native

--- a/docs/09-testing.md
+++ b/docs/09-testing.md
@@ -99,9 +99,17 @@ cd packages/client && pnpm vitest run --mode=integration tests/integration/clien
 
 # @byline/db-postgres
 cd packages/db-postgres && pnpm vitest run --mode=integration tests/conformance.integration.test.ts
+
+# @byline/search-postgres
+cd packages/search-postgres && pnpm vitest run --mode=integration tests/conformance.integration.test.ts
 ```
 
-The conformance entry point runs all eleven `@byline/db-conformance` suites (versioning, document paths, transactions, and so on) against the Postgres adapter in one file, so narrow to a single suite by name with `-t`:
+The storage conformance entry point runs `@byline/db-conformance` against the
+database adapter. The search entry point runs
+`@byline/search-conformance` against the real PostgreSQL index, including
+matching semantics, multilingual parser survival, lifecycle operations,
+relative weighting, and analyzer-fingerprint enforcement. Narrow either
+aggregate file to one case or suite with `-t`:
 
 ```sh
 pnpm vitest run --mode=integration -t "tampered"

--- a/knip.json
+++ b/knip.json
@@ -35,6 +35,10 @@
       ],
       "project": ["src/**"]
     },
+    "packages/search-postgres": {
+      "entry": ["src/*.ts", "src/**/*.test.node.ts", "tests/**/*.ts"],
+      "project": ["src/**", "tests/**"]
+    },
     "packages/*": {
       "entry": ["src/*.{ts,tsx}", "src/**/*.test.*.{ts,tsx}", "src/**/*.test.{ts,tsx}"],
       "project": ["src/**"]

--- a/packages/client/src/collection-handle.ts
+++ b/packages/client/src/collection-handle.ts
@@ -357,7 +357,7 @@ export class CollectionHandle<TFields extends Record<string, any> = Record<strin
     if (provider == null || this.definition.search == null) return result
 
     // Clear the slice so deleted documents don't leave orphan rows.
-    await provider.reindex?.({ collectionPath: this.definition.path })
+    await provider.reindex({ collectionPath: this.definition.path })
 
     const pageSize = 100
     let page = 1

--- a/packages/client/tests/integration/client-zone-search.integration.test.ts
+++ b/packages/client/tests/integration/client-zone-search.integration.test.ts
@@ -316,11 +316,11 @@ describe('zone (cross-collection) search', () => {
         collectionPath,
       })
 
-      await changed.reindex?.({ collectionPath })
+      await changed.reindex({ collectionPath })
       await changed.upsert(document)
       await expect(search(changed)).resolves.toMatchObject({ total: 1 })
     } finally {
-      await changed.reindex?.({ collectionPath })
+      await changed.reindex({ collectionPath })
     }
   })
 
@@ -356,7 +356,7 @@ describe('zone (cross-collection) search', () => {
         })
       ).resolves.toMatchObject({ total: 1 })
     } finally {
-      await provider.reindex?.({ collectionPath })
+      await provider.reindex({ collectionPath })
     }
   })
 

--- a/packages/core/src/@types/search-types.ts
+++ b/packages/core/src/@types/search-types.ts
@@ -22,7 +22,7 @@
  * `@byline/search-postgres`; external drivers implement the same interface
  * rather than forking the read path.
  *
- * The provider factory (e.g. `postgresSearch({ getClient })`) lives in the
+ * The provider factory (e.g. `postgresSearch({ pool })`) lives in the
  * driver package, not here — core declares only the interface and its data
  * types, the same way `RichTextPopulateFn` is declared in core while
  * `lexicalEditorPopulateServer()` lives in `@byline/richtext-lexical`. This
@@ -303,11 +303,8 @@ export interface SearchCapabilities {
   weighting: boolean
   /** Matched-snippet highlighting in results. */
   highlights: boolean
-  /**
-   * Detailed lexical capabilities. Optional during the compatibility window
-   * for existing third-party providers; new providers should declare it.
-   */
-  lexical?: {
+  /** Detailed lexical analysis and matching capabilities. */
+  lexical: {
     /** The backend applies its own language analyzer to original text. */
     nativeAnalysis: boolean
     /** The backend can index application-produced portable logical tokens. */
@@ -350,9 +347,9 @@ export interface SearchProvider {
   /** Execute a query and return ranked hits. */
   search(query: SearchQuery): Promise<SearchResults>
   /**
-   * Drop and rebuild a collection's slice (or the whole index). Used for
-   * first-time backfill, driver swaps, and after a `search` config change.
-   * Optional — not every driver supports bulk rebuild.
+   * Clear a collection's slice (or the whole derived index) before the caller
+   * rebuilds it. Required because search projections are disposable and must
+   * be reproducible after analyzer, schema, or provider changes.
    */
-  reindex?(opts: { collectionPath?: string }): Promise<void>
+  reindex(opts: { collectionPath?: string }): Promise<void>
 }

--- a/packages/search-conformance/README.md
+++ b/packages/search-conformance/README.md
@@ -1,0 +1,30 @@
+# @byline/search-conformance
+
+Private, backend-neutral behavioral suites for Byline `SearchProvider`
+implementations. The package owns no search implementation and opens no
+connections itself. Each adapter supplies hooks for its real test backend:
+
+```ts
+runSearchProviderConformanceSuite({
+  createProvider,
+  createPortableProvider,
+  migrate,
+  reset,
+  teardown,
+})
+```
+
+The aggregate runner covers:
+
+- capability declarations;
+- idempotent upsert, removal, collection/global rebuilds, and query scoping;
+- pagination and published-status filtering;
+- all/any, minimum-should-match, and phrase behavior; and
+- portable normalization, SQL stopwords, identifiers, language expansions,
+  Han-bigram fallback, relative weighting, and analyzer fingerprints.
+
+Named suite exports let an incomplete adapter port register one group at a
+time. A complete adapter should use `runSearchProviderConformanceSuite()`.
+Backend scores are intentionally not compared numerically: conformance asserts
+positive scores and relative weighting, while relevance tuning belongs to a
+separate shared corpus.

--- a/packages/search-conformance/package.json
+++ b/packages/search-conformance/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@byline/search-conformance",
+  "private": true,
+  "license": "MPL-2.0",
+  "version": "0.0.1",
+  "engines": {
+    "node": ">=20.9.0"
+  },
+  "description": "Backend-neutral behavioral conformance suites for Byline CMS SearchProvider implementations",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "lint": "biome check --write --unsafe --diagnostic-level=error",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@byline/core": "workspace:*",
+    "@byline/search-analysis": "workspace:*"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "2.5.4",
+    "@types/node": "^26.1.1",
+    "typescript": "^7.0.2",
+    "vitest": "^4.1.10"
+  }
+}

--- a/packages/search-conformance/src/fixtures.ts
+++ b/packages/search-conformance/src/fixtures.ts
@@ -1,0 +1,41 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import type { SearchDocument, SearchField } from '@byline/core'
+
+let sequence = 0
+
+export function searchDocument(
+  text: string,
+  overrides: Partial<SearchDocument> = {}
+): SearchDocument {
+  sequence += 1
+  const documentId = overrides.documentId ?? `search-conformance-${sequence}`
+  return {
+    collectionPath: 'search-conformance',
+    documentId,
+    locale: 'en',
+    status: 'published',
+    zones: ['search-conformance'],
+    title: text,
+    path: documentId,
+    fields: [bodyField(text)],
+    updatedAt: new Date(1_700_000_000_000 + sequence).toISOString(),
+    ...overrides,
+  }
+}
+
+export function bodyField(text: string, boost?: number): SearchField {
+  return {
+    name: 'body',
+    type: 'text',
+    role: 'body',
+    value: text,
+    ...(boost == null ? {} : { boost }),
+  }
+}

--- a/packages/search-conformance/src/index.ts
+++ b/packages/search-conformance/src/index.ts
@@ -1,0 +1,69 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import type { SearchProvider } from '@byline/core'
+import type { PortableSearchAnalyzer } from '@byline/search-analysis'
+import { afterAll, beforeAll } from 'vitest'
+
+import { capabilitiesSuite } from './suites/capabilities.js'
+import { lexicalMatchingSuite } from './suites/lexical-matching.js'
+import { lifecycleSuite } from './suites/lifecycle.js'
+import { portableAnalysisSuite } from './suites/portable-analysis.js'
+
+export { capabilitiesSuite } from './suites/capabilities.js'
+export { lexicalMatchingSuite } from './suites/lexical-matching.js'
+export { lifecycleSuite } from './suites/lifecycle.js'
+export { portableAnalysisSuite } from './suites/portable-analysis.js'
+
+/**
+ * Adapter-owned operations needed to run the shared behavioral suites against
+ * one real backend. Implementations should reuse one connection pool across
+ * provider instances and close it in `teardown`.
+ */
+export interface SearchConformanceHooks {
+  /** Construct the adapter with its ordinary production defaults. */
+  createProvider(): SearchProvider | Promise<SearchProvider>
+  /**
+   * Construct the adapter with an explicit portable analyzer. Supply this
+   * only when `capabilities.lexical.portableAnalysis` is true; doing so
+   * registers the portable parser/fingerprint suites.
+   */
+  createPortableProvider?(
+    analyzer: PortableSearchAnalyzer
+  ): SearchProvider | Promise<SearchProvider>
+  /** Bring the adapter-owned search schema to its current version. */
+  migrate(): Promise<void>
+  /** Clear every derived search row while retaining the schema. */
+  reset(): Promise<void>
+  /** Close backend connections. */
+  teardown(): Promise<void>
+}
+
+/**
+ * Register the complete Byline search-provider conformance suite. Named suite
+ * exports let an adapter port register smaller phases while it is incomplete;
+ * a completed adapter should use this aggregate runner.
+ */
+export function runSearchProviderConformanceSuite(hooks: SearchConformanceHooks): void {
+  beforeAll(async () => {
+    await hooks.migrate()
+  })
+
+  afterAll(async () => {
+    try {
+      await hooks.reset()
+    } finally {
+      await hooks.teardown()
+    }
+  })
+
+  capabilitiesSuite(hooks)
+  lifecycleSuite(hooks)
+  lexicalMatchingSuite(hooks)
+  portableAnalysisSuite(hooks)
+}

--- a/packages/search-conformance/src/suites/capabilities.ts
+++ b/packages/search-conformance/src/suites/capabilities.ts
@@ -1,0 +1,41 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import type { SearchProvider } from '@byline/core'
+import { createPortableSearchAnalyzer } from '@byline/search-analysis'
+import { beforeAll, describe, expect, it } from 'vitest'
+
+import type { SearchConformanceHooks } from '../index.js'
+
+export function capabilitiesSuite(hooks: SearchConformanceHooks): void {
+  let provider: SearchProvider
+
+  describe.sequential('SearchProvider capabilities', () => {
+    beforeAll(async () => {
+      provider = await hooks.createProvider()
+    })
+
+    it('declares one analysis strategy and the shared lexical matching floor', () => {
+      const lexical = provider.capabilities.lexical
+
+      expect(lexical.nativeAnalysis || lexical.portableAnalysis).toBe(true)
+      expect(lexical).toMatchObject({
+        allTerms: true,
+        anyTerms: true,
+        minimumShouldMatch: true,
+        phrase: true,
+      })
+    })
+
+    it('declares portable analysis when a portable-provider factory is supplied', async () => {
+      if (hooks.createPortableProvider == null) return
+      const portableProvider = await hooks.createPortableProvider(createPortableSearchAnalyzer())
+      expect(portableProvider.capabilities.lexical.portableAnalysis).toBe(true)
+    })
+  })
+}

--- a/packages/search-conformance/src/suites/lexical-matching.ts
+++ b/packages/search-conformance/src/suites/lexical-matching.ts
@@ -1,0 +1,100 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import type { SearchProvider } from '@byline/core'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { searchDocument } from '../fixtures.js'
+import type { SearchConformanceHooks } from '../index.js'
+
+export function lexicalMatchingSuite(hooks: SearchConformanceHooks): void {
+  let provider: SearchProvider
+
+  describe.sequential('SearchProvider lexical matching', () => {
+    beforeEach(async () => {
+      await hooks.reset()
+      provider = await hooks.createProvider()
+    })
+
+    it('implements all, any, and minimum-should-match by source concept', async () => {
+      await provider.upsert(searchDocument('forest restoration database'))
+
+      await expect(
+        provider.search({
+          query: 'forest missing',
+          collectionPath: 'search-conformance',
+          matching: { operator: 'all' },
+        })
+      ).resolves.toMatchObject({ total: 0 })
+      await expect(
+        provider.search({
+          query: 'forest missing',
+          collectionPath: 'search-conformance',
+          matching: { operator: 'any' },
+        })
+      ).resolves.toMatchObject({ total: 1 })
+      await expect(
+        provider.search({
+          query: 'forest restoration missing',
+          collectionPath: 'search-conformance',
+          matching: { operator: 'any', minimumShouldMatch: 2 },
+        })
+      ).resolves.toMatchObject({ total: 1 })
+      await expect(
+        provider.search({
+          query: 'forest restoration missing',
+          collectionPath: 'search-conformance',
+          matching: { operator: 'any', minimumShouldMatch: 3 },
+        })
+      ).resolves.toMatchObject({ total: 0 })
+    })
+
+    it('preserves quoted and required phrase order and permits phrase opt-out', async () => {
+      await provider.upsert(searchDocument('forest restoration', { documentId: 'phrase-exact' }))
+      await provider.upsert(searchDocument('restoration forest', { documentId: 'phrase-reversed' }))
+      await provider.upsert(
+        searchDocument('forest habitat restoration', { documentId: 'phrase-separated' })
+      )
+
+      await expect(
+        provider.search({
+          query: '"forest restoration"',
+          collectionPath: 'search-conformance',
+        })
+      ).resolves.toMatchObject({
+        total: 1,
+        hits: [{ documentId: 'phrase-exact' }],
+      })
+      await expect(
+        provider.search({
+          query: 'forest restoration',
+          collectionPath: 'search-conformance',
+          matching: { phrase: 'required' },
+        })
+      ).resolves.toMatchObject({
+        total: 1,
+        hits: [{ documentId: 'phrase-exact' }],
+      })
+      await expect(
+        provider.search({
+          query: '"forest restoration"',
+          collectionPath: 'search-conformance',
+          matching: { phrase: 'off' },
+        })
+      ).resolves.toMatchObject({ total: 3 })
+    })
+
+    it('returns an empty result for a query with no searchable concepts', async () => {
+      await provider.upsert(searchDocument('punctuation marker'))
+
+      await expect(
+        provider.search({ query: '— -- !!!', collectionPath: 'search-conformance' })
+      ).resolves.toEqual({ hits: [], total: 0 })
+    })
+  })
+}

--- a/packages/search-conformance/src/suites/lifecycle.ts
+++ b/packages/search-conformance/src/suites/lifecycle.ts
@@ -1,0 +1,176 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import type { SearchProvider } from '@byline/core'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { searchDocument } from '../fixtures.js'
+import type { SearchConformanceHooks } from '../index.js'
+
+export function lifecycleSuite(hooks: SearchConformanceHooks): void {
+  let provider: SearchProvider
+
+  describe.sequential('SearchProvider document lifecycle and scope', () => {
+    beforeEach(async () => {
+      await hooks.reset()
+      provider = await hooks.createProvider()
+    })
+
+    it('replaces one logical row idempotently on upsert', async () => {
+      const original = searchDocument('alpha report', { documentId: 'replace-me' })
+      await provider.upsert(original)
+      await provider.upsert({
+        ...original,
+        title: 'beta report',
+        fields: [{ ...original.fields[0]!, value: 'beta report' }],
+      })
+
+      await expect(
+        provider.search({ query: 'alpha', collectionPath: original.collectionPath })
+      ).resolves.toMatchObject({ total: 0 })
+      await expect(
+        provider.search({ query: 'beta', collectionPath: original.collectionPath })
+      ).resolves.toMatchObject({
+        total: 1,
+        hits: [{ documentId: 'replace-me', title: 'beta report' }],
+      })
+    })
+
+    it('applies collection, zone, locale, and published-status scopes', async () => {
+      const documents = [
+        searchDocument('scope marker', {
+          documentId: 'collection-a-en',
+          collectionPath: 'collection-a',
+          zones: ['shared-zone'],
+        }),
+        searchDocument('scope marker', {
+          documentId: 'collection-b-fr',
+          collectionPath: 'collection-b',
+          locale: 'fr',
+          zones: ['shared-zone'],
+        }),
+        searchDocument('scope marker', {
+          documentId: 'collection-a-draft',
+          collectionPath: 'collection-a',
+          status: 'draft',
+          zones: ['draft-zone'],
+        }),
+      ]
+      await Promise.all(documents.map((document) => provider.upsert(document)))
+
+      await expect(
+        provider.search({ query: 'scope', collectionPath: 'collection-a' })
+      ).resolves.toMatchObject({ total: 1 })
+      await expect(
+        provider.search({ query: 'scope', zone: 'shared-zone', locale: 'fr' })
+      ).resolves.toMatchObject({
+        total: 1,
+        hits: [{ documentId: 'collection-b-fr', locale: 'fr' }],
+      })
+      await expect(provider.search({ query: 'scope', zone: 'draft-zone' })).resolves.toMatchObject({
+        total: 0,
+      })
+      await expect(
+        provider.search({ query: 'scope', zone: 'draft-zone', status: 'any' })
+      ).resolves.toMatchObject({ total: 1 })
+    })
+
+    it('returns stable pagination with a corpus-wide total', async () => {
+      for (const documentId of ['page-a', 'page-b', 'page-c']) {
+        await provider.upsert(searchDocument('pagination marker', { documentId }))
+      }
+
+      const first = await provider.search({
+        query: 'pagination',
+        collectionPath: 'search-conformance',
+        limit: 1,
+      })
+      const second = await provider.search({
+        query: 'pagination',
+        collectionPath: 'search-conformance',
+        limit: 1,
+        offset: 1,
+      })
+
+      expect(first).toMatchObject({ total: 3 })
+      expect(second).toMatchObject({ total: 3 })
+      expect(first.hits).toHaveLength(1)
+      expect(second.hits).toHaveLength(1)
+      expect(second.hits[0]?.documentId).not.toBe(first.hits[0]?.documentId)
+    })
+
+    it('removes one locale or every locale for a document', async () => {
+      const english = searchDocument('localized marker', {
+        documentId: 'localized',
+        locale: 'en',
+      })
+      const french = searchDocument('localized marker', {
+        documentId: 'localized',
+        locale: 'fr',
+      })
+      await provider.upsert(english)
+      await provider.upsert(french)
+
+      await provider.remove({
+        collectionPath: english.collectionPath,
+        documentId: english.documentId,
+        locale: 'en',
+      })
+      await expect(
+        provider.search({
+          query: 'localized',
+          collectionPath: english.collectionPath,
+          locale: 'en',
+        })
+      ).resolves.toMatchObject({ total: 0 })
+      await expect(
+        provider.search({
+          query: 'localized',
+          collectionPath: english.collectionPath,
+          locale: 'fr',
+        })
+      ).resolves.toMatchObject({ total: 1 })
+
+      await provider.remove({
+        collectionPath: english.collectionPath,
+        documentId: english.documentId,
+      })
+      await expect(
+        provider.search({ query: 'localized', collectionPath: english.collectionPath })
+      ).resolves.toMatchObject({ total: 0 })
+    })
+
+    it('clears one collection or the complete index for rebuilding', async () => {
+      await provider.upsert(
+        searchDocument('reindex marker', {
+          documentId: 'reindex-a',
+          collectionPath: 'reindex-a',
+        })
+      )
+      await provider.upsert(
+        searchDocument('reindex marker', {
+          documentId: 'reindex-b',
+          collectionPath: 'reindex-b',
+        })
+      )
+
+      await provider.reindex({ collectionPath: 'reindex-a' })
+      await expect(
+        provider.search({ query: 'reindex', collectionPath: 'reindex-a' })
+      ).resolves.toMatchObject({ total: 0 })
+      await expect(
+        provider.search({ query: 'reindex', collectionPath: 'reindex-b' })
+      ).resolves.toMatchObject({ total: 1 })
+
+      await provider.reindex({})
+      await expect(provider.search({ query: 'reindex', status: 'any' })).resolves.toMatchObject({
+        total: 0,
+      })
+    })
+  })
+}

--- a/packages/search-conformance/src/suites/portable-analysis.ts
+++ b/packages/search-conformance/src/suites/portable-analysis.ts
@@ -1,0 +1,138 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import type { SearchProvider } from '@byline/core'
+import { createPortableSearchAnalyzer, type SearchTokenExpander } from '@byline/search-analysis'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { bodyField, searchDocument } from '../fixtures.js'
+import type { SearchConformanceHooks } from '../index.js'
+
+export function portableAnalysisSuite(hooks: SearchConformanceHooks): void {
+  if (hooks.createPortableProvider == null) return
+
+  const createProvider = hooks.createPortableProvider
+  let provider: SearchProvider
+
+  describe.sequential('portable SearchProvider analysis', () => {
+    beforeEach(async () => {
+      await hooks.reset()
+      provider = await createProvider(createPortableSearchAnalyzer())
+    })
+
+    it('preserves normalized terms, SQL stopwords, and protected identifiers', async () => {
+      await provider.upsert(
+        searchDocument('ＴＨＥ Node.js SKU-1234 editor@example.com', {
+          documentId: 'portable-identifiers',
+        })
+      )
+
+      for (const query of ['the', 'Node.js', 'SKU-1234', 'editor@example.com']) {
+        const result = await provider.search({
+          query,
+          collectionPath: 'search-conformance',
+        })
+        expect(result.total, query).toBe(1)
+        expect(result.hits[0]?.score, query).toBeGreaterThan(0)
+      }
+    })
+
+    it('matches ordered Han-bigram substrings with a positive score', async () => {
+      await provider.upsert(
+        searchDocument('数据库搜索', {
+          documentId: 'portable-han',
+          locale: 'zh',
+        })
+      )
+
+      const result = await provider.search({
+        query: '据库搜',
+        collectionPath: 'search-conformance',
+        locale: 'zh',
+      })
+      expect(result).toMatchObject({
+        total: 1,
+        hits: [{ documentId: 'portable-han' }],
+      })
+      expect(result.hits[0]?.score).toBeGreaterThan(0)
+    })
+
+    it('indexes exact-preserving language expansions symmetrically', async () => {
+      const expander: SearchTokenExpander = {
+        fingerprint: 'search-conformance-english1',
+        supports: (locale) => locale.startsWith('en'),
+        expand: (token) =>
+          token.value === 'running' || token.value === 'runs'
+            ? [{ kind: 'stem', value: 'run' }]
+            : [],
+      }
+      provider = await createProvider(createPortableSearchAnalyzer({ expanders: [expander] }))
+      await provider.upsert(searchDocument('running', { documentId: 'portable-expansion' }))
+
+      await expect(
+        provider.search({ query: 'runs', collectionPath: 'search-conformance' })
+      ).resolves.toMatchObject({
+        total: 1,
+        hits: [{ documentId: 'portable-expansion' }],
+      })
+      await expect(
+        provider.search({ query: 'running', collectionPath: 'search-conformance' })
+      ).resolves.toMatchObject({ total: 1 })
+    })
+
+    it('ranks a heavier field above the same term in a lighter field', async () => {
+      if (!provider.capabilities.weighting) return
+      await provider.upsert(
+        searchDocument('heavy result', {
+          documentId: 'weight-heavy',
+          fields: [bodyField('weighted', 2)],
+        })
+      )
+      await provider.upsert(
+        searchDocument('light result', {
+          documentId: 'weight-light',
+          fields: [bodyField('weighted', 0.1)],
+        })
+      )
+
+      const result = await provider.search({
+        query: 'weighted',
+        collectionPath: 'search-conformance',
+      })
+      expect(result.total).toBe(2)
+      expect(result.hits[0]?.documentId).toBe('weight-heavy')
+      expect(result.hits[0]?.score).toBeGreaterThan(result.hits[1]?.score ?? 0)
+    })
+
+    it('rejects mixed analyzer fingerprints until the collection is rebuilt', async () => {
+      const collectionPath = 'fingerprint-guard'
+      const original = await createProvider(createPortableSearchAnalyzer({ defaultLocale: 'en' }))
+      const changed = await createProvider(createPortableSearchAnalyzer({ defaultLocale: 'th' }))
+      const document = searchDocument('fingerprint marker', {
+        collectionPath,
+        documentId: 'fingerprint-document',
+      })
+
+      await original.upsert(document)
+      await expect(changed.search({ query: 'fingerprint', collectionPath })).rejects.toMatchObject({
+        code: 'SEARCH_INDEX_REINDEX_REQUIRED',
+        collectionPath,
+      })
+      await expect(changed.upsert(document)).rejects.toMatchObject({
+        code: 'SEARCH_INDEX_REINDEX_REQUIRED',
+        collectionPath,
+      })
+
+      await changed.reindex({ collectionPath })
+      await changed.upsert(document)
+      await expect(changed.search({ query: 'fingerprint', collectionPath })).resolves.toMatchObject(
+        { total: 1 }
+      )
+    })
+  })
+}

--- a/packages/search-conformance/tsconfig.json
+++ b/packages/search-conformance/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "target": "es2024",
+    "allowJs": true,
+    "resolveJsonModule": true,
+    "moduleDetection": "force",
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noFallthroughCasesInSwitch": true,
+    "module": "NodeNext",
+    "noEmit": true,
+    "sourceMap": false,
+    "declaration": false,
+    "lib": ["es2024"],
+    "types": ["node"]
+  },
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}

--- a/packages/search-postgres/package.json
+++ b/packages/search-postgres/package.json
@@ -34,6 +34,7 @@
     "clean": "node scripts/clean.js node_modules dist build .turbo",
     "lint": "biome check --write --unsafe --diagnostic-level=error",
     "test": "vitest run --mode=node",
+    "test:integration": "vitest run --mode=integration",
     "test:watch": "vitest --mode=node",
     "typecheck": "tsc --noEmit"
   },
@@ -58,10 +59,12 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.4",
+    "@byline/search-conformance": "workspace:*",
     "@types/node": "^26.1.1",
     "@types/pg": "^8.20.0",
     "chokidar": "^5.0.0",
     "chokidar-cli": "^3.0.0",
+    "dotenv": "^17.4.2",
     "npm-run-all": "^4.1.5",
     "pg": "^8.22.0",
     "tsc-alias": "^1.9.1",

--- a/packages/search-postgres/tests/conformance.integration.test.ts
+++ b/packages/search-postgres/tests/conformance.integration.test.ts
@@ -1,0 +1,58 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import type { PortableSearchAnalyzer } from '@byline/search-analysis'
+import { runSearchProviderConformanceSuite } from '@byline/search-conformance'
+import pg from 'pg'
+
+import { migrate, postgresSearch } from '../src/index.js'
+
+const connectionString = assertTestDatabase(process.env.BYLINE_DB_POSTGRES_CONNECTION_STRING)
+const pool = new pg.Pool({ connectionString, max: 4 })
+
+runSearchProviderConformanceSuite({
+  createProvider: () => postgresSearch({ pool, defaultLocale: 'en' }),
+  createPortableProvider: (analyzer: PortableSearchAnalyzer) => postgresSearch({ pool, analyzer }),
+
+  async migrate(): Promise<void> {
+    await migrate(pool)
+  },
+
+  async reset(): Promise<void> {
+    await pool.query('TRUNCATE byline_search_documents, byline_search_index_metadata')
+  },
+
+  async teardown(): Promise<void> {
+    await pool.end()
+  },
+})
+
+function assertTestDatabase(value: string | undefined): string {
+  if (value == null) {
+    throw new Error(
+      'BYLINE_DB_POSTGRES_CONNECTION_STRING is not set. Create packages/search-postgres/.env.test.'
+    )
+  }
+
+  let databaseName: string
+  try {
+    databaseName = new URL(value).pathname.replace(/^\//, '')
+  } catch (error) {
+    throw new Error(
+      `BYLINE_DB_POSTGRES_CONNECTION_STRING is not a valid URL: ${(error as Error).message}`
+    )
+  }
+
+  if (!databaseName.endsWith('_test')) {
+    throw new Error(
+      `Refusing search conformance tests against database "${databaseName}". ` +
+        'The database name must end in "_test".'
+    )
+  }
+  return value
+}

--- a/packages/search-postgres/tests/setup.integration.ts
+++ b/packages/search-postgres/tests/setup.integration.ts
@@ -1,0 +1,11 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import { config as loadEnv } from 'dotenv'
+
+loadEnv({ path: '.env.test', quiet: true })

--- a/packages/search-postgres/vitest.config.ts
+++ b/packages/search-postgres/vitest.config.ts
@@ -1,7 +1,8 @@
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig(({ mode }) => {
-  const testFiles = mode === 'node' ? ['**/*.test.node.ts'] : ['**/*.test.ts']
+  const isIntegration = mode === 'integration'
+  const testFiles = isIntegration ? ['tests/**/*.integration.test.ts'] : ['**/*.test.node.ts']
 
   return {
     test: {
@@ -9,6 +10,14 @@ export default defineConfig(({ mode }) => {
       include: testFiles,
       reporter: 'verbose',
       globals: true,
+      ...(isIntegration
+        ? {
+            setupFiles: ['./tests/setup.integration.ts'],
+            fileParallelism: false,
+            maxWorkers: 1,
+            isolate: false,
+          }
+        : {}),
     },
   }
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1099,7 +1099,7 @@ importers:
         specifier: ^4.1.10
         version: 4.1.10(@types/node@26.1.1)(happy-dom@20.10.6)(jsdom@29.1.1)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.7)(sass@1.101.0)(stylus@0.62.0(supports-color@5.5.0))(tsx@4.23.1)(yaml@2.9.0))
 
-  packages/search-postgres:
+  packages/search-conformance:
     dependencies:
       '@byline/core':
         specifier: workspace:*
@@ -1114,6 +1114,31 @@ importers:
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1
+      typescript:
+        specifier: ^7.0.2
+        version: 7.0.2
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@26.1.1)(happy-dom@20.10.6)(jsdom@29.1.1)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.7)(sass@1.101.0)(stylus@0.62.0(supports-color@5.5.0))(tsx@4.23.1)(yaml@2.9.0))
+
+  packages/search-postgres:
+    dependencies:
+      '@byline/core':
+        specifier: workspace:*
+        version: link:../core
+      '@byline/search-analysis':
+        specifier: workspace:*
+        version: link:../search-analysis
+    devDependencies:
+      '@biomejs/biome':
+        specifier: 2.5.4
+        version: 2.5.4
+      '@byline/search-conformance':
+        specifier: workspace:*
+        version: link:../search-conformance
+      '@types/node':
+        specifier: ^26.1.1
+        version: 26.1.1
       '@types/pg':
         specifier: ^8.20.0
         version: 8.20.0
@@ -1123,6 +1148,9 @@ importers:
       chokidar-cli:
         specifier: ^3.0.0
         version: 3.0.0
+      dotenv:
+        specifier: ^17.4.2
+        version: 17.4.2
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5


### PR DESCRIPTION
## Summary

- add the private `@byline/search-conformance` package with named and aggregate behavioral suites for provider capabilities, lifecycle/scoping, lexical matching, and portable analysis
- run the complete suite against the real PostgreSQL adapter and include it in the serial integration-test workflow
- make `SearchCapabilities.lexical` and `SearchProvider.reindex` required now that search projections are explicitly disposable and rebuildable
- document the conformance boundary and mark the provider-conformance phase complete

## Why

The PostgreSQL, forthcoming MySQL, and existing Solr adapters need one executable provider contract. This harness tests shared behavior without requiring backend score parity: scores must be positive and weighting must preserve relative order, while each engine remains free to use its own relevance model.

Named suites allow the MySQL port to land incrementally; completed adapters use the aggregate runner.

## Developer impact

Third-party `SearchProvider` implementations must now declare detailed lexical capabilities and implement `reindex({ collectionPath? })` as the index-clearing half of a rebuild. The owned no-op configurations have been updated accordingly.

## Validation

- `pnpm byline:generate:check`
- `pnpm docs:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm knip`
- `pnpm test`
- `pnpm test:integration`
- `pnpm build`
- PostgreSQL shared conformance suite: 15/15 passing

All commits include the required DCO sign-off and contain no GPG signature or co-author trailer.