### PR TITLE
feat(search-mysql): add portable full-text provider

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -17,6 +17,7 @@
       "@byline/i18n",
       "@byline/richtext-lexical",
       "@byline/search-analysis",
+      "@byline/search-mysql",
       "@byline/search-postgres",
       "@byline/storage-local",
       "@byline/storage-s3",

--- a/.changeset/search-mysql-adapter.md
+++ b/.changeset/search-mysql-adapter.md
@@ -1,0 +1,13 @@
+---
+"@byline/search-mysql": minor
+"@byline/db-mysql": minor
+"@byline/core": patch
+---
+
+Added the built-in MySQL full-text `SearchProvider`, backed by portable
+multilingual analysis, weighted MySQL `FULLTEXT` indexes, driver-owned
+migrations, analyzer-fingerprint enforcement, and the shared provider
+conformance suite.
+
+Documented and wired `@byline/db-mysql` installations to use the real search
+provider instead of a no-op workaround.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,9 @@ jobs:
           cat > packages/db-mysql/.env.test <<EOF
           BYLINE_DB_MYSQL_CONNECTION_STRING=$BYLINE_DB_MYSQL_CONNECTION_STRING
           EOF
+          cat > packages/search-mysql/.env.test <<EOF
+          BYLINE_DB_MYSQL_CONNECTION_STRING=$BYLINE_DB_MYSQL_CONNECTION_STRING
+          EOF
 
       # Unit suites across every package (core/auth/admin/ai/host/client/...).
       # Pure CPU, no DB

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,7 @@ Byline CMS — an open-source, AI-first headless CMS. Currently at a stable v4.x
 | `packages/richtext-lexical` | `@byline/richtext-lexical` | Lexical-based richtext editor adapter |
 | `packages/search-analysis` | `@byline/search-analysis` | Portable multilingual lexical analysis and backend-neutral query planning — NFKC normalization, locale resolution, protected identifiers, ICU word segmentation, language expansion hooks, Han bigrams, analyzer fingerprints, and SQL-safe physical tokens |
 | `packages/search-conformance` | `@byline/search-conformance` | Private backend-neutral behavioral suite for `SearchProvider` adapters — capabilities, lifecycle/scoping, lexical matching, portable parser survival, weighting, and analyzer-fingerprint rebuild enforcement |
+| `packages/search-mysql` | `@byline/search-mysql` | Built-in MySQL full-text `SearchProvider` driver — portable parser-safe tokens in weighted `FULLTEXT` indexes; owns its own schema; reuses the host mysql2 pool. See "Search & Retrieval" below |
 | `packages/search-postgres` | `@byline/search-postgres` | Built-in Postgres full-text `SearchProvider` driver — weighted `tsvector` index; owns its own schema (numbered SQL migrations); reuses the host pg pool. See "Search & Retrieval" below |
 | `packages/ai` | `@byline/ai` | AI subsystem — provider-agnostic execution (OpenAI / Google / Anthropic) for `executeInstruction`, `generateStructured`, and Lexical-node `patch` (streaming + non-streaming). Browser-safe root entry; SDK-backed execution behind `@byline/ai/server`; editor plugins at `@byline/ai/plugins/{text,lexical}`. See `packages/ai/README.md` |
 | `packages/cli` | `@byline/cli` | Guided installer that adds Byline to an existing TanStack Start app (`byline init`, `doctor`, …) |
@@ -191,7 +192,7 @@ One-way Lexical → markdown serialization (`lexicalToMarkdown`, `@byline/richte
 
 A pluggable `SearchProvider` seam in `@byline/core` (registered on
 `ServerConfig.search`, validated at `initBylineCore()` via `validateSearchConfig`)
-with a built-in Postgres full-text driver. The present-state reference is
+with built-in PostgreSQL and MySQL full-text drivers. The present-state reference is
 [docs/05-reading-and-delivery/07-search.md](docs/05-reading-and-delivery/07-search.md);
 the forward-looking landscape for the unbuilt phases is
 `docs/05-reading-and-delivery/08-search-extraction-strategy.md`.
@@ -206,13 +207,12 @@ the forward-looking landscape for the unbuilt phases is
   backend-neutral token and query-plan layer: search-only NFKC normalization,
   validated locale/script fallback, protected identifiers, ICU word boundaries,
   exact-preserving language expansions, Han bigrams, SQL-safe physical token
-  encoding, and analyzer fingerprints for safe rebuilds. The PostgreSQL driver
-  uses this portable analysis exclusively.
+  encoding, and analyzer fingerprints for safe rebuilds. Both built-in SQL
+  drivers use this portable analysis exclusively.
 - **Conformance**: `@byline/search-conformance` owns the shared capability,
   lifecycle/scoping, matching, parser-survival, weighting, and fingerprint
-  suites. `packages/search-postgres/tests/conformance.integration.test.ts`
-  runs the complete suite against live PostgreSQL; MySQL consumes the same
-  named suites during its port.
+  suites. The PostgreSQL and MySQL packages each run the complete aggregate
+  suite against a live database.
 - **Collection search config**: `CollectionDefinition.search = { body?, facets?, filters?, zones? }`
   (`SearchFieldDecl = string | { field, boost? }`). The implementor names fields by
   the part they play; core derives each field's type from the schema. Nothing auto-pulled.
@@ -222,14 +222,13 @@ the forward-looking landscape for the unbuilt phases is
   `ServerConfig.fields.richText.toText` seam (`RichTextToTextFn`; Lexical impl `lexicalToText` /
   `lexicalEditorToTextServer` in `@byline/richtext-lexical/server`). Facets resolve to
   `{ id: target counter, term: target useAsTitle }`.
-- **Driver**: `@byline/search-postgres` — `postgresSearch({ pool, defaultLocale?, autoMigrate? })`
-  takes the host's pg pool (e.g. `db.pool`), not a client. Portable logical terms are encoded into
-  a weighted `tsvector` (body→A–D by boost, facet terms→C, Han grams→D), translated to
-  `to_tsquery('simple', …)`, and ranked with `ts_rank`. **Owns its disposable schema** via numbered
-  SQL in `migrations/` + `migrate(pool)` (its own
-  `byline_search_migrations` table) — NOT in the host's Drizzle stream. `capabilities`:
-  `weighting` + portable lexical policies today; highlights/facets/where/fuzzy/bm25/semantic are
-  `false` (follow-ups). Analyzer-fingerprint changes require clearing and rebuilding search rows.
+- **Drivers**: `@byline/search-postgres` provides weighted `tsvector` search;
+  `@byline/search-mysql` stores parser-safe portable terms in weighted
+  `FULLTEXT` indexes. Both factories take the host adapter's pool, implement the
+  complete portable lexical and weighting contract, own independent disposable
+  numbered-migration streams, and require a clear/rebuild after analyzer
+  fingerprint changes. Highlights, facets, structured `where`, fuzzy matching,
+  BM25, and semantic retrieval remain `false`.
 - **Indexing**: lifecycle hooks call `client.collection(x).indexDocument(id)` / `removeFromIndex(id)`
   (orchestration lives in `@byline/client`, not the provider). `indexDocument` re-syncs by reading
   the published view per locale (`status: 'published'`, `onMissingLocale: 'omit'`) and

--- a/README.md
+++ b/README.md
@@ -127,8 +127,8 @@ schema versioning.
   the reference `publicCacheMiddleware`, cookie-aware CDN bypass for editors,
   invalidation strategies, and clustering trade-offs.
 - **[Search](docs/05-reading-and-delivery/07-search.md)** — the pluggable
-  `SearchProvider` seam, the built-in Postgres full-text driver, lifecycle-hook
-  indexing, reindex, and the collection `search()` query surface.
+  `SearchProvider` seam, the built-in PostgreSQL and MySQL full-text drivers,
+  lifecycle-hook indexing, reindex, and the collection `search()` query surface.
 - **[Search & Document Extraction](docs/05-reading-and-delivery/08-search-extraction-strategy.md)**
   — forward-looking research for attachment extraction and retrieval: provider
   boundaries, persistence, chunking, and phased delivery.

--- a/apps/webapp/byline/server.config-mysql.ts
+++ b/apps/webapp/byline/server.config-mysql.ts
@@ -27,6 +27,7 @@ import {
   lexicalEditorToMarkdownServer,
   lexicalEditorToTextServer,
 } from '@byline/richtext-lexical/server'
+import { migrate, mysqlSearch } from '@byline/search-mysql'
 import { localStorageProvider } from '@byline/storage-local'
 
 import { collections } from './collections/index.js'
@@ -38,12 +39,11 @@ const serverURL = process.env.VITE_SERVER_URL || DEFAULT_SERVER_URL
 
 // HMR-safe singleton. Vite's program reload re-evaluates this module
 // without disposing the previous module's resources — every reload
-// would otherwise allocate a fresh pg `Pool` (max: 20) inside
-// `pgAdapter`, the previous pool would orphan but stay alive, and
-// after a handful of HMR cycles Postgres' `max_connections` is
-// exhausted and every query fails with `53300 sorry, too many clients
-// already`. Stashing the resolving `Promise` (so concurrent reloads
-// converge on one build) lets module reloads reuse the same pool.
+// would otherwise allocate a fresh MySQL pool inside `mysqlAdapter`.
+// The previous pool would remain alive, and enough HMR cycles would
+// exhaust the server's connections. Stashing the resolving `Promise`
+// (so concurrent reloads converge on one build) lets module reloads
+// reuse the same pool.
 // Production has no HMR so this guard is a no-op there.
 declare global {
   // biome-ignore lint: globalThis augmentation requires `var` rather than `let`
@@ -103,43 +103,8 @@ async function buildBylineCore(): Promise<BylineCore<AdminStore>> {
       ? Number(process.env.BYLINE_DB_MYSQL_CONNECTION_TIMEOUT_MILLIS)
       : undefined,
   })
-  //
-  // Search is Postgres-only today (`@byline/search-postgres` has no MySQL
-  // counterpart — tracked as #52). Five collections opt into search via
-  // `CollectionDefinition.search`, and `validateSearchConfig` throws at boot if
-  // any collection opts in with no provider registered — so you cannot simply
-  // omit `search`. Register this no-op instead: it satisfies validation, and
-  // indexing / querying become silent no-ops rather than errors. The admin
-  // Reindex button and the docs search page will return nothing, which is the
-  // honest answer on MySQL.
-  //
-  const noopSearch = {
-    capabilities: {
-      facets: false,
-      typoTolerance: false,
-      semantic: false,
-      bm25: false,
-      weighting: false,
-      highlights: false,
-      lexical: {
-        nativeAnalysis: false,
-        portableAnalysis: false,
-        allTerms: false,
-        anyTerms: false,
-        minimumShouldMatch: false,
-        phrase: false,
-      },
-    },
-    async upsert() {},
-    async remove() {},
-    async reindex() {},
-    async search() {
-      return { hits: [], total: 0 }
-    },
-  }
-
   // Ensure the search-index schema before the provider serves any traffic.
-  // The driver owns its schema (numbered SQL in `@byline/search-postgres`);
+  // The driver owns its schema (numbered SQL in `@byline/search-mysql`);
   // we apply it deliberately here rather than relying on `autoMigrate` so
   // startup is deterministic and DDL is an explicit, awaited step. Reuses the
   // adapter's pool — no second connection. See the package README.
@@ -147,17 +112,11 @@ async function buildBylineCore(): Promise<BylineCore<AdminStore>> {
   // Wrapped defensively: a migration failure degrades search but must not take
   // down the whole app at boot — log loudly and continue.
   //
-  // ── MySQL adapter (end-to-end testing), edit 3 of 4 ─────────────────────────
-  // Comment this whole `try/catch` out when running on MySQL. `migrate()` comes
-  // from `@byline/search-postgres` and expects a **pg** pool; on the MySQL
-  // adapter `db.pool` is a mysql2 pool, so leaving this in place fails inside
-  // the driver rather than anywhere informative.
-
-  // try {
-  //   await migrate(db.pool, { log: (m) => console.log(m) })
-  // } catch (err) {
-  //   console.error('[search-mysql] migrate failed — search may be unavailable:', err)
-  // }
+  try {
+    await migrate(db.pool, { log: (message) => console.log(message) })
+  } catch (error) {
+    console.error('[search-mysql] migrate failed — search may be unavailable:', error)
+  }
 
   const adminStore = createAdminStore(db.drizzle)
 
@@ -280,16 +239,11 @@ async function buildBylineCore(): Promise<BylineCore<AdminStore>> {
         toText: lexicalEditorToTextServer(),
       },
     },
-    // Built-in Postgres full-text search provider. Reuses the adapter's pool
+    // Built-in MySQL full-text search provider. Reuses the adapter's pool
     // (no second connection); the search index lives in the same database.
     // Collections opt in via their `search` config; lifecycle
     // hooks maintain the index (see e.g. `collections/docs/hooks.ts`).
-    // ── MySQL adapter (end-to-end testing), edit 4 of 4 ───────────────────────
-    // On MySQL, comment the `postgresSearch(...)` line out and uncomment the
-    // `noopSearch` line — see the no-op provider defined in the adapter block
-    // above, and why omitting `search` entirely throws at boot.
-    // search: postgresSearch({ pool: db.pool, defaultLocale: i18n.content.defaultLocale }),
-    search: noopSearch,
+    search: mysqlSearch({ pool: db.pool, defaultLocale: i18n.content.defaultLocale }),
   })
 
   // Register admin-subsystem abilities (admin.users.*, admin.roles.*) on

--- a/apps/webapp/byline/server.config-pg.ts
+++ b/apps/webapp/byline/server.config-pg.ts
@@ -233,12 +233,7 @@ async function buildBylineCore(): Promise<BylineCore<AdminStore>> {
     // (no second connection); the search index lives in the same database.
     // Collections opt in via their `search` config; lifecycle
     // hooks maintain the index (see e.g. `collections/docs/hooks.ts`).
-    // ── MySQL adapter (end-to-end testing), edit 4 of 4 ───────────────────────
-    // On MySQL, comment the `postgresSearch(...)` line out and uncomment the
-    // `noopSearch` line — see the no-op provider defined in the adapter block
-    // above, and why omitting `search` entirely throws at boot.
     search: postgresSearch({ pool: db.pool, defaultLocale: i18n.content.defaultLocale }),
-    // search: noopSearch,
   })
 
   // Register admin-subsystem abilities (admin.users.*, admin.roles.*) on

--- a/apps/webapp/byline/server.config.ts
+++ b/apps/webapp/byline/server.config.ts
@@ -22,8 +22,7 @@ import { pgAdapter } from '@byline/db-postgres'
 import { createAdminStore } from '@byline/db-postgres/admin'
 // ── MySQL adapter (end-to-end testing) ────────────────────────────────────────
 // Comment out the two `@byline/db-postgres` imports above and uncomment these
-// two, then follow the matching block in `buildBylineCore()` below. There are
-// FOUR coordinated edits in this file — the block below lists all of them.
+// two, then follow the matching block in `buildBylineCore()` below.
 //
 // import { mysqlAdapter } from '@byline/db-mysql'
 // import { createAdminStore } from '@byline/db-mysql/admin'
@@ -34,6 +33,7 @@ import {
   lexicalEditorToMarkdownServer,
   lexicalEditorToTextServer,
 } from '@byline/richtext-lexical/server'
+// import { migrate, mysqlSearch } from '@byline/search-mysql'
 import { migrate, postgresSearch } from '@byline/search-postgres'
 import { localStorageProvider } from '@byline/storage-local'
 
@@ -103,17 +103,12 @@ async function buildBylineCore(): Promise<BylineCore<AdminStore>> {
 
   // ── MySQL adapter (end-to-end testing) ──────────────────────────────────────
   //
-  // Swapping adapters takes FOUR edits in this file, all marked with this
-  // banner. Missing any one of them fails at boot or, worse, hands a mysql2
-  // pool to a Postgres-only driver:
+  // Swapping adapters takes three coordinated edits:
   //
-  //   1. the imports at the top of this file
+  //   1. the database and search-provider imports at the top of this file
   //   2. this block — comment out the `pgAdapter({...})` call above, uncomment
   //      the `mysqlAdapter({...})` call below
-  //   3. the `await migrate(db.pool, …)` call below — Postgres-only, must be
-  //      commented out
-  //   4. the `search:` entry in `initBylineCore()` — swap to the no-op provider
-  //      given at the end of this comment
+  //   3. the `search:` entry in `initBylineCore()` — select `mysqlSearch`
   //
   // Prerequisites:
   //
@@ -141,55 +136,18 @@ async function buildBylineCore(): Promise<BylineCore<AdminStore>> {
   //     ? Number(process.env.BYLINE_DB_MYSQL_CONNECTION_TIMEOUT_MILLIS)
   //     : undefined,
   // })
-  //
-  // Search is Postgres-only today (`@byline/search-postgres` has no MySQL
-  // counterpart — tracked as #52). Five collections opt into search via
-  // `CollectionDefinition.search`, and `validateSearchConfig` throws at boot if
-  // any collection opts in with no provider registered — so you cannot simply
-  // omit `search`. Register this no-op instead: it satisfies validation, and
-  // indexing / querying become silent no-ops rather than errors. The admin
-  // Reindex button and the docs search page will return nothing, which is the
-  // honest answer on MySQL.
-  //
-  // const noopSearch = {
-  //   capabilities: {
-  //     facets: false,
-  //     typoTolerance: false,
-  //     semantic: false,
-  //     bm25: false,
-  //     weighting: false,
-  //     highlights: false,
-  //     lexical: {
-  //       nativeAnalysis: false,
-  //       portableAnalysis: false,
-  //       allTerms: false,
-  //       anyTerms: false,
-  //       minimumShouldMatch: false,
-  //       phrase: false,
-  //     },
-  //   },
-  //   async upsert() {},
-  //   async remove() {},
-  //   async reindex() {},
-  //   async search() {
-  //     return { hits: [], total: 0 }
-  //   },
-  // }
 
   // Ensure the search-index schema before the provider serves any traffic.
-  // The driver owns its schema (numbered SQL in `@byline/search-postgres`);
-  // we apply it deliberately here rather than relying on `autoMigrate` so
+  // The selected search driver owns its schema in an independent numbered
+  // migration stream. Both built-in SQL providers expose the same `migrate`
+  // function shape and reuse their database adapter's existing pool.
+  // Apply it deliberately here rather than relying on `autoMigrate` so
   // startup is deterministic and DDL is an explicit, awaited step. Reuses the
   // adapter's pool — no second connection. See the package README.
   //
   // Wrapped defensively: a migration failure degrades search but must not take
   // down the whole app at boot — log loudly and continue.
   //
-  // ── MySQL adapter (end-to-end testing), edit 3 of 4 ─────────────────────────
-  // Comment this whole `try/catch` out when running on MySQL. `migrate()` comes
-  // from `@byline/search-postgres` and expects a **pg** pool; on the MySQL
-  // adapter `db.pool` is a mysql2 pool, so leaving this in place fails inside
-  // the driver rather than anywhere informative.
   try {
     await migrate(db.pool, { log: (m) => console.log(m) })
   } catch (err) {
@@ -317,16 +275,12 @@ async function buildBylineCore(): Promise<BylineCore<AdminStore>> {
         toText: lexicalEditorToTextServer(),
       },
     },
-    // Built-in Postgres full-text search provider. Reuses the adapter's pool
+    // Built-in SQL full-text search provider. Reuses the adapter's pool
     // (no second connection); the search index lives in the same database.
     // Collections opt in via their `search` config; lifecycle
     // hooks maintain the index (see e.g. `collections/docs/hooks.ts`).
-    // ── MySQL adapter (end-to-end testing), edit 4 of 4 ───────────────────────
-    // On MySQL, comment the `postgresSearch(...)` line out and uncomment the
-    // `noopSearch` line — see the no-op provider defined in the adapter block
-    // above, and why omitting `search` entirely throws at boot.
     search: postgresSearch({ pool: db.pool, defaultLocale: i18n.content.defaultLocale }),
-    // search: noopSearch,
+    // search: mysqlSearch({ pool: db.pool, defaultLocale: i18n.content.defaultLocale }),
   })
 
   // Register admin-subsystem abilities (admin.users.*, admin.roles.*) on

--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -76,6 +76,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.5.4",
     "@byline/db-mysql": "workspace:*",
+    "@byline/search-mysql": "workspace:*",
     "@playwright/test": "^1.61.1",
     "@tailwindcss/vite": "4.3.3",
     "@tanstack/devtools-vite": "^0.8.1",

--- a/docs/03-architecture/01-document-storage.md
+++ b/docs/03-architecture/01-document-storage.md
@@ -66,13 +66,11 @@ conformance suite before it fails anything a consumer would notice.
 
 The Postgres adapter is the supported default. The MySQL adapter is **preliminary**: its
 storage layer passes the full conformance suite, but MySQL is not yet a fully supported
-Byline backend. There is no MySQL search provider, and because `initBylineCore()` refuses
-to start when a collection declares a `search` block with no provider registered, a MySQL
-installation needs the no-op provider the
-[`@byline/db-mysql` README](https://github.com/Byline-CMS/bylinecms.dev/blob/develop/packages/db-mysql/README.md#search-on-mysql)
-documents. `byline init` also scaffolds Postgres only. Choose MySQL for evaluation,
-prototypes, or installations that do not need search; choose Postgres for everything else
-until those gaps close.
+Byline backend. `@byline/search-mysql` provides portable weighted full-text search and
+passes the shared search-provider conformance suite. `byline init` still scaffolds
+Postgres only, and MySQL's environment matrix is narrower. Choose MySQL for evaluation,
+prototypes, or controlled installations; choose Postgres when the supported default and
+CLI scaffolding matter.
 
 ## What happens when you save a document
 

--- a/docs/05-reading-and-delivery/07-search.md
+++ b/docs/05-reading-and-delivery/07-search.md
@@ -1,13 +1,13 @@
 ---
 title: "Search & Retrieval"
 path: "search"
-summary: "A pluggable SearchProvider seam with built-in Postgres full-text search, collection and zone queries, optional hydration, and strict post-ranking row authorization. Lifecycle hooks keep the published index live; BM25/vector/hybrid drivers and attachment extraction are future phases."
+summary: "A pluggable SearchProvider seam with built-in PostgreSQL and MySQL full-text search, collection and zone queries, optional hydration, and strict post-ranking row authorization. Lifecycle hooks keep the published index live; BM25/vector/hybrid drivers and attachment extraction are future phases."
 ---
 
 # Search & Retrieval
 
 :::note[Partly shipped]
-The `SearchProvider` seam, the built-in Postgres full-text driver, the
+The `SearchProvider` seam, the built-in PostgreSQL and MySQL full-text drivers, the
 type-enriched `SearchDocument` + assembler, lifecycle-hook indexing, the
 `reindex` command + admin button, the single-collection
 `client.collection(x).search()` query surface, the cross-collection **zone**
@@ -49,8 +49,9 @@ which is why this is one seam rather than two.
 
 The subsystem is a **single seam** — `SearchProvider` — with:
 
-- a **built-in Postgres full-text driver** (`@byline/search-postgres`) so every
-  installation gets ranked search with zero extra infrastructure, and
+- **built-in SQL full-text drivers** (`@byline/search-postgres` and
+  `@byline/search-mysql`) so installations using either database adapter get
+  ranked search with zero extra infrastructure, and
 - a **sanctioned extension point** so external drivers (BM25 rankers, vector
   stores, hybrid retrievers) plug in through one interface rather than ad-hoc
   forks of the query path.
@@ -72,8 +73,9 @@ The vertical, top to bottom:
    type-enriched `SearchDocument` (a typed `SearchField[]` projection). Rich-text
    `body` fields are flattened through the `fields.richText.toText` seam.
 3. **`SearchProvider`** (`ServerConfig.search`) indexes `SearchDocument`s and
-   answers queries. The built-in **`@byline/search-postgres`** driver stores a
-   weighted `tsvector`, owns its own schema, and reuses the host's pool.
+   answers queries. The built-in SQL drivers store disposable weighted
+   projections, own independent migration streams, and reuse the host database
+   adapter's pool.
 4. **Lifecycle hooks** call `client.collection(x).indexDocument(id)` /
    `removeFromIndex(id)` to keep the index live; **`client.reindex()`** (and the
    admin **reindex button**) rebuild it.
@@ -121,13 +123,14 @@ interface SearchCapabilities {
 }
 ```
 
-- **Registration** follows the established factory pattern. The built-in driver
-  is `postgresSearch({ pool, … })` — it takes the **host's existing pg pool**
-  (e.g. `db.pool` from `pgAdapter`), not a `getClient`, because the provider is a
-  pure index sink (it never reads source documents). `ServerConfig.search?:
+- **Registration** follows the established factory pattern. Use
+  `postgresSearch({ pool, … })` with `pgAdapter` or
+  `mysqlSearch({ pool, … })` with `mysqlAdapter`. Each takes the host database
+  adapter's existing pool, not a `getClient`, because a provider is a pure
+  index sink and never reads source documents. `ServerConfig.search?:
   SearchProvider`; `initBylineCore()` fails fast when a collection opts into
   search but no provider is registered (`validateSearchConfig`).
-- **`capabilities`** is the honesty layer: the PostgreSQL floor declares
+- **`capabilities`** is the honesty layer: both built-in SQL drivers declare
   `weighting` and portable lexical matching; `highlights` / `facets` /
   `typoTolerance` / `semantic` / `bm25` are `false` until a richer driver (or
   capability) lands. Consumers
@@ -140,8 +143,8 @@ interface SearchCapabilities {
 - **Conformance** is executable rather than documentary:
   `@byline/search-conformance` supplies backend-neutral capability, lifecycle,
   scoping, matching, multilingual parser, weighting, and analyzer-fingerprint
-  suites. PostgreSQL runs the aggregate suite against its real test database;
-  MySQL will use the named suites incrementally during its port.
+  suites. PostgreSQL and MySQL each run the aggregate suite against a real
+  database and must produce the same provider-level behavior.
 
 ## The collection search config (shipped)
 
@@ -286,12 +289,41 @@ interface SearchFacetValue { id: number | string; term: string }  // counter id 
 - **Schema ownership** — the driver **owns its schema**: numbered SQL files in
   `migrations/` are the source of truth, applied by `migrate(pool)` (tracked in
   its own `byline_search_migrations` table) or an opt-in `autoMigrate` at boot.
-  It is *not* part of the host's Drizzle migration stream — a future
-  `@byline/search-mysql` ships its own. Install paths: run the SQL by hand,
+  It is *not* part of the host's Drizzle migration stream. Install paths: run
+  the SQL by hand,
   `migrate(pool)` as a deploy step (recommended), or `autoMigrate` (dev). See the
   package README. The portable-analysis cutover rewrites the disposable initial
   schema directly: drop the search-owned tables and rebuild from published
   content; there is no in-place compatibility migration.
+
+## The MySQL full-text driver (shipped)
+
+`@byline/search-mysql` implements the same seam and portable analysis contract
+over MySQL 8 `FULLTEXT` indexes:
+
+- **Portable matching** — the adapter encodes exact, expanded, identifier, and
+  Han-gram logical terms into ASCII tokens before MySQL parses them. This avoids
+  server stopword and minimum-token differences while preserving the shared
+  `all`, `any`, minimum-should-match, and phrase behavior.
+- **Ranking** — one combined `search_text` index enforces matching semantics.
+  Separate `search_a` through `search_d` indexes produce a weighted score with
+  fixed A–D multipliers. Exact and identifier terms retain their source field's
+  class, derived terms lose one class, and Han grams use D.
+- **Scoping and locale** — one row per `(collection_path, document_id, locale)`;
+  collection, locale, published status, and JSON zone membership are applied
+  before paging. Facets and typed filters remain JSON projections for future
+  aggregation and structured filtering.
+- **Capabilities** — the provider reports the same portable lexical and
+  weighting capabilities as PostgreSQL. It does not claim BM25: MySQL's native
+  score is useful for ranking, but it is not a stable BM25 contract.
+- **Analyzer consistency** — collection metadata and rows carry the analyzer
+  fingerprint. A mismatch requires clearing and rebuilding that collection.
+- **Schema ownership** — numbered SQL files under the package's `migrations/`
+  directory form an independent stream applied by `migrate(pool)`. MySQL DDL
+  auto-commits, so the migrator serializes runners with `GET_LOCK`, uses
+  idempotent statements, and writes its ledger only after a file completes.
+  The search index is disposable; there is no compatibility path for an
+  earlier experimental schema.
 
 ## Mapping the seam to Solr (design study)
 
@@ -432,7 +464,7 @@ const results = await client.collection('docs').search({
   },
   locale,                // defaults to the client default
   status: 'published',   // defaults to published
-  where,                 // accepted; not yet applied by the Postgres driver
+  where,                 // accepted; not yet applied by the built-in SQL drivers
   facets,                // accepted; aggregation not yet implemented
   limit, offset,
 })
@@ -450,7 +482,7 @@ collection + `published` by default, and delegates to `provider.search()`. It
 passes the same optional `matching` policy as zone search: `operator` is
 `'all'` or `'any'`, `minimumShouldMatch` refines `'any'`, and `phrase` is
 `'auto'`, `'required'`, or `'off'`. Providers declare detailed support in
-`capabilities.lexical`; the PostgreSQL provider implements all four policies
+`capabilities.lexical`; both built-in SQL providers implement all four policies
 through the portable query plan.
 It accepts `status: 'any'`, but the framework lifecycle indexes published views
 only, so this does not make drafts appear in the built-in index; it only relaxes
@@ -749,9 +781,10 @@ construction — which is the proof the seam boundary is drawn correctly.
 0. **Prerequisites — done.** `admin.itemView` + the relation column formatter +
    depth-1 list populate.
 1. **Design** — ✅ done (this doc, now a present-state reference).
-2. **`SearchProvider` seam + Postgres FTS driver — ✅ shipped.** The interface +
+2. **`SearchProvider` seam + built-in SQL FTS drivers — ✅ shipped.** The interface +
    typed `SearchDocument` + assembler + `richTextToText` seam in `@byline/core`;
    `@byline/search-postgres` (weighted `tsvector`, owns its schema);
+   `@byline/search-mysql` (weighted `FULLTEXT` indexes, owns its schema);
    `ServerConfig.search` registration + boot validation; the collection
    `search` config; lifecycle-hook indexing; `reindex` + the `collections.<path>.reindex`
    ability + admin button; `client.collection(x).search()`; the docs frontend
@@ -773,15 +806,15 @@ construction — which is the proof the seam boundary is drawn correctly.
 - **Resolved — per-locale portable analysis.** Shipped: one `SearchDocument`
   per `(document, locale)`, analyzed through the declared/detected locale, plus
   a `defaultLocale` fallback.
-- **Resolved — awaited indexing for the Postgres driver.** Shipped inline in the
+- **Resolved — awaited indexing for the built-in SQL drivers.** Shipped inline in the
   post-commit lifecycle hook. Async/durable outbox support remains open.
 - **Partly resolved — facets over EAV.** The `{ id, term }` projection is built
   and indexed (term searchable, id stored). Facet *aggregation queries* remain
-  open for the Postgres driver (`capabilities.facets === false`) — but the
+  open for both built-in SQL drivers (`capabilities.facets === false`) — but the
   [Solr design study](#mapping-the-seam-to-solr-design-study) shows the
   aggregation path at the seam (JSON Facet API over the projected `counter`
   ids returning the shared `SearchFacetBucket` shape), so what's left is
-  Postgres-side implementation, not design.
+  SQL-driver implementation, not design.
 - **Settled in design — driver-specific query extensions.** The
   declaration-merged `SearchQuery.driver` slot (see
   [the typed escape hatch](#driver-specific-query-options-the-typed-escape-hatch)):

--- a/docs/05-reading-and-delivery/08-search-extraction-strategy.md
+++ b/docs/05-reading-and-delivery/08-search-extraction-strategy.md
@@ -9,9 +9,9 @@ summary: "Forward-looking research for attachment extraction and retrieval: prov
 :::note[Status]
 This is **forward-looking landscape research**, not a description of shipped
 code. Since it was written, the **search** subsystem's first slice has shipped —
-the `SearchProvider` seam, the built-in Postgres full-text driver
-(`@byline/search-postgres`), the type-enriched `SearchDocument` + assembler,
-lifecycle indexing, `reindex`, and `client.collection(x).search()`. The
+the `SearchProvider` seam, the built-in PostgreSQL and MySQL full-text drivers,
+the type-enriched `SearchDocument` + assembler, lifecycle indexing, `reindex`,
+and `client.collection(x).search()`. The
 present-state reference for that is [Search & Retrieval](./07-search.md). This
 brief remains the strategy source for the **still-unbuilt phases** it
 cross-links to: §1 informs the external-driver tiers (Solr / Meilisearch /

--- a/docs/05-reading-and-delivery/09-multilingual-search-analysis.md
+++ b/docs/05-reading-and-delivery/09-multilingual-search-analysis.md
@@ -7,17 +7,18 @@ summary: "The backend-neutral lexical matching, token analysis, query-plan, phys
 # Portable Multilingual Search Analysis
 
 Companions:
-- [Search & Retrieval](./07-search.md) — the provider seam, index lifecycle, query surfaces, authorization, and current PostgreSQL implementation.
+- [Search & Retrieval](./07-search.md) — the provider seam, index lifecycle, query surfaces, authorization, and built-in PostgreSQL and MySQL implementations.
 - [Search & Document Extraction](./08-search-extraction-strategy.md) — the separate attachment-extraction pipeline whose text will feed the same search projection.
 - [Client SDK](./01-client-sdk.md) — the collection and zone search APIs that accept the matching policy.
 
-:::note[PostgreSQL adapter shipped]
+:::note[Built-in SQL adapters shipped]
 `@byline/search-analysis`, the additive `SearchQuery.matching` contract, and
-the portable `@byline/search-postgres` index/query translator are available.
+the portable PostgreSQL and MySQL index/query translators are available.
 The PostgreSQL cutover intentionally replaces its old native-analysis index:
 installations drop the driver-owned search tables, apply the rewritten
 `0001_init.sql`, and rebuild the published index. There is no dual-mode or
-in-place compatibility path.
+in-place compatibility path. The new MySQL adapter likewise starts from a
+disposable `0001_init.sql` projection.
 :::
 
 ## Why this is a separate package
@@ -40,7 +41,7 @@ The ownership boundaries are:
 This split keeps the portable behavior independently testable. It also avoids
 forcing Solr, OpenSearch, or another engine with a strong native analyzer to
 store application-produced tokens. Providers declare whether they use native
-or portable analysis. The PostgreSQL provider uses portable analysis only.
+or portable analysis. Both built-in SQL providers use portable analysis only.
 
 ## Matching intent
 
@@ -103,7 +104,7 @@ can express:
 without accidentally flattening all expansions into one broad OR query.
 Quoted and required phrases refer to ordered concept indexes. Han grams remain
 ordered sequences rather than independent alternatives. This structure is the
-portable contract that PostgreSQL and MySQL translators will share.
+portable contract shared by the PostgreSQL and MySQL translators.
 
 ## Physical SQL tokens
 
@@ -150,7 +151,7 @@ The implementation sequence keeps each phase reviewable:
    `@byline/search-conformance`, with PostgreSQL as the first passing
    adapter.**
 4. Complete `@byline/search-mysql` against the same query plans and conformance
-   suite, with MySQL-specific schema and full-text translation.
+   suite, with MySQL-specific schema and full-text translation. **Shipped.**
 5. Adapt the existing Solr implementation, normally using Solr's native
    analyzers while mapping the public matching contract and capability report.
 

--- a/docs/05-reading-and-delivery/index.md
+++ b/docs/05-reading-and-delivery/index.md
@@ -26,7 +26,7 @@ it efficiently.
 - [Caching](./06-caching.md) — CDN edge caching, invalidation strategies, and the
   optional in-memory data cache.
 - [Search & Retrieval](./07-search.md) — the pluggable `SearchProvider` seam
-  (Postgres full-text search built in, vector / hybrid as external drivers),
+  (PostgreSQL and MySQL full-text search built in, vector / hybrid as external drivers),
   shipped collection/zone search, hydration, and post-ranking authorization,
   exposed through the Client SDK surfaces developers build site search on.
 - [Portable Multilingual Search Analysis](./09-multilingual-search-analysis.md)

--- a/docs/09-testing.md
+++ b/docs/09-testing.md
@@ -1,21 +1,22 @@
 ---
 title: "Testing"
 path: "testing"
-summary: "Two suites, two commands: pnpm test (unit, no Postgres) and pnpm test:integration (real db). Isolation, safety guards, and how to run a single test file."
+summary: "Two suites, two commands: pnpm test (unit, no database) and pnpm test:integration (real PostgreSQL and MySQL). Isolation, safety guards, and how to run a single test file."
 ---
 
 # Testing
 
 Companions:
-- [Development environment and example application](./01-getting-started/02-development-environment.md) — the Postgres container and database setup the integration suite builds on.
+- [Development environment and example application](./01-getting-started/02-development-environment.md) — the local database and application setup the integration suite builds on.
 - [Markdown Export](./05-reading-and-delivery/04-markdown-export.md) — the agent-facing routes the agent-surface specs pin the served output of.
 
 Two test suites, two commands:
 
-- **`pnpm test`** — unit tests across every package. Pure CPU, no Postgres needed.
-- **`pnpm test:integration`** — DB-backed tests for `@byline/client` and `@byline/db-postgres`. Runs against a dedicated `byline_test` Postgres database — never `byline_dev`.
+- **`pnpm test`** — unit tests across every package. Pure CPU, no database needed.
+- **`pnpm test:integration`** — DB-backed storage, client, and search-provider
+  tests. Runs against dedicated `byline_test` PostgreSQL and MySQL databases.
 
-CI runs both, in the same job, against a Postgres service container.
+CI runs both in the same job against PostgreSQL and MySQL service containers.
 
 ## TL;DR
 
@@ -24,9 +25,16 @@ CI runs both, in the same job, against a Postgres service container.
 cp packages/db-postgres/.env.example      packages/db-postgres/.env       # dev DB
 cp packages/db-postgres/.env.test.example packages/db-postgres/.env.test  # test DB
 cp packages/client/.env.test.example      packages/client/.env.test       # client integration tests
+cp packages/search-postgres/.env.test.example packages/search-postgres/.env.test
+cp packages/db-mysql/.env.example         packages/db-mysql/.env          # MySQL dev DB
+cp packages/db-mysql/.env.test.example    packages/db-mysql/.env.test     # MySQL test DB
+cp packages/search-mysql/.env.test.example packages/search-mysql/.env.test
 cd postgres && ./postgres.sh up -d  # start the container
+cd ../mysql && ./mysql.sh up -d      # start MySQL
+cd ..
 pnpm db:init       # create byline_dev (one-time)
 pnpm db:init:test  # create byline_test (one-time)
+pnpm db:init:test:mysql
 
 # Every test run
 pnpm test              # unit suites — no DB
@@ -47,26 +55,36 @@ The integration runner auto-migrates `byline_test` on startup (Drizzle's migrato
 | `@byline/host-tanstack-start` | ✅ vitest `--mode=node` | — |
 | `@byline/client` | ✅ vitest `--mode=node` (`*.test.node.ts`) | ✅ vitest `--mode=integration` (`*.integration.test.ts`) |
 | `@byline/db-postgres` | ❌ no-op (every test needs a DB) | ✅ vitest `--mode=integration` (`src/**/tests/**/*.test.ts`) |
+| `@byline/db-mysql` | ❌ no-op (every test needs a DB) | ✅ shared storage conformance against MySQL |
+| `@byline/search-postgres` | ✅ vitest `--mode=node` | ✅ shared search conformance against PostgreSQL |
+| `@byline/search-mysql` | ✅ vitest `--mode=node` | ✅ shared search conformance against MySQL |
 
-Only `@byline/client` and `@byline/db-postgres` write to `byline_test`. Everything else is pure in-memory.
+Only integration-mode suites write to the dedicated test databases. Unit suites
+remain in-memory.
 
-`pnpm test` (root) runs `turbo run test`. `pnpm test:integration` (root) runs `turbo run test:integration --concurrency=1` — the concurrency flag serialises the two DB-backed suites so each one's per-file `TRUNCATE` doesn't wipe the other's seeded fixtures mid-run.
+`pnpm test` (root) runs `turbo run test`. `pnpm test:integration` (root) runs
+`turbo run test:integration --concurrency=1`. The concurrency flag serialises
+suites that share a database so their cleanup cannot erase another suite's
+fixtures mid-run.
 
-## Two databases, two purposes
+## Development and test databases
 
-| Database | Used by | Lifecycle |
+| Database name | Used by | Lifecycle |
 |---|---|---|
 | `byline_dev` | `pnpm dev` (webapp, admin UI) | Created once, lives as long as you want, manual seed |
 | `byline_test` | `pnpm test:integration` | Created once, wiped by the test runner between test files |
 
-Both live in the same local Postgres container (`postgres/docker-compose.yml`). Same `byline` role. The split is logical, not physical — local Postgres is a dev tool.
+The local PostgreSQL and MySQL containers each use this logical split. Search
+and storage suites only target their engine's `byline_test` database.
 
 ## Safety guards
 
-Two layers prevent any test from ever pointing at the wrong database:
+Two layers prevent tests from pointing at the wrong database:
 
-1. **Script-level (braces)** — `packages/db-postgres/src/database/common.sh` parses `BYLINE_DB_POSTGRES_CONNECTION_STRING` and refuses to continue unless the derived database name ends in `_dev` or `_test`. `db_init.sh` and `db_init_test.sh` both go through it.
-2. **Runtime (belt)** — `assertTestDatabase()` in `packages/db-postgres/src/lib/test-db.ts` parses the connection string at the top of every test bootstrap and throws unless the DB name ends in `_test`. Both Vitest global setup files call it: `packages/client/tests/_global-setup.ts` and `packages/db-postgres/tests/_global-setup.ts`.
+1. **Script-level** — both database adapters' init scripts refuse database
+   names that do not end in `_dev` or `_test`.
+2. **Runtime** — integration bootstraps parse their connection string and throw
+   unless the target database name ends in `_test`.
 
 ## Isolation strategy
 
@@ -81,7 +99,10 @@ Both `@byline/client` and `@byline/db-postgres` use the same vitest config shape
 `.github/workflows/ci.yml` runs on every pull request and on direct pushes to `develop` / `main`. Two jobs:
 
 - **lint-and-typecheck** — `pnpm install --frozen-lockfile` → `pnpm byline:generate:check` → `pnpm docs:check` → `pnpm lint` → `pnpm typecheck` → `pnpm knip`.
-- **test-suite** — boots a Postgres service container with `byline_test` pre-created, writes `.env.test` files from the job-level env block, builds the workspace packages, then runs `pnpm test` (unit) followed by `pnpm test:integration`. Both run in the same job so they share one `pnpm install`.
+- **test-suite** — boots PostgreSQL and MySQL service containers with
+  `byline_test` pre-created, writes `.env.test` files from the job-level env
+  block, builds the workspace packages, then runs `pnpm test` followed by
+  `pnpm test:integration`.
 
 Both jobs skip when the head commit starts with `chore(release):` so version-bump pushes from `pnpm version-packages` don't trigger redundant runs. Tag pushes (`git push --tags`) and `gh release create` aren't listened to at all, so the local-only release flow stays silent.
 
@@ -102,11 +123,14 @@ cd packages/db-postgres && pnpm vitest run --mode=integration tests/conformance.
 
 # @byline/search-postgres
 cd packages/search-postgres && pnpm vitest run --mode=integration tests/conformance.integration.test.ts
+
+# @byline/search-mysql
+cd packages/search-mysql && pnpm vitest run --mode=integration tests/conformance.integration.test.ts
 ```
 
 The storage conformance entry point runs `@byline/db-conformance` against the
 database adapter. The search entry point runs
-`@byline/search-conformance` against the real PostgreSQL index, including
+`@byline/search-conformance` against the real PostgreSQL or MySQL index, including
 matching semantics, multilingual parser survival, lifecycle operations,
 relative weighting, and analyzer-fingerprint enforcement. Narrow either
 aggregate file to one case or suite with `-t`:

--- a/knip.json
+++ b/knip.json
@@ -39,6 +39,10 @@
       "entry": ["src/*.ts", "src/**/*.test.node.ts", "tests/**/*.ts"],
       "project": ["src/**", "tests/**"]
     },
+    "packages/search-mysql": {
+      "entry": ["src/*.ts", "src/**/*.test.node.ts", "tests/**/*.ts"],
+      "project": ["src/**", "tests/**"]
+    },
     "packages/*": {
       "entry": ["src/*.{ts,tsx}", "src/**/*.test.*.{ts,tsx}", "src/**/*.test.{ts,tsx}"],
       "project": ["src/**"]

--- a/packages/core/src/@types/search-types.ts
+++ b/packages/core/src/@types/search-types.ts
@@ -17,12 +17,13 @@
  * the provider never sees EAV store rows. The document carries a typed,
  * role-tagged field projection ({@link SearchField}) so a driver can map
  * each field onto its own index schema (Postgres store columns + weighted
- * tsvector, Solr dynamic fields, a vector store's payload, …) without
- * re-deriving types. A built-in Postgres full-text driver ships as
- * `@byline/search-postgres`; external drivers implement the same interface
- * rather than forking the read path.
+ * tsvector, MySQL FULLTEXT columns, Solr dynamic fields, a vector store's
+ * payload, …) without re-deriving types. Built-in SQL full-text drivers ship as
+ * `@byline/search-postgres` and `@byline/search-mysql`; external drivers
+ * implement the same interface rather than forking the read path.
  *
- * The provider factory (e.g. `postgresSearch({ pool })`) lives in the
+ * The provider factory (e.g. `postgresSearch({ pool })` or
+ * `mysqlSearch({ pool })`) lives in the
  * driver package, not here — core declares only the interface and its data
  * types, the same way `RichTextPopulateFn` is declared in core while
  * `lexicalEditorPopulateServer()` lives in `@byline/richtext-lexical`. This

--- a/packages/core/src/@types/site-config.ts
+++ b/packages/core/src/@types/site-config.ts
@@ -425,10 +425,10 @@ export interface ServerConfig<TAdminStore = unknown> extends BaseConfig {
    * beside `db` and `storage`, composed by `initBylineCore()`.
    *
    * Drivers ship as separate packages and are constructed via a factory,
-   * mirroring the richText server adapters. The built-in Postgres
-   * full-text driver is `@byline/search-postgres`. When any collection
-   * opts into search (`CollectionDefinition.search`) but no provider is
-   * registered, `initBylineCore()` fails fast.
+   * mirroring the richText server adapters. The built-in SQL full-text drivers
+   * are `@byline/search-postgres` and `@byline/search-mysql`. When any
+   * collection opts into search (`CollectionDefinition.search`) but no
+   * provider is registered, `initBylineCore()` fails fast.
    *
    * @example
    * ```ts

--- a/packages/core/src/services/validate-search-config.ts
+++ b/packages/core/src/services/validate-search-config.ts
@@ -40,7 +40,7 @@ export function validateSearchConfig(
   throw new Error(
     `initBylineCore: ${optedIn.length} collection(s) opt into search ` +
       `(${optedIn.join(', ')}) but no search provider is registered. ` +
-      `Wire one via ServerConfig.search — see \`@byline/search-postgres\` → ` +
-      `\`postgresSearch()\` for the built-in Postgres full-text driver.`
+      `Wire one via ServerConfig.search — use \`postgresSearch()\` from ` +
+      `\`@byline/search-postgres\` or \`mysqlSearch()\` from \`@byline/search-mysql\`.`
   )
 }

--- a/packages/db-mysql/README.md
+++ b/packages/db-mysql/README.md
@@ -4,14 +4,12 @@
 > exercised, not because MySQL is a fully supported Byline backend yet. The
 > storage layer is complete and proven — it passes the entire shared
 > `@byline/db-conformance` behavioural suite, the same suite `@byline/db-postgres`
-> passes, with identical results. What is missing is the surrounding ecosystem:
+> passes, with identical results. Search is also implemented; the remaining
+> limitations are in tooling and breadth of environment coverage:
 >
-> - **No search provider.** `@byline/search-postgres` has no MySQL counterpart, and
->   this is not merely a missing feature — `initBylineCore()` **throws at boot** if
->   any collection declares `search` and no provider is registered. See
->   [Search on MySQL](#search-on-mysql) below for the one-step workaround you will
->   need. Tracked in
->   [#52](https://github.com/Byline-CMS/bylinecms.dev/issues/52).
+> - **Search is available.** `@byline/search-mysql` implements the same
+>   provider contract and conformance suite as the built-in PostgreSQL search
+>   driver. It owns an independent, disposable migration stream.
 > - **No CLI support.** `byline init` scaffolds a Postgres installation; wiring
 >   MySQL is a manual edit to your `server.config.ts`.
 > - **Narrower CI coverage than Postgres.** Continuous integration pins MySQL 8.0
@@ -19,8 +17,8 @@
 >   runs under a non-UTC timezone. Tracked in
 >   [#55](https://github.com/Byline-CMS/bylinecms.dev/issues/55).
 >
-> Treat it as suitable for evaluation, prototypes, and installations that do not
-> need search. The criteria for general availability are tracked in
+> Treat it as suitable for evaluation, prototypes, and controlled installations.
+> The criteria for general availability are tracked in
 > [#58](https://github.com/Byline-CMS/bylinecms.dev/issues/58).
 
 MySQL adapter for Byline CMS — Drizzle schema, migrations, and the storage /
@@ -198,12 +196,10 @@ databases, and a few divergences are real rather than papered over.
   are meaning-bearing in some scripts (a Thai tone mark, a Devanagari
   anusvara, Hebrew niqqud) are never silently folded together the way
   `ai_ci` would fold them.
-- **No search provider yet.** `@byline/search-postgres` has no MySQL
-  counterpart today — a collection's `search` config
-  (`CollectionDefinition.search`) requires a registered `SearchProvider`,
-  and none ships for MySQL yet. Track
-  [the `@byline/search-mysql` follow-up issue](https://github.com/Byline-CMS/bylinecms.dev/issues/52)
-  for status.
+- **Search uses a dialect-specific provider.** Register
+  `@byline/search-mysql` with this adapter. It implements the same portable
+  lexical and weighting contract as `@byline/search-postgres`, while owning its
+  own MySQL `FULLTEXT` schema and migrations.
 - **The connection string is the only connection input.** See "Usage"
   above — this is called out here too because it is the most common way
   this adapter is misconfigured by a reader coming from the Postgres
@@ -218,56 +214,33 @@ databases, and a few divergences are real rather than papered over.
 
 ## Search on MySQL
 
-There is no MySQL search provider yet, and the absence is load-bearing rather
-than cosmetic: `validateSearchConfig` runs inside `initBylineCore()` and
-**throws** when any collection declares a `search` block but no provider is
-registered. Byline's own reference application opts five collections into
-search, so a MySQL installation that copies it fails at boot with an error that
-does not mention MySQL at all.
-
-Until `@byline/search-mysql` exists, register a no-op provider. It satisfies
-validation, and indexing and querying become silent no-ops rather than errors —
-the admin Reindex action and any search page return nothing, which is the honest
-answer on this adapter today:
+Register `@byline/search-mysql` with the adapter's existing promise pool. Apply
+the provider's independent migration stream before serving traffic:
 
 ```ts
-const noopSearch = {
-  capabilities: {
-    facets: false,
-    typoTolerance: false,
-    semantic: false,
-    bm25: false,
-    weighting: false,
-    highlights: false,
-  },
-  async upsert() {},
-  async remove() {},
-  async search() {
-    return { hits: [], total: 0 }
-  },
-}
+import { migrate, mysqlSearch } from '@byline/search-mysql'
+
+await migrate(db.pool)
 
 await initBylineCore({
   // …
   db,
-  search: noopSearch,
+  search: mysqlSearch({ pool: db.pool, defaultLocale }),
 })
 ```
 
-The alternative — removing the `search` block from every collection definition —
-also works, but it discards configuration you will want back when a provider
-lands. The no-op keeps your collections declarative and confines the workaround
-to one place.
+Search rows are a disposable projection of published versions. The provider
+uses parser-safe portable terms, weighted MySQL `FULLTEXT` indexes, and analyzer
+fingerprints. Its package README documents migrations, capabilities, and the
+clear-and-rebuild procedure.
 
 ## Not yet shipped
 
-- **`@byline/search-mysql`** — see [Search on MySQL](#search-on-mysql) above.
-  Tracked in [issue #52](https://github.com/Byline-CMS/bylinecms.dev/issues/52).
 - **CLI support.** `byline init` scaffolds a Postgres installation. Adding MySQL
   to an existing project is a manual edit to `byline/server.config.ts` — swap
   `pgAdapter` for `mysqlAdapter`, swap the `@byline/db-postgres/admin` import for
-  `@byline/db-mysql/admin`, drop the `@byline/search-postgres` migrate call, and
-  register the no-op search provider above.
+  `@byline/db-mysql/admin`, and swap `postgresSearch` for `mysqlSearch`. Both
+  search packages expose the same `migrate(pool)` shape.
 - **A MySQL storage-benchmark target.** The design spec flags view
   materialisation (the `ROW_NUMBER()` window inside a derived table, used
   by both current-version views) as a question to answer before this

--- a/packages/search-conformance/src/suites/portable-analysis.ts
+++ b/packages/search-conformance/src/suites/portable-analysis.ts
@@ -85,6 +85,33 @@ export function portableAnalysisSuite(hooks: SearchConformanceHooks): void {
       ).resolves.toMatchObject({ total: 1 })
     })
 
+    it('preserves phrase adjacency across expansions and exact fallbacks', async () => {
+      const expander: SearchTokenExpander = {
+        fingerprint: 'search-conformance-phrase-english1',
+        supports: (locale) => locale.startsWith('en'),
+        expand: (token) =>
+          token.value === 'running' || token.value === 'runs'
+            ? [{ kind: 'stem', value: 'run' }]
+            : [],
+      }
+      provider = await createProvider(createPortableSearchAnalyzer({ expanders: [expander] }))
+      await provider.upsert(
+        searchDocument('running restoration', {
+          documentId: 'portable-expansion-phrase',
+        })
+      )
+
+      await expect(
+        provider.search({
+          query: '"runs restoration"',
+          collectionPath: 'search-conformance',
+        })
+      ).resolves.toMatchObject({
+        total: 1,
+        hits: [{ documentId: 'portable-expansion-phrase' }],
+      })
+    })
+
     it('ranks a heavier field above the same term in a lighter field', async () => {
       if (!provider.capabilities.weighting) return
       await provider.upsert(

--- a/packages/search-mysql/.env.test.example
+++ b/packages/search-mysql/.env.test.example
@@ -1,0 +1,4 @@
+# Copy this file to .env.test for the dedicated MySQL test database.
+# The database name must end in `_test`; the search conformance bootstrap
+# refuses any other target.
+BYLINE_DB_MYSQL_CONNECTION_STRING=mysql://byline:byline@127.0.0.1:3306/byline_test

--- a/packages/search-mysql/README.md
+++ b/packages/search-mysql/README.md
@@ -1,0 +1,109 @@
+# @byline/search-mysql
+
+The built-in MySQL full-text `SearchProvider` for Byline CMS. It combines the
+portable multilingual analyzer from `@byline/search-analysis` with weighted
+MySQL `FULLTEXT` indexes, providing ranked search with no additional service
+and reusing the existing MySQL connection pool.
+
+It stores one row per `(collection_path, document_id, locale)`. Searchable
+logical terms are encoded into parser-safe ASCII tokens before MySQL sees them,
+which preserves Byline's normalization, identifier, expansion, and Han-gram
+semantics without depending on server stopword lists or minimum token lengths.
+Four physical indexes retain the A–D field-weight classes used by the built-in
+PostgreSQL provider.
+
+See
+[`docs/05-reading-and-delivery/07-search.md`](../../docs/05-reading-and-delivery/07-search.md)
+for the full subsystem design.
+
+## Install
+
+```sh
+pnpm add @byline/search-mysql
+```
+
+`mysql2` is a peer dependency. An installation using `@byline/db-mysql`
+already has it.
+
+## Register
+
+The provider reuses the host's existing promise pool (`db.pool` from
+`mysqlAdapter`), so the index lives in the same database:
+
+```ts
+import { defineServerConfig } from '@byline/core'
+import { mysqlAdapter } from '@byline/db-mysql'
+import { mysqlSearch } from '@byline/search-mysql'
+
+const db = mysqlAdapter({ connectionString, collections, defaultContentLocale })
+
+defineServerConfig({
+  db,
+  search: mysqlSearch({ pool: db.pool }),
+  // …
+})
+```
+
+A collection opts into indexing through its `search` config
+(`{ body, facets, filters, zones }`). `initBylineCore()` fails fast if a
+collection opts in but no provider is registered.
+
+## Schema and migrations
+
+This driver owns a disposable search projection. Its numbered SQL files under
+[`migrations/`](./migrations) are independent of the host database adapter's
+Drizzle migrations and are tracked in `byline_search_migrations`.
+
+For production, apply pending migrations deliberately before serving traffic:
+
+```ts
+import { migrate } from '@byline/search-mysql'
+
+const { applied } = await migrate(db.pool, { log: (message) => logger.info(message) })
+```
+
+MySQL auto-commits DDL. The migrator therefore uses a server advisory lock,
+idempotent DDL, and records a version only after every statement succeeds.
+Migration files must contain ordinary semicolon-delimited statements, not
+stored routines with internal delimiters.
+
+For local development, `mysqlSearch({ pool: db.pool, autoMigrate: true })`
+starts migration in the background. Prefer an explicit awaited `migrate()`
+call whenever deterministic startup matters.
+
+There is no compatibility migration for earlier experimental schemas. Drop
+only the search-owned tables, apply `0001_init.sql`, and rebuild searchable
+collections from their published versions:
+
+```sql
+DROP TABLE IF EXISTS byline_search_index_metadata;
+DROP TABLE IF EXISTS byline_search_documents;
+DROP TABLE IF EXISTS byline_search_migrations;
+```
+
+## Capabilities
+
+The adapter supports portable analysis, `all` and `any` matching,
+minimum-should-match, phrase constraints, and field weighting. Facet data and
+typed filters are retained in JSON for future query features.
+
+Highlighting, facet aggregation, structured filtering, typo tolerance,
+semantic retrieval, and BM25 are currently reported as unsupported. MySQL's
+native relevance score contributes term frequency and inverse document
+frequency, but the provider does not claim BM25 because MySQL does not expose a
+stable BM25 contract.
+
+## Language and locale
+
+The portable analyzer applies Unicode normalization, ICU word segmentation,
+identifier preservation, optional language expanders, and Han bigrams before
+the adapter writes physical terms. `defaultLocale` supplies the fallback when
+content or a query does not declare a usable locale:
+
+```ts
+mysqlSearch({ pool: db.pool, defaultLocale: 'en' })
+```
+
+Custom analyzers must have stable, versioned fingerprints. The provider stores
+the fingerprint per collection and rejects mixed analysis pipelines. Clear and
+reindex an affected collection after changing its analyzer.

--- a/packages/search-mysql/migrations/0001_init.sql
+++ b/packages/search-mysql/migrations/0001_init.sql
@@ -1,0 +1,40 @@
+-- @byline/search-mysql — 0001_init
+--
+-- Disposable portable full-text index. One row per
+-- (collection_path, document_id, locale). Every searchable logical token is
+-- encoded by @byline/search-analysis before MySQL's parser sees it, avoiding
+-- language-specific stopword and minimum-token divergence.
+
+CREATE TABLE IF NOT EXISTS byline_search_documents (
+  collection_path      varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
+  document_id          varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
+  locale               varchar(35)  CHARACTER SET ascii   COLLATE ascii_bin   NOT NULL,
+  status               varchar(64)  CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
+  zones                json                                                   NOT NULL,
+  title                text CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci  NOT NULL,
+  path                 text CHARACTER SET utf8mb4 COLLATE utf8mb4_bin,
+  body                 longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL,
+  search_text          longtext CHARACTER SET ascii COLLATE ascii_bin         NOT NULL,
+  search_a             longtext CHARACTER SET ascii COLLATE ascii_bin         NOT NULL,
+  search_b             longtext CHARACTER SET ascii COLLATE ascii_bin         NOT NULL,
+  search_c             longtext CHARACTER SET ascii COLLATE ascii_bin         NOT NULL,
+  search_d             longtext CHARACTER SET ascii COLLATE ascii_bin         NOT NULL,
+  analyzer_fingerprint varchar(512) CHARACTER SET ascii COLLATE ascii_bin      NOT NULL,
+  facets               json                                                   NOT NULL,
+  filters              json                                                   NOT NULL,
+  updated_at           datetime(6)                                            NOT NULL,
+  PRIMARY KEY (collection_path, document_id, locale),
+  KEY byline_search_documents_collection_idx (collection_path, status),
+  FULLTEXT KEY byline_search_documents_text_idx (search_text),
+  FULLTEXT KEY byline_search_documents_a_idx (search_a),
+  FULLTEXT KEY byline_search_documents_b_idx (search_b),
+  FULLTEXT KEY byline_search_documents_c_idx (search_c),
+  FULLTEXT KEY byline_search_documents_d_idx (search_d)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS byline_search_index_metadata (
+  collection_path      varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
+  analyzer_fingerprint varchar(512) CHARACTER SET ascii COLLATE ascii_bin      NOT NULL,
+  updated_at           datetime(6)                                            NOT NULL,
+  PRIMARY KEY (collection_path)
+) ENGINE=InnoDB;

--- a/packages/search-mysql/package.json
+++ b/packages/search-mysql/package.json
@@ -1,0 +1,85 @@
+{
+  "name": "@byline/search-mysql",
+  "private": false,
+  "license": "MPL-2.0",
+  "version": "4.8.0",
+  "engines": {
+    "node": ">=20.9.0"
+  },
+  "description": "Byline CMS built-in MySQL full-text search provider",
+  "keywords": [
+    "cms",
+    "headless cms",
+    "content management",
+    "search",
+    "mysql",
+    "full-text search"
+  ],
+  "homepage": "https://github.com/Byline-CMS/bylinecms.dev",
+  "bugs": {
+    "url": "https://github.com/Byline-CMS/bylinecms.dev/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Byline-CMS/bylinecms.dev.git",
+    "directory": "packages/search-mysql"
+  },
+  "type": "module",
+  "main": "dist/index.js",
+  "index": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "dev": "chokidar 'src/**/*' -c 'npm-run-all build'",
+    "build": "tsc -p tsconfig.json && tsc-alias",
+    "clean": "node scripts/clean.js node_modules dist build .turbo",
+    "lint": "biome check --write --unsafe --diagnostic-level=error",
+    "test": "vitest run --mode=node",
+    "test:integration": "vitest run --mode=integration",
+    "test:watch": "vitest --mode=node",
+    "typecheck": "tsc --noEmit"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist",
+    "migrations"
+  ],
+  "dependencies": {
+    "@byline/core": "workspace:*",
+    "@byline/search-analysis": "workspace:*"
+  },
+  "peerDependencies": {
+    "mysql2": "^3.23.1"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "2.5.4",
+    "@byline/search-conformance": "workspace:*",
+    "@types/node": "^26.1.1",
+    "chokidar": "^5.0.0",
+    "chokidar-cli": "^3.0.0",
+    "dotenv": "^17.4.2",
+    "mysql2": "^3.23.1",
+    "npm-run-all": "^4.1.5",
+    "tsc-alias": "^1.9.1",
+    "tsx": "^4.23.1",
+    "typescript": "^7.0.2",
+    "vitest": "^4.1.10"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js",
+        "require": "./dist/index.js"
+      },
+      "./package.json": "./package.json"
+    }
+  }
+}

--- a/packages/search-mysql/scripts/clean.js
+++ b/packages/search-mysql/scripts/clean.js
@@ -1,0 +1,5 @@
+import { rmSync } from 'node:fs'
+
+for (const target of process.argv.slice(2)) {
+  rmSync(target, { recursive: true, force: true })
+}

--- a/packages/search-mysql/src/build-index-row.test.node.ts
+++ b/packages/search-mysql/src/build-index-row.test.node.ts
@@ -1,0 +1,67 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import type { SearchDocument } from '@byline/core'
+import { describe, expect, it } from 'vitest'
+
+import { buildIndexRow, weightClass } from './build-index-row.js'
+
+const base: SearchDocument = {
+  collectionPath: 'reports',
+  documentId: 'report-1',
+  locale: 'en',
+  status: 'published',
+  zones: ['library'],
+  title: 'Display title',
+  path: 'display-title',
+  updatedAt: '2026-07-26T00:00:00.000Z',
+  fields: [],
+}
+
+describe('weightClass', () => {
+  it('uses role defaults and maps boost magnitudes consistently', () => {
+    expect(weightClass(undefined, 'B')).toBe('B')
+    expect(weightClass(2, 'B')).toBe('A')
+    expect(weightClass(1, 'B')).toBe('B')
+    expect(weightClass(0.5, 'B')).toBe('C')
+    expect(weightClass(0.1, 'B')).toBe('D')
+  })
+})
+
+describe('buildIndexRow', () => {
+  it('projects weighted body, facet terms and ids, and typed filters', () => {
+    const row = buildIndexRow({
+      ...base,
+      fields: [
+        { name: 'title', type: 'text', role: 'body', value: 'Heavy title', boost: 2 },
+        { name: 'summary', type: 'text', role: 'body', value: 'Ordinary summary' },
+        {
+          name: 'topics',
+          type: 'facet',
+          role: 'facet',
+          value: [{ id: 12, term: 'Forestry' }],
+        },
+        { name: 'year', type: 'integer', role: 'filter', value: 2026 },
+      ],
+    })
+
+    expect(row.weighted).toEqual({
+      A: 'Heavy title',
+      B: 'Ordinary summary',
+      C: 'Forestry',
+      D: '',
+    })
+    expect(row.body).toBe('Heavy title\nOrdinary summary\nForestry')
+    expect(row.facets).toEqual({ topics: [{ id: 12, term: 'Forestry' }] })
+    expect(row.filters).toEqual({ year: 2026 })
+  })
+
+  it('keeps the display title out of search unless projected as body', () => {
+    expect(buildIndexRow(base).body).toBe('')
+  })
+})

--- a/packages/search-mysql/src/build-index-row.ts
+++ b/packages/search-mysql/src/build-index-row.ts
@@ -1,0 +1,109 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import type { SearchDocument, SearchFacetValue, SearchField } from '@byline/core'
+
+/** The four adapter-neutral relevance classes, A (highest) through D. */
+export type WeightClass = 'A' | 'B' | 'C' | 'D'
+
+/** Flat MySQL row input derived from one type-enriched search document. */
+export interface IndexRow {
+  collectionPath: string
+  documentId: string
+  locale: string
+  status: string
+  zones: string[]
+  title: string
+  path: string | null
+  body: string
+  weighted: Record<WeightClass, string>
+  facets: Record<string, SearchFacetValue[]>
+  filters: Record<string, string | number | boolean>
+  updatedAt: string
+}
+
+export function weightClass(boost: number | undefined, defaultClass: WeightClass): WeightClass {
+  if (boost == null) return defaultClass
+  if (boost >= 2) return 'A'
+  if (boost >= 1) return 'B'
+  if (boost >= 0.5) return 'C'
+  return 'D'
+}
+
+/**
+ * Project searchable values into the same A–D buckets used by the PostgreSQL
+ * and Solr adapters. Titles remain display-only unless explicitly included in
+ * the collection's body declaration.
+ */
+export function buildIndexRow(doc: SearchDocument): IndexRow {
+  const weighted: Record<WeightClass, string[]> = { A: [], B: [], C: [], D: [] }
+  const facets: Record<string, SearchFacetValue[]> = {}
+  const filters: Record<string, string | number | boolean> = {}
+
+  for (const field of doc.fields) {
+    switch (field.role) {
+      case 'body': {
+        const text = textValue(field.value)
+        if (text) weighted[weightClass(field.boost, 'B')].push(text)
+        break
+      }
+      case 'facet': {
+        const values = Array.isArray(field.value) ? (field.value as SearchFacetValue[]) : []
+        if (values.length > 0) {
+          facets[field.name] = values
+          const cls = weightClass(field.boost, 'C')
+          for (const value of values) {
+            if (value.term) weighted[cls].push(value.term)
+          }
+        }
+        break
+      }
+      case 'filter': {
+        if (
+          typeof field.value === 'string' ||
+          typeof field.value === 'number' ||
+          typeof field.value === 'boolean'
+        ) {
+          filters[field.name] = field.value
+        }
+        break
+      }
+    }
+  }
+
+  const join = (parts: string[]): string => parts.join('\n')
+  const weightedText: Record<WeightClass, string> = {
+    A: join(weighted.A),
+    B: join(weighted.B),
+    C: join(weighted.C),
+    D: join(weighted.D),
+  }
+
+  return {
+    collectionPath: doc.collectionPath,
+    documentId: doc.documentId,
+    locale: doc.locale,
+    status: doc.status,
+    zones: doc.zones,
+    title: doc.title,
+    path: doc.path,
+    body: [weightedText.A, weightedText.B, weightedText.C, weightedText.D]
+      .filter((text) => text.length > 0)
+      .join('\n'),
+    weighted: weightedText,
+    facets,
+    filters,
+    updatedAt: doc.updatedAt,
+  }
+}
+
+function textValue(value: SearchField['value']): string | null {
+  if (typeof value === 'string') return value.trim().length > 0 ? value : null
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  return null
+}

--- a/packages/search-mysql/src/errors.ts
+++ b/packages/search-mysql/src/errors.ts
@@ -1,0 +1,24 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+export class SearchAnalyzerMismatchError extends Error {
+  readonly code = 'SEARCH_INDEX_REINDEX_REQUIRED'
+
+  constructor(
+    readonly collectionPath: string,
+    readonly expectedFingerprint: string,
+    readonly actualFingerprint: string | null
+  ) {
+    super(
+      `Search index for collection "${collectionPath}" uses analyzer fingerprint ` +
+        `"${actualFingerprint ?? '(missing)'}", but "${expectedFingerprint}" is configured. ` +
+        'Clear and rebuild this collection before searching or indexing it.'
+    )
+    this.name = 'SearchAnalyzerMismatchError'
+  }
+}

--- a/packages/search-mysql/src/index.ts
+++ b/packages/search-mysql/src/index.ts
@@ -1,0 +1,48 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import type { SearchProvider } from '@byline/core'
+import { createPortableSearchAnalyzer, type PortableSearchAnalyzer } from '@byline/search-analysis'
+import type { Pool } from 'mysql2/promise'
+
+import { migrate } from './migrate.js'
+import { MySqlSearchProvider } from './mysql-search-provider.js'
+
+export { buildIndexRow, type IndexRow, type WeightClass, weightClass } from './build-index-row.js'
+export { SearchAnalyzerMismatchError } from './errors.js'
+export { type MigrateOptions, type MigrateResult, migrate } from './migrate.js'
+export { MySqlSearchProvider } from './mysql-search-provider.js'
+
+export interface MySqlSearchOptions {
+  /** The host's existing mysql2 promise pool, normally `db.pool`. */
+  pool: Pool
+  /** Development convenience; production should await `migrate(pool)`. */
+  autoMigrate?: boolean
+  /** Portable analyzer fallback locale. Defaults to `en`. */
+  defaultLocale?: string
+  /** Custom versioned portable analyzer. */
+  analyzer?: PortableSearchAnalyzer
+  /** Optional migration progress sink. */
+  log?: (message: string) => void
+}
+
+/** Construct the MySQL FULLTEXT provider while reusing the host pool. */
+export function mysqlSearch(options: MySqlSearchOptions): SearchProvider {
+  const analyzer =
+    options.analyzer ?? createPortableSearchAnalyzer({ defaultLocale: options.defaultLocale })
+
+  if (options.autoMigrate === true) {
+    void migrate(options.pool, { log: options.log }).catch((error) => {
+      const message = `[search-mysql] autoMigrate failed: ${(error as Error).message}`
+      if (options.log) options.log(message)
+      else console.error(message)
+    })
+  }
+
+  return new MySqlSearchProvider(options.pool, analyzer)
+}

--- a/packages/search-mysql/src/migrate.ts
+++ b/packages/search-mysql/src/migrate.ts
@@ -1,0 +1,96 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import type { Pool, RowDataPacket } from 'mysql2/promise'
+
+import { MIGRATIONS } from './migrations-data.js'
+
+const MIGRATION_LOCK = 'byline-search-mysql-migrations'
+
+export interface MigrateOptions {
+  log?: (message: string) => void
+}
+
+export interface MigrateResult {
+  applied: number[]
+}
+
+interface LockRow extends RowDataPacket {
+  acquired: number | null
+}
+
+interface VersionRow extends RowDataPacket {
+  version: number
+}
+
+/**
+ * Apply the driver-owned numbered migrations. MySQL DDL auto-commits, so an
+ * advisory lock plus idempotent statements serialize concurrent runners; the
+ * ledger row is written only after every statement in a migration succeeds.
+ */
+export async function migrate(pool: Pool, options: MigrateOptions = {}): Promise<MigrateResult> {
+  const connection = await pool.getConnection()
+  const log = options.log ?? (() => {})
+
+  try {
+    const [lockRows] = await connection.query<LockRow[]>('SELECT GET_LOCK(?, 30) AS acquired', [
+      MIGRATION_LOCK,
+    ])
+    if (lockRows[0]?.acquired !== 1) {
+      throw new Error('[search-mysql] timed out waiting for the migration lock')
+    }
+
+    await connection.query(`
+      CREATE TABLE IF NOT EXISTS byline_search_migrations (
+        version    int       NOT NULL,
+        applied_at datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+        PRIMARY KEY (version)
+      ) ENGINE=InnoDB
+    `)
+
+    const [rows] = await connection.query<VersionRow[]>(
+      'SELECT version FROM byline_search_migrations'
+    )
+    const done = new Set(rows.map((row) => Number(row.version)))
+    const applied: number[] = []
+
+    for (const migration of [...MIGRATIONS].sort((left, right) => left.version - right.version)) {
+      if (done.has(migration.version)) continue
+      try {
+        for (const statement of splitStatements(migration.sql)) {
+          await connection.query(statement)
+        }
+        await connection.query('INSERT INTO byline_search_migrations (version) VALUES (?)', [
+          migration.version,
+        ])
+        applied.push(migration.version)
+        log(`[search-mysql] applied migration ${migration.name}`)
+      } catch (error) {
+        throw new Error(
+          `[search-mysql] migration ${migration.name} failed: ${(error as Error).message}`,
+          { cause: error }
+        )
+      }
+    }
+
+    return { applied }
+  } finally {
+    try {
+      await connection.query('SELECT RELEASE_LOCK(?)', [MIGRATION_LOCK])
+    } finally {
+      connection.release()
+    }
+  }
+}
+
+function splitStatements(sql: string): string[] {
+  return sql
+    .split(';')
+    .map((statement) => statement.trim())
+    .filter((statement) => statement.length > 0)
+}

--- a/packages/search-mysql/src/migrations-data.test.node.ts
+++ b/packages/search-mysql/src/migrations-data.test.node.ts
@@ -1,0 +1,40 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import { readdirSync, readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+import { MIGRATIONS } from './migrations-data.js'
+
+const migrationsDir = join(dirname(fileURLToPath(import.meta.url)), '../migrations')
+
+describe('embedded migrations vs the .sql files', () => {
+  const sqlFiles = readdirSync(migrationsDir)
+    .filter((file) => file.endsWith('.sql'))
+    .sort()
+
+  it('embeds exactly the .sql files that ship in the package', () => {
+    expect(MIGRATIONS.map((migration) => migration.name).sort()).toEqual(sqlFiles)
+  })
+
+  it.each(sqlFiles)('embedded SQL for %s matches the file on disk', (name) => {
+    const onDisk = readFileSync(join(migrationsDir, name), 'utf8')
+    const embedded = MIGRATIONS.find((migration) => migration.name === name)
+    expect(embedded, `no embedded migration named ${name}`).toBeDefined()
+    expect(embedded?.sql.trim()).toBe(onDisk.trim())
+  })
+
+  it('numbers each migration from its filename prefix', () => {
+    for (const migration of MIGRATIONS) {
+      expect(migration.version).toBe(Number.parseInt(migration.name.split('_')[0] ?? '', 10))
+    }
+  })
+})

--- a/packages/search-mysql/src/migrations-data.ts
+++ b/packages/search-mysql/src/migrations-data.ts
@@ -1,0 +1,61 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+export interface EmbeddedMigration {
+  version: number
+  name: string
+  sql: string
+}
+
+export const MIGRATIONS: EmbeddedMigration[] = [
+  {
+    version: 1,
+    name: '0001_init.sql',
+    sql: `-- @byline/search-mysql — 0001_init
+--
+-- Disposable portable full-text index. One row per
+-- (collection_path, document_id, locale). Every searchable logical token is
+-- encoded by @byline/search-analysis before MySQL's parser sees it, avoiding
+-- language-specific stopword and minimum-token divergence.
+
+CREATE TABLE IF NOT EXISTS byline_search_documents (
+  collection_path      varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
+  document_id          varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
+  locale               varchar(35)  CHARACTER SET ascii   COLLATE ascii_bin   NOT NULL,
+  status               varchar(64)  CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
+  zones                json                                                   NOT NULL,
+  title                text CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci  NOT NULL,
+  path                 text CHARACTER SET utf8mb4 COLLATE utf8mb4_bin,
+  body                 longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL,
+  search_text          longtext CHARACTER SET ascii COLLATE ascii_bin         NOT NULL,
+  search_a             longtext CHARACTER SET ascii COLLATE ascii_bin         NOT NULL,
+  search_b             longtext CHARACTER SET ascii COLLATE ascii_bin         NOT NULL,
+  search_c             longtext CHARACTER SET ascii COLLATE ascii_bin         NOT NULL,
+  search_d             longtext CHARACTER SET ascii COLLATE ascii_bin         NOT NULL,
+  analyzer_fingerprint varchar(512) CHARACTER SET ascii COLLATE ascii_bin      NOT NULL,
+  facets               json                                                   NOT NULL,
+  filters              json                                                   NOT NULL,
+  updated_at           datetime(6)                                            NOT NULL,
+  PRIMARY KEY (collection_path, document_id, locale),
+  KEY byline_search_documents_collection_idx (collection_path, status),
+  FULLTEXT KEY byline_search_documents_text_idx (search_text),
+  FULLTEXT KEY byline_search_documents_a_idx (search_a),
+  FULLTEXT KEY byline_search_documents_b_idx (search_b),
+  FULLTEXT KEY byline_search_documents_c_idx (search_c),
+  FULLTEXT KEY byline_search_documents_d_idx (search_d)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS byline_search_index_metadata (
+  collection_path      varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
+  analyzer_fingerprint varchar(512) CHARACTER SET ascii COLLATE ascii_bin      NOT NULL,
+  updated_at           datetime(6)                                            NOT NULL,
+  PRIMARY KEY (collection_path)
+) ENGINE=InnoDB;
+`,
+  },
+]

--- a/packages/search-mysql/src/mysql-search-provider.ts
+++ b/packages/search-mysql/src/mysql-search-provider.ts
@@ -1,0 +1,362 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import type {
+  SearchCapabilities,
+  SearchDocument,
+  SearchHit,
+  SearchProvider,
+  SearchQuery,
+  SearchResults,
+} from '@byline/core'
+import type { PortableSearchAnalyzer } from '@byline/search-analysis'
+import type { Pool, PoolConnection, ResultSetHeader, RowDataPacket } from 'mysql2/promise'
+
+import { buildIndexRow, type IndexRow } from './build-index-row.js'
+import { SearchAnalyzerMismatchError } from './errors.js'
+import { buildPortableMySqlIndexDocument } from './portable-index-document.js'
+import { buildPortableMySqlQuery, type PortableMySqlQuery } from './portable-query.js'
+
+const CAPABILITIES: SearchCapabilities = {
+  facets: false,
+  typoTolerance: false,
+  semantic: false,
+  bm25: false,
+  weighting: true,
+  highlights: false,
+  lexical: {
+    nativeAnalysis: false,
+    portableAnalysis: true,
+    allTerms: true,
+    anyTerms: true,
+    minimumShouldMatch: true,
+    phrase: true,
+  },
+}
+
+/** MySQL FULLTEXT implementation over portable parser-safe logical tokens. */
+export class MySqlSearchProvider implements SearchProvider {
+  readonly capabilities = CAPABILITIES
+
+  constructor(
+    private readonly pool: Pool,
+    private readonly analyzer: PortableSearchAnalyzer
+  ) {}
+
+  async upsert(doc: SearchDocument): Promise<void> {
+    const row = buildIndexRow(doc)
+    const indexDocument = buildPortableMySqlIndexDocument(row, this.analyzer)
+    const connection = await this.pool.getConnection()
+
+    try {
+      await connection.beginTransaction()
+      await connection.query(
+        `INSERT INTO byline_search_index_metadata
+           (collection_path, analyzer_fingerprint, updated_at)
+         VALUES (?, ?, UTC_TIMESTAMP(6))
+         ON DUPLICATE KEY UPDATE collection_path = collection_path`,
+        [row.collectionPath, indexDocument.analyzerFingerprint]
+      )
+      const [metadata] = await connection.query<FingerprintRow[]>(
+        `SELECT analyzer_fingerprint
+         FROM byline_search_index_metadata
+         WHERE collection_path = ?
+         FOR UPDATE`,
+        [row.collectionPath]
+      )
+      const actualFingerprint = metadata[0]?.analyzer_fingerprint ?? null
+      if (actualFingerprint !== indexDocument.analyzerFingerprint) {
+        throw new SearchAnalyzerMismatchError(
+          row.collectionPath,
+          indexDocument.analyzerFingerprint,
+          actualFingerprint
+        )
+      }
+
+      await connection.query<ResultSetHeader>(UPSERT_SQL, upsertParams(row, indexDocument))
+      await connection.commit()
+    } catch (error) {
+      await rollback(connection)
+      throw error
+    } finally {
+      connection.release()
+    }
+  }
+
+  async remove(ref: {
+    collectionPath: string
+    documentId: string
+    locale?: string
+  }): Promise<void> {
+    if (ref.locale != null) {
+      await this.pool.query(
+        `DELETE FROM byline_search_documents
+         WHERE collection_path = ? AND document_id = ? AND locale = ?`,
+        [ref.collectionPath, ref.documentId, ref.locale]
+      )
+    } else {
+      await this.pool.query(
+        `DELETE FROM byline_search_documents
+         WHERE collection_path = ? AND document_id = ?`,
+        [ref.collectionPath, ref.documentId]
+      )
+    }
+  }
+
+  async reindex(opts: { collectionPath?: string } = {}): Promise<void> {
+    const connection = await this.pool.getConnection()
+    try {
+      await connection.beginTransaction()
+      if (opts.collectionPath != null) {
+        await connection.query('DELETE FROM byline_search_documents WHERE collection_path = ?', [
+          opts.collectionPath,
+        ])
+        await connection.query(
+          'DELETE FROM byline_search_index_metadata WHERE collection_path = ?',
+          [opts.collectionPath]
+        )
+      } else {
+        await connection.query('DELETE FROM byline_search_documents')
+        await connection.query('DELETE FROM byline_search_index_metadata')
+      }
+      await connection.commit()
+    } catch (error) {
+      await rollback(connection)
+      throw error
+    } finally {
+      connection.release()
+    }
+  }
+
+  async search(query: SearchQuery): Promise<SearchResults> {
+    const plan = this.analyzer.analyzeQuery({
+      query: query.query,
+      locale: query.locale,
+      matching: query.matching,
+    })
+    const translated = buildPortableMySqlQuery(plan)
+    if (translated.rankingQuery.length === 0) return { hits: [], total: 0 }
+
+    await this.assertAnalyzerFingerprint(query)
+
+    const lexical = buildLexicalPredicate(translated)
+    const where = [lexical.sql]
+    const whereParams: unknown[] = [...lexical.params]
+    appendScopeFilters(query, whereParams, where, true)
+    const whereSql = where.join(' AND ')
+
+    const [countRows] = await this.pool.query<TotalRow[]>(
+      `SELECT COUNT(*) AS total
+       FROM byline_search_documents d
+       WHERE ${whereSql}`,
+      whereParams
+    )
+    const total = Number(countRows[0]?.total ?? 0)
+
+    const scoreSql = [
+      '8 * MATCH(d.search_a) AGAINST (? IN BOOLEAN MODE)',
+      '4 * MATCH(d.search_b) AGAINST (? IN BOOLEAN MODE)',
+      '2 * MATCH(d.search_c) AGAINST (? IN BOOLEAN MODE)',
+      '1 * MATCH(d.search_d) AGAINST (? IN BOOLEAN MODE)',
+    ].join(' + ')
+    const limit = query.limit ?? 20
+    const offset = query.offset ?? 0
+    const [hitRows] = await this.pool.query<HitRow[]>(
+      `SELECT d.collection_path, d.document_id, d.locale, d.title, d.path,
+              (${scoreSql}) AS score
+       FROM byline_search_documents d
+       WHERE ${whereSql}
+       ORDER BY score DESC, d.updated_at DESC,
+                d.collection_path, d.document_id, d.locale
+       LIMIT ? OFFSET ?`,
+      [
+        translated.rankingQuery,
+        translated.rankingQuery,
+        translated.rankingQuery,
+        translated.rankingQuery,
+        ...whereParams,
+        limit,
+        offset,
+      ]
+    )
+
+    const hits: SearchHit[] = hitRows.map((row) => ({
+      collectionPath: row.collection_path,
+      documentId: row.document_id,
+      locale: row.locale,
+      title: row.title,
+      path: row.path,
+      score: Number(row.score),
+    }))
+    return { hits, total }
+  }
+
+  private async assertAnalyzerFingerprint(query: SearchQuery): Promise<void> {
+    const params: unknown[] = [this.analyzer.fingerprint]
+    const where = ['d.analyzer_fingerprint <> ?']
+    appendScopeFilters(query, params, where, false)
+
+    const [rows] = await this.pool.query<IncompatibleRow[]>(
+      `SELECT d.collection_path, d.analyzer_fingerprint
+       FROM byline_search_documents d
+       WHERE ${where.join(' AND ')}
+       LIMIT 1`,
+      params
+    )
+    const row = rows[0]
+    if (row != null) {
+      throw new SearchAnalyzerMismatchError(
+        row.collection_path,
+        this.analyzer.fingerprint,
+        row.analyzer_fingerprint
+      )
+    }
+  }
+}
+
+interface FingerprintRow extends RowDataPacket {
+  analyzer_fingerprint: string
+}
+
+interface IncompatibleRow extends FingerprintRow {
+  collection_path: string
+}
+
+interface TotalRow extends RowDataPacket {
+  total: number | string
+}
+
+interface HitRow extends RowDataPacket {
+  collection_path: string
+  document_id: string
+  locale: string
+  title: string
+  path: string | null
+  score: number | string
+}
+
+interface PortableIndexValues {
+  searchText: string
+  weighted: Record<'A' | 'B' | 'C' | 'D', string>
+  analyzerFingerprint: string
+}
+
+function upsertParams(row: IndexRow, indexDocument: PortableIndexValues): unknown[] {
+  const updatedAt = new Date(row.updatedAt)
+  if (Number.isNaN(updatedAt.valueOf())) {
+    throw new TypeError(`Search document updatedAt is invalid: ${row.updatedAt}`)
+  }
+
+  return [
+    row.collectionPath,
+    row.documentId,
+    row.locale,
+    row.status,
+    JSON.stringify(row.zones),
+    row.title,
+    row.path,
+    row.body,
+    indexDocument.searchText,
+    indexDocument.weighted.A,
+    indexDocument.weighted.B,
+    indexDocument.weighted.C,
+    indexDocument.weighted.D,
+    indexDocument.analyzerFingerprint,
+    JSON.stringify(row.facets),
+    JSON.stringify(row.filters),
+    updatedAt,
+  ]
+}
+
+function buildLexicalPredicate(query: PortableMySqlQuery): {
+  sql: string
+  params: (string | number)[]
+} {
+  const params: (string | number)[] = []
+  const match = (value: string): string => {
+    params.push(value)
+    return 'MATCH(d.search_text) AGAINST (? IN BOOLEAN MODE) > 0'
+  }
+
+  const concepts = query.conceptQueries.map(match)
+  let conceptSql: string
+  if (query.minimumShouldMatch != null) {
+    params.push(query.minimumShouldMatch)
+    conceptSql = `(${concepts.map((sql) => `IF(${sql}, 1, 0)`).join(' + ')}) >= ?`
+  } else {
+    const operator = query.operator === 'all' ? ' AND ' : ' OR '
+    conceptSql = `(${concepts.join(operator)})`
+  }
+
+  if (query.gramQueries.length > 0) {
+    conceptSql = `(${conceptSql} OR ${query.gramQueries.map(match).join(' OR ')})`
+  }
+
+  const clauses = [conceptSql]
+  for (const phraseAlternatives of query.phraseQueries) {
+    if (phraseAlternatives.length === 0) {
+      clauses.push('(FALSE)')
+      continue
+    }
+    clauses.push(`(${phraseAlternatives.map(match).join(' OR ')})`)
+  }
+  return { sql: clauses.join(' AND '), params }
+}
+
+function appendScopeFilters(
+  query: SearchQuery,
+  params: unknown[],
+  where: string[],
+  includeStatus: boolean
+): void {
+  if (query.collectionPath != null) {
+    params.push(query.collectionPath)
+    where.push('d.collection_path = ?')
+  }
+  if (query.zone != null) {
+    params.push(query.zone)
+    where.push("JSON_CONTAINS(d.zones, JSON_QUOTE(?), '$') = 1")
+  }
+  if (query.locale != null) {
+    params.push(query.locale)
+    where.push('d.locale = ?')
+  }
+  if (includeStatus && query.status !== 'any') {
+    params.push('published')
+    where.push('d.status = ?')
+  }
+}
+
+async function rollback(connection: PoolConnection): Promise<void> {
+  try {
+    await connection.rollback()
+  } catch {
+    // Preserve the original operation error.
+  }
+}
+
+const UPSERT_SQL = `INSERT INTO byline_search_documents
+  (collection_path, document_id, locale, status, zones, title, path, body,
+   search_text, search_a, search_b, search_c, search_d, analyzer_fingerprint,
+   facets, filters, updated_at)
+ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ ON DUPLICATE KEY UPDATE
+   status = VALUES(status),
+   zones = VALUES(zones),
+   title = VALUES(title),
+   path = VALUES(path),
+   body = VALUES(body),
+   search_text = VALUES(search_text),
+   search_a = VALUES(search_a),
+   search_b = VALUES(search_b),
+   search_c = VALUES(search_c),
+   search_d = VALUES(search_d),
+   analyzer_fingerprint = VALUES(analyzer_fingerprint),
+   facets = VALUES(facets),
+   filters = VALUES(filters),
+   updated_at = VALUES(updated_at)`

--- a/packages/search-mysql/src/portable-index-document.test.node.ts
+++ b/packages/search-mysql/src/portable-index-document.test.node.ts
@@ -1,0 +1,83 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import {
+  createPortableSearchAnalyzer,
+  encodeSqlToken,
+  type SearchTokenExpander,
+} from '@byline/search-analysis'
+import { describe, expect, it } from 'vitest'
+
+import { buildPortableMySqlIndexDocument } from './portable-index-document.js'
+import type { IndexRow } from './build-index-row.js'
+
+const expander: SearchTokenExpander = {
+  fingerprint: 'english-test1',
+  supports: (locale) => locale.startsWith('en'),
+  expand: (token) => (token.value === 'running' ? [{ kind: 'stem', value: 'run' }] : []),
+}
+
+function row(overrides: Partial<IndexRow> = {}): IndexRow {
+  return {
+    collectionPath: 'reports',
+    documentId: 'report-1',
+    locale: 'en',
+    status: 'published',
+    zones: ['library'],
+    title: 'Running database',
+    path: 'running-database',
+    body: 'Running 数据库',
+    weighted: { A: 'Running 数据库', B: '', C: '', D: '' },
+    facets: {},
+    filters: {},
+    updatedAt: '2026-07-26T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+describe('buildPortableMySqlIndexDocument', () => {
+  it('keeps exact terms at source weight and lowers derived variants', () => {
+    const analyzer = createPortableSearchAnalyzer({ expanders: [expander] })
+    const document = buildPortableMySqlIndexDocument(row(), analyzer)
+    const exact = encodeSqlToken({ kind: 'exact', value: 'running' })
+    const stem = encodeSqlToken({ kind: 'stem', value: 'run' })
+
+    expect(document.weighted.A).toContain(exact)
+    expect(document.weighted.A).not.toContain(stem)
+    expect(document.weighted.B).toContain(stem)
+    expect(document.analyzerFingerprint).toBe(analyzer.fingerprint)
+  })
+
+  it('always assigns Han grams to the lightest weight class', () => {
+    const document = buildPortableMySqlIndexDocument(row(), createPortableSearchAnalyzer())
+
+    expect(document.weighted.D).toContain(encodeSqlToken({ kind: 'gram', value: '数据' }))
+    expect(document.weighted.D).toContain(encodeSqlToken({ kind: 'gram', value: '据库' }))
+  })
+
+  it('inserts unsearchable boundaries between independent streams', () => {
+    const document = buildPortableMySqlIndexDocument(
+      row({ weighted: { A: 'alpha', B: 'beta', C: '', D: '' } }),
+      createPortableSearchAnalyzer()
+    )
+
+    expect(document.searchText).toContain('bylinefulltextboundary')
+  })
+
+  it('uses exact fallbacks beside derived terms in matching streams', () => {
+    const analyzer = createPortableSearchAnalyzer({ expanders: [expander] })
+    const document = buildPortableMySqlIndexDocument(
+      row({ weighted: { A: 'running restoration', B: '', C: '', D: '' } }),
+      analyzer
+    )
+    const stem = encodeSqlToken({ kind: 'stem', value: 'run' })
+    const exactNeighbor = encodeSqlToken({ kind: 'exact', value: 'restoration' })
+
+    expect(document.searchText).toContain(`${stem} ${exactNeighbor}`)
+  })
+})

--- a/packages/search-mysql/src/portable-index-document.ts
+++ b/packages/search-mysql/src/portable-index-document.ts
@@ -1,0 +1,149 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import {
+  encodeSqlToken,
+  type LogicalToken,
+  type PortableSearchAnalyzer,
+} from '@byline/search-analysis'
+
+import type { IndexRow, WeightClass } from './build-index-row.js'
+
+const WEIGHT_CLASSES: readonly WeightClass[] = ['A', 'B', 'C', 'D']
+const STREAM_BOUNDARY = 'bylinefulltextboundary'
+
+export interface PortableMySqlIndexDocument {
+  searchText: string
+  weighted: Record<WeightClass, string>
+  analyzerFingerprint: string
+}
+
+/**
+ * Encode portable logical terms into text streams consumed by MySQL FULLTEXT.
+ * Separate exact, expansion-kind, and Han-gram streams preserve adjacency for
+ * phrase matching without letting phrases cross weight classes or token
+ * streams.
+ */
+export function buildPortableMySqlIndexDocument(
+  row: Pick<IndexRow, 'locale' | 'weighted'>,
+  analyzer: PortableSearchAnalyzer
+): PortableMySqlIndexDocument {
+  const matchingStreams: string[] = []
+  const tokensByWeight: Record<WeightClass, LogicalToken[]> = {
+    A: [],
+    B: [],
+    C: [],
+    D: [],
+  }
+
+  for (const sourceWeight of WEIGHT_CLASSES) {
+    const analyzed = analyzer.analyzeText({
+      text: row.weighted[sourceWeight],
+      locale: row.locale,
+    })
+    matchingStreams.push(...serializeMatchingStreams(analyzed.tokens))
+    for (const token of analyzed.tokens) {
+      tokensByWeight[tokenWeight(token, sourceWeight)].push(token)
+    }
+  }
+
+  const weighted: Record<WeightClass, string> = {
+    A: serializeStreams(tokensByWeight.A),
+    B: serializeStreams(tokensByWeight.B),
+    C: serializeStreams(tokensByWeight.C),
+    D: serializeStreams(tokensByWeight.D),
+  }
+
+  return {
+    searchText: matchingStreams.join(` ${STREAM_BOUNDARY} `),
+    weighted,
+    analyzerFingerprint: analyzer.fingerprint,
+  }
+}
+
+function tokenWeight(token: LogicalToken, sourceWeight: WeightClass): WeightClass {
+  if (token.kind === 'gram') return 'D'
+  if (token.kind === 'exact' || token.kind === 'identifier') return sourceWeight
+  return lowerWeight(sourceWeight)
+}
+
+function lowerWeight(weight: WeightClass): WeightClass {
+  switch (weight) {
+    case 'A':
+      return 'B'
+    case 'B':
+      return 'C'
+    case 'C':
+    case 'D':
+      return 'D'
+  }
+}
+
+function serializeStreams(tokens: readonly LogicalToken[]): string {
+  const streams: LogicalToken[][] = []
+  const source = tokens
+    .filter((token) => token.kind === 'exact' || token.kind === 'identifier')
+    .toSorted(compareTokens)
+  if (source.length > 0) streams.push(source)
+
+  for (const kind of ['stem', 'lemma', 'normalized'] as const) {
+    const derived = tokens.filter((token) => token.kind === kind).toSorted(compareTokens)
+    if (derived.length > 0) streams.push(derived)
+  }
+
+  const grams = tokens.filter((token) => token.kind === 'gram').toSorted(compareTokens)
+  if (grams.length > 0) streams.push(grams)
+
+  return streams
+    .map((stream) => stream.map((token) => encodeSqlToken(token)).join(' '))
+    .join(` ${STREAM_BOUNDARY} `)
+}
+
+/**
+ * Preserve source-token adjacency for matching while making each expansion
+ * kind phrase-capable. A derived stream falls back to the exact/identifier
+ * token at positions where that kind produced no alternative, so a query such
+ * as `"runs restoration"` can match indexed `"running restoration"` through
+ * the stem `run` without losing the unchanged neighboring term.
+ */
+function serializeMatchingStreams(tokens: readonly LogicalToken[]): string[] {
+  const source = tokens
+    .filter((token) => token.kind === 'exact' || token.kind === 'identifier')
+    .toSorted(compareTokens)
+  const streams = source.length > 0 ? [serializeTokenStream(source)] : []
+
+  for (const kind of ['stem', 'lemma', 'normalized'] as const) {
+    const derived = tokens.filter((token) => token.kind === kind)
+    if (derived.length === 0) continue
+
+    const firstByPosition = new Map<number, LogicalToken>()
+    for (const token of derived.toSorted(compareTokens)) {
+      if (!firstByPosition.has(token.position)) firstByPosition.set(token.position, token)
+    }
+    streams.push(
+      serializeTokenStream(source.map((token) => firstByPosition.get(token.position) ?? token))
+    )
+  }
+
+  const grams = tokens.filter((token) => token.kind === 'gram').toSorted(compareTokens)
+  if (grams.length > 0) streams.push(serializeTokenStream(grams))
+  return streams.filter((stream) => stream.length > 0)
+}
+
+function serializeTokenStream(tokens: readonly LogicalToken[]): string {
+  return tokens.map((token) => encodeSqlToken(token)).join(' ')
+}
+
+function compareTokens(left: LogicalToken, right: LogicalToken): number {
+  return (
+    left.position - right.position ||
+    left.normalizedStart - right.normalizedStart ||
+    left.normalizedEnd - right.normalizedEnd ||
+    left.value.localeCompare(right.value)
+  )
+}

--- a/packages/search-mysql/src/portable-query.test.node.ts
+++ b/packages/search-mysql/src/portable-query.test.node.ts
@@ -1,0 +1,64 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import {
+  createPortableSearchAnalyzer,
+  encodeSqlToken,
+  type SearchTokenExpander,
+} from '@byline/search-analysis'
+import { describe, expect, it } from 'vitest'
+
+import { buildPortableMySqlQuery } from './portable-query.js'
+
+const expander: SearchTokenExpander = {
+  fingerprint: 'english-test1',
+  supports: (locale) => locale.startsWith('en'),
+  expand: (token) => (token.value === 'running' ? [{ kind: 'stem', value: 'run' }] : []),
+}
+
+describe('buildPortableMySqlQuery', () => {
+  it('keeps alternatives grouped by source concept', () => {
+    const analyzer = createPortableSearchAnalyzer({ expanders: [expander] })
+    const translated = buildPortableMySqlQuery(
+      analyzer.analyzeQuery({ query: 'running restoration', locale: 'en' })
+    )
+
+    expect(translated.conceptQueries).toHaveLength(2)
+    expect(translated.conceptQueries[0]).toContain(
+      encodeSqlToken({ kind: 'exact', value: 'running' })
+    )
+    expect(translated.conceptQueries[0]).toContain(encodeSqlToken({ kind: 'stem', value: 'run' }))
+    expect(translated.operator).toBe('all')
+  })
+
+  it('preserves phrase order and minimum-should-match intent', () => {
+    const translated = buildPortableMySqlQuery(
+      createPortableSearchAnalyzer().analyzeQuery({
+        query: '"forest restoration" database',
+        matching: { operator: 'any', minimumShouldMatch: 2 },
+      })
+    )
+
+    expect(translated.conceptQueries).toHaveLength(3)
+    expect(translated.phraseQueries[0]?.[0]).toMatch(/^"[a-z0-9]+ [a-z0-9]+"$/)
+    expect(translated.minimumShouldMatch).toBe(2)
+  })
+
+  it('returns an empty ranking query for punctuation-only input', () => {
+    const translated = buildPortableMySqlQuery(
+      createPortableSearchAnalyzer().analyzeQuery({ query: '— -- !!!' })
+    )
+
+    expect(translated).toMatchObject({
+      conceptQueries: [],
+      phraseQueries: [],
+      gramQueries: [],
+      rankingQuery: '',
+    })
+  })
+})

--- a/packages/search-mysql/src/portable-query.ts
+++ b/packages/search-mysql/src/portable-query.ts
@@ -1,0 +1,113 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import {
+  encodeSqlToken,
+  type LogicalToken,
+  type PortableQueryPlan,
+  type QueryConcept,
+} from '@byline/search-analysis'
+
+const MAX_PHRASE_VARIANTS = 256
+
+export interface PortableMySqlQuery {
+  /** Boolean-mode query per source concept; terms inside one query are ORs. */
+  conceptQueries: string[]
+  /** Alternative quoted Boolean-mode queries for each required phrase. */
+  phraseQueries: string[][]
+  /** Ordered Han-gram fallback phrases. */
+  gramQueries: string[]
+  /** Flat optional-term query used only for weighted relevance scoring. */
+  rankingQuery: string
+  operator: 'all' | 'any'
+  minimumShouldMatch?: number
+}
+
+/** Translate a portable plan into parser-safe MySQL Boolean-mode inputs. */
+export function buildPortableMySqlQuery(plan: PortableQueryPlan): PortableMySqlQuery {
+  const conceptTerms = plan.concepts.map(conceptAlternatives)
+  if (conceptTerms.some((terms) => terms.length === 0)) {
+    throw new TypeError('Portable query plan contains a concept with no searchable terms')
+  }
+
+  const phraseQueries = plan.phrases.map((phrase) => {
+    const alternatives = phrase.conceptIndexes.map((index) => conceptTerms[index])
+    if (alternatives.some((terms) => terms == null || terms.length === 0)) {
+      throw new RangeError('Portable query phrase references an unknown concept')
+    }
+    return phraseVariants(alternatives as string[][])
+  })
+
+  const gramQueries = plan.gramSequences
+    .map((sequence) => quotedPhrase(orderedTerms(sequence)))
+    .filter((query) => query.length > 0)
+  const rankingQuery = [
+    ...conceptTerms.flat(),
+    ...plan.gramSequences.flatMap((sequence) => orderedTerms(sequence)),
+  ]
+    .filter((term, index, terms) => terms.indexOf(term) === index)
+    .join(' ')
+
+  return {
+    conceptQueries: conceptTerms.map((terms) => terms.join(' ')),
+    phraseQueries,
+    gramQueries,
+    rankingQuery,
+    operator: plan.matching.operator,
+    ...(plan.matching.minimumShouldMatch != null
+      ? { minimumShouldMatch: plan.matching.minimumShouldMatch }
+      : {}),
+  }
+}
+
+function conceptAlternatives(concept: QueryConcept): string[] {
+  const terms = [
+    ...concept.exactTokens,
+    ...concept.stemTokens,
+    ...concept.lemmaTokens,
+    ...concept.normalizedTokens,
+    ...concept.identifierTokens,
+  ].map((token) => encodeSqlToken(token))
+
+  const gramPhrase = quotedPhrase(orderedTerms(concept.gramTokens))
+  if (gramPhrase.length > 0) terms.push(gramPhrase)
+  return [...new Set(terms)]
+}
+
+function phraseVariants(alternatives: string[][]): string[] {
+  let variants: string[][] = [[]]
+  for (const terms of alternatives) {
+    const next: string[][] = []
+    for (const prefix of variants) {
+      for (const term of terms) {
+        // A concept-local gram fallback is itself quoted and cannot be nested
+        // into a larger MySQL phrase. Cross-concept grams are represented by
+        // `gramQueries` instead.
+        if (term.startsWith('"')) continue
+        next.push([...prefix, term])
+        if (next.length >= MAX_PHRASE_VARIANTS) break
+      }
+      if (next.length >= MAX_PHRASE_VARIANTS) break
+    }
+    variants = next
+  }
+  return variants.map(quotedPhrase).filter((query) => query.length > 0)
+}
+
+function orderedTerms(tokens: readonly LogicalToken[]): string[] {
+  return tokens
+    .toSorted(
+      (left, right) =>
+        left.normalizedStart - right.normalizedStart || left.normalizedEnd - right.normalizedEnd
+    )
+    .map((token) => encodeSqlToken(token))
+}
+
+function quotedPhrase(terms: readonly string[]): string {
+  return terms.length > 0 ? `"${terms.join(' ')}"` : ''
+}

--- a/packages/search-mysql/tests/conformance.integration.test.ts
+++ b/packages/search-mysql/tests/conformance.integration.test.ts
@@ -1,0 +1,65 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import type { PortableSearchAnalyzer } from '@byline/search-analysis'
+import { runSearchProviderConformanceSuite } from '@byline/search-conformance'
+import mysql from 'mysql2/promise'
+
+import { migrate, mysqlSearch } from '../src/index.js'
+
+const connectionString = assertTestDatabase(process.env.BYLINE_DB_MYSQL_CONNECTION_STRING)
+const pool = mysql.createPool({
+  uri: connectionString,
+  connectionLimit: 4,
+  timezone: 'Z',
+  decimalNumbers: false,
+  charset: 'UTF8MB4_0900_AI_CI',
+})
+
+runSearchProviderConformanceSuite({
+  createProvider: () => mysqlSearch({ pool, defaultLocale: 'en' }),
+  createPortableProvider: (analyzer: PortableSearchAnalyzer) => mysqlSearch({ pool, analyzer }),
+
+  async migrate(): Promise<void> {
+    await migrate(pool)
+  },
+
+  async reset(): Promise<void> {
+    await pool.query('DELETE FROM byline_search_documents')
+    await pool.query('DELETE FROM byline_search_index_metadata')
+  },
+
+  async teardown(): Promise<void> {
+    await pool.end()
+  },
+})
+
+function assertTestDatabase(value: string | undefined): string {
+  if (value == null) {
+    throw new Error(
+      'BYLINE_DB_MYSQL_CONNECTION_STRING is not set. Create packages/search-mysql/.env.test.'
+    )
+  }
+
+  let databaseName: string
+  try {
+    databaseName = new URL(value).pathname.replace(/^\//, '')
+  } catch (error) {
+    throw new Error(
+      `BYLINE_DB_MYSQL_CONNECTION_STRING is not a valid URL: ${(error as Error).message}`
+    )
+  }
+
+  if (!databaseName.endsWith('_test')) {
+    throw new Error(
+      `Refusing search conformance tests against database "${databaseName}". ` +
+        'The database name must end in "_test".'
+    )
+  }
+  return value
+}

--- a/packages/search-mysql/tests/setup.integration.ts
+++ b/packages/search-mysql/tests/setup.integration.ts
@@ -1,0 +1,11 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import { config as loadEnv } from 'dotenv'
+
+loadEnv({ path: '.env.test', quiet: true })

--- a/packages/search-mysql/tsconfig.json
+++ b/packages/search-mysql/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "target": "es2024",
+    "allowJs": true,
+    "resolveJsonModule": true,
+    "moduleDetection": "force",
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noFallthroughCasesInSwitch": true,
+    "module": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "sourceMap": false,
+    "declaration": true,
+    "declarationMap": false,
+    "lib": ["es2024"],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}

--- a/packages/search-mysql/vitest.config.ts
+++ b/packages/search-mysql/vitest.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig(({ mode }) => {
+  const isIntegration = mode === 'integration'
+  const testFiles = isIntegration ? ['tests/**/*.integration.test.ts'] : ['**/*.test.node.ts']
+
+  return {
+    test: {
+      environment: 'node',
+      include: testFiles,
+      reporter: 'verbose',
+      globals: true,
+      testTimeout: 30_000,
+      hookTimeout: 60_000,
+      ...(isIntegration
+        ? {
+            setupFiles: ['./tests/setup.integration.ts'],
+            fileParallelism: false,
+            maxWorkers: 1,
+            isolate: false,
+          }
+        : {}),
+    },
+  }
+})

--- a/packages/search-postgres/.env.test.example
+++ b/packages/search-postgres/.env.test.example
@@ -1,0 +1,4 @@
+# Copy this file to .env.test for the dedicated PostgreSQL test database.
+# The database name must end in `_test`; the search conformance bootstrap
+# refuses any other target.
+BYLINE_DB_POSTGRES_CONNECTION_STRING=postgres://byline:byline@127.0.0.1:5432/byline_test

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,6 +145,9 @@ importers:
       '@byline/db-mysql':
         specifier: workspace:*
         version: link:../../packages/db-mysql
+      '@byline/search-mysql':
+        specifier: workspace:*
+        version: link:../../packages/search-mysql
       '@playwright/test':
         specifier: ^1.61.1
         version: 1.61.1
@@ -1114,6 +1117,52 @@ importers:
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1
+      typescript:
+        specifier: ^7.0.2
+        version: 7.0.2
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@26.1.1)(happy-dom@20.10.6)(jsdom@29.1.1)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.7)(sass@1.101.0)(stylus@0.62.0(supports-color@5.5.0))(tsx@4.23.1)(yaml@2.9.0))
+
+  packages/search-mysql:
+    dependencies:
+      '@byline/core':
+        specifier: workspace:*
+        version: link:../core
+      '@byline/search-analysis':
+        specifier: workspace:*
+        version: link:../search-analysis
+    devDependencies:
+      '@biomejs/biome':
+        specifier: 2.5.4
+        version: 2.5.4
+      '@byline/search-conformance':
+        specifier: workspace:*
+        version: link:../search-conformance
+      '@types/node':
+        specifier: ^26.1.1
+        version: 26.1.1
+      chokidar:
+        specifier: ^5.0.0
+        version: 5.0.0
+      chokidar-cli:
+        specifier: ^3.0.0
+        version: 3.0.0
+      dotenv:
+        specifier: ^17.4.2
+        version: 17.4.2
+      mysql2:
+        specifier: ^3.23.1
+        version: 3.23.1(@types/node@26.1.1)
+      npm-run-all:
+        specifier: ^4.1.5
+        version: 4.1.5
+      tsc-alias:
+        specifier: ^1.9.1
+        version: 1.9.1
+      tsx:
+        specifier: ^4.23.1
+        version: 4.23.1
       typescript:
         specifier: ^7.0.2
         version: 7.0.2

--- a/turbo.json
+++ b/turbo.json
@@ -60,7 +60,7 @@
       "dependsOn": ["^build"],
       "outputs": [],
       "cache": false,
-      "env": ["BYLINE_DB_POSTGRES_CONNECTION_STRING"]
+      "env": ["BYLINE_DB_MYSQL_CONNECTION_STRING", "BYLINE_DB_POSTGRES_CONNECTION_STRING"]
     },
     "preview": {
       "cache": false,


### PR DESCRIPTION
## Summary

- add the public `@byline/search-mysql` provider with an independent migration stream, analyzer fingerprint enforcement, portable index/query analysis, weighted MySQL FULLTEXT ranking, zones, filters, and facets
- extend shared provider conformance coverage for mixed expansion/exact-fallback phrases and run the MySQL provider against the same portable contract as PostgreSQL
- wire the MySQL webapp configuration, CI environment, package/release metadata, and operator/developer documentation

## Architecture

The provider stores parser-safe portable analysis tokens in MySQL FULLTEXT columns and keeps the matching contract in Byline rather than relying on database-language stemming. Search indexes are treated as disposable derived state, so this introduces a clean baseline without a compatibility migration.

## Validation

- `pnpm byline:generate:check`
- `pnpm docs:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm knip`
- `pnpm test`
- `pnpm test:integration`
- `pnpm build`
- `pnpm changeset status`
- `git diff --check`

Integration coverage included both search providers (16 conformance tests each), PostgreSQL storage (177 tests), MySQL storage (201 tests), and the client integration suite.