### PR TITLE
refactor(search): rename lexical capabilities

### DIFF
--- a/.changeset/search-analysis-contracts.md
+++ b/.changeset/search-analysis-contracts.md
@@ -4,12 +4,12 @@
 "@byline/search-analysis": minor
 ---
 
-Added provider-neutral lexical matching contracts and
+Added provider-neutral full-text matching contracts and
 `@byline/search-analysis`, a portable multilingual analysis and query-planning
 package. The analyzer preserves exact terms, validates locale declarations,
 uses ICU word boundaries, protects domain identifiers, emits optional
 language-specific variants and Han bigrams, and records a stable fingerprint
 for reindex decisions. Collection and zone search now pass explicit all/any,
 minimum-should-match, and phrase intent to search providers. Search providers
-must declare their lexical capabilities and implement index clearing so every
+must declare their full-text capabilities and implement index clearing so every
 derived projection remains explicitly rebuildable.

--- a/.changeset/search-postgres-portable-analysis.md
+++ b/.changeset/search-postgres-portable-analysis.md
@@ -2,7 +2,7 @@
 "@byline/search-postgres": minor
 ---
 
-Replaced PostgreSQL-native lexical analysis with the shared portable
+Replaced PostgreSQL-native term analysis with the shared portable
 multilingual analyzer and query plan. The adapter now supports all/any,
 minimum-should-match, phrases, protected identifiers, exact-preserving
 expansions, ordered Han-bigram fallback, and analyzer-fingerprint rebuild

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,8 +27,8 @@ Byline CMS — an open-source, AI-first headless CMS. Currently at a stable v4.x
 | `packages/ui` | `@byline/ui` | Framework-agnostic React primitives — Button, Input, Modal, Drawer, Table, Alert, icons, datepicker, generic `DraggableSortable`. No CMS concepts; importable independent of admin. Single barrel at `@byline/ui/react`. |
 | `packages/i18n` | `@byline/i18n` | Admin-interface translation system — `TranslationBundle` types, `mergeTranslations`, ICU formatter, locale resolution. React surface (`I18nProvider`, `useTranslation`, `LanguageMenu`) at `@byline/i18n/react`. Built-in `byline-admin` bundle (EN/FR) + `adminTranslations({ locales })` factory at `@byline/i18n/admin`. |
 | `packages/richtext-lexical` | `@byline/richtext-lexical` | Lexical-based richtext editor adapter |
-| `packages/search-analysis` | `@byline/search-analysis` | Portable multilingual lexical analysis and backend-neutral query planning — NFKC normalization, locale resolution, protected identifiers, ICU word segmentation, language expansion hooks, Han bigrams, analyzer fingerprints, and SQL-safe physical tokens |
-| `packages/search-conformance` | `@byline/search-conformance` | Private backend-neutral behavioral suite for `SearchProvider` adapters — capabilities, lifecycle/scoping, lexical matching, portable parser survival, weighting, and analyzer-fingerprint rebuild enforcement |
+| `packages/search-analysis` | `@byline/search-analysis` | Portable multilingual term analysis and backend-neutral query planning — NFKC normalization, locale resolution, protected identifiers, ICU word segmentation, language expansion hooks, Han bigrams, analyzer fingerprints, and SQL-safe physical tokens |
+| `packages/search-conformance` | `@byline/search-conformance` | Private backend-neutral behavioral suite for `SearchProvider` adapters — capabilities, lifecycle/scoping, full-text matching, portable parser survival, weighting, and analyzer-fingerprint rebuild enforcement |
 | `packages/search-mysql` | `@byline/search-mysql` | Built-in MySQL full-text `SearchProvider` driver — portable parser-safe tokens in weighted `FULLTEXT` indexes; owns its own schema; reuses the host mysql2 pool. See "Search & Retrieval" below |
 | `packages/search-postgres` | `@byline/search-postgres` | Built-in Postgres full-text `SearchProvider` driver — weighted `tsvector` index; owns its own schema (numbered SQL migrations); reuses the host pg pool. See "Search & Retrieval" below |
 | `packages/ai` | `@byline/ai` | AI subsystem — provider-agnostic execution (OpenAI / Google / Anthropic) for `executeInstruction`, `generateStructured`, and Lexical-node `patch` (streaming + non-streaming). Browser-safe root entry; SDK-backed execution behind `@byline/ai/server`; editor plugins at `@byline/ai/plugins/{text,lexical}`. See `packages/ai/README.md` |
@@ -225,7 +225,7 @@ the forward-looking landscape for the unbuilt phases is
 - **Drivers**: `@byline/search-postgres` provides weighted `tsvector` search;
   `@byline/search-mysql` stores parser-safe portable terms in weighted
   `FULLTEXT` indexes. Both factories take the host adapter's pool, implement the
-  complete portable lexical and weighting contract, own independent disposable
+  complete portable full-text matching and weighting contract, own independent disposable
   numbered-migration streams, and require a clear/rebuild after analyzer
   fingerprint changes. Highlights, facets, structured `where`, fuzzy matching,
   BM25, and semantic retrieval remain `false`.

--- a/docs/05-reading-and-delivery/07-search.md
+++ b/docs/05-reading-and-delivery/07-search.md
@@ -27,7 +27,7 @@ Companions:
 - [Collections](../04-collections/index.md) — the collection `search` config and the lifecycle hooks that maintain the index.
 - [Authentication & Authorization](../06-auth-and-security/01-authn-authz.md) — the `collections.<path>.reindex` ability and the `beforeRead` row-scoping that search honours.
 - [Search and document extraction strategy](./08-search-extraction-strategy.md) — forward-looking landscape + tiered strategy for Phases 3–4 (attachment extraction, external drivers).
-- [Portable multilingual search analysis](./09-multilingual-search-analysis.md) — the portable lexical-analysis and query-plan contracts that adapters can implement without changing the `SearchProvider` seam.
+- [Portable multilingual search analysis](./09-multilingual-search-analysis.md) — the portable term-analysis and query-plan contracts that adapters can implement without changing the `SearchProvider` seam.
 
 ## Overview
 
@@ -112,7 +112,7 @@ interface SearchCapabilities {
   bm25: boolean           // IDF-aware ranking
   weighting: boolean      // per-field SearchField.boost
   highlights: boolean     // matched-snippet highlighting
-  lexical: {              // detailed matching/analysis support
+  fullText: {             // detailed matching/analysis support
     nativeAnalysis: boolean
     portableAnalysis: boolean
     allTerms: boolean
@@ -131,7 +131,7 @@ interface SearchCapabilities {
   SearchProvider`; `initBylineCore()` fails fast when a collection opts into
   search but no provider is registered (`validateSearchConfig`).
 - **`capabilities`** is the honesty layer: both built-in SQL drivers declare
-  `weighting` and portable lexical matching; `highlights` / `facets` /
+  `weighting` and portable full-text matching; `highlights` / `facets` /
   `typoTolerance` / `semantic` / `bm25` are `false` until a richer driver (or
   capability) lands. Consumers
   light up features against it rather than assuming — which also makes driver
@@ -313,7 +313,7 @@ over MySQL 8 `FULLTEXT` indexes:
   collection, locale, published status, and JSON zone membership are applied
   before paging. Facets and typed filters remain JSON projections for future
   aggregation and structured filtering.
-- **Capabilities** — the provider reports the same portable lexical and
+- **Capabilities** — the provider reports the same portable full-text and
   weighting capabilities as PostgreSQL. It does not claim BM25: MySQL's native
   score is useful for ranking, but it is not a stable BM25 contract.
 - **Analyzer consistency** — collection metadata and rows carry the analyzer
@@ -482,7 +482,7 @@ collection + `published` by default, and delegates to `provider.search()`. It
 passes the same optional `matching` policy as zone search: `operator` is
 `'all'` or `'any'`, `minimumShouldMatch` refines `'any'`, and `phrase` is
 `'auto'`, `'required'`, or `'off'`. Providers declare detailed support in
-`capabilities.lexical`; both built-in SQL providers implement all four policies
+`capabilities.fullText`; both built-in SQL providers implement all four policies
 through the portable query plan.
 It accepts `status: 'any'`, but the framework lifecycle indexes published views
 only, so this does not make drafts appear in the built-in index; it only relaxes

--- a/docs/05-reading-and-delivery/09-multilingual-search-analysis.md
+++ b/docs/05-reading-and-delivery/09-multilingual-search-analysis.md
@@ -1,7 +1,7 @@
 ---
 title: "Portable Multilingual Search Analysis"
 path: "multilingual-search-analysis"
-summary: "The backend-neutral lexical matching, token analysis, query-plan, physical encoding, and analyzer-fingerprint contracts shared by Byline search providers."
+summary: "The backend-neutral full-text matching, token analysis, query-plan, physical encoding, and analyzer-fingerprint contracts shared by Byline search providers."
 ---
 
 # Portable Multilingual Search Analysis
@@ -25,7 +25,7 @@ disposable `0001_init.sql` projection.
 
 `SearchProvider` remains the stable storage and retrieval seam. It accepts
 original `SearchDocument` projections and returns ranked `SearchResults`.
-Multilingual lexical analysis is a different concern: it converts original text
+Multilingual term analysis is a different concern: it converts original text
 and query intent into a deterministic logical representation before an adapter
 chooses its physical index syntax.
 

--- a/packages/client/tests/unit/enforcement.test.node.ts
+++ b/packages/client/tests/unit/enforcement.test.node.ts
@@ -526,7 +526,7 @@ describe('CollectionHandle enforcement', () => {
   })
 
   describe('search query contracts', () => {
-    it('passes lexical matching intent through collection and zone search', async () => {
+    it('passes full-text matching intent through collection and zone search', async () => {
       const providerSearch = vi.fn().mockResolvedValue({ hits: [], total: 0 })
       const client = createBylineClient({
         db: mockDb(),

--- a/packages/core/src/@types/search-types.ts
+++ b/packages/core/src/@types/search-types.ts
@@ -161,7 +161,7 @@ export interface SearchDocument {
 // Query surface
 // ---------------------------------------------------------------------------
 
-/** How independently analyzed query concepts combine for lexical matching. */
+/** How independently analyzed query concepts combine for full-text matching. */
 export type SearchTermOperator = 'all' | 'any'
 
 /**
@@ -174,7 +174,7 @@ export type SearchTermOperator = 'all' | 'any'
 export type SearchPhraseMode = 'auto' | 'required' | 'off'
 
 /**
- * Provider-neutral lexical matching intent. Providers translate this into
+ * Provider-neutral full-text matching intent. Providers translate this into
  * their native query syntax; it is product behavior, not a ranking hint.
  */
 export interface SearchMatching {
@@ -183,7 +183,7 @@ export interface SearchMatching {
   /**
    * Require at least this many concepts when `operator` is `any`.
    * Providers that cannot express this advertise that limitation through
-   * `capabilities.lexical.minimumShouldMatch`.
+   * `capabilities.fullText.minimumShouldMatch`.
    */
   minimumShouldMatch?: number
   /** Phrase handling. Defaults to `auto`. */
@@ -199,7 +199,7 @@ export interface SearchQuery {
   /** The free-text query string. */
   query: string
   /**
-   * Explicit lexical matching semantics. Defaults to all concepts required
+   * Explicit full-text matching semantics. Defaults to all concepts required
    * with quoted spans treated as phrases.
    */
   matching?: SearchMatching
@@ -304,8 +304,8 @@ export interface SearchCapabilities {
   weighting: boolean
   /** Matched-snippet highlighting in results. */
   highlights: boolean
-  /** Detailed lexical analysis and matching capabilities. */
-  lexical: {
+  /** Detailed full-text analysis and matching capabilities. */
+  fullText: {
     /** The backend applies its own language analyzer to original text. */
     nativeAnalysis: boolean
     /** The backend can index application-produced portable logical tokens. */

--- a/packages/search-analysis/README.md
+++ b/packages/search-analysis/README.md
@@ -1,6 +1,6 @@
 # @byline/search-analysis
 
-Portable multilingual lexical analysis and backend-neutral query planning for
+Portable multilingual term analysis and backend-neutral query planning for
 Byline CMS search providers.
 
 The package owns logical search behavior:

--- a/packages/search-analysis/package.json
+++ b/packages/search-analysis/package.json
@@ -6,7 +6,7 @@
   "engines": {
     "node": ">=20.9.0"
   },
-  "description": "Portable multilingual lexical analysis and query planning for Byline CMS search providers",
+  "description": "Portable multilingual term analysis and query planning for Byline CMS search providers",
   "keywords": [
     "cms",
     "headless cms",

--- a/packages/search-conformance/src/index.ts
+++ b/packages/search-conformance/src/index.ts
@@ -11,12 +11,12 @@ import type { PortableSearchAnalyzer } from '@byline/search-analysis'
 import { afterAll, beforeAll } from 'vitest'
 
 import { capabilitiesSuite } from './suites/capabilities.js'
-import { lexicalMatchingSuite } from './suites/lexical-matching.js'
+import { fullTextMatchingSuite } from './suites/full-text-matching.js'
 import { lifecycleSuite } from './suites/lifecycle.js'
 import { portableAnalysisSuite } from './suites/portable-analysis.js'
 
 export { capabilitiesSuite } from './suites/capabilities.js'
-export { lexicalMatchingSuite } from './suites/lexical-matching.js'
+export { fullTextMatchingSuite } from './suites/full-text-matching.js'
 export { lifecycleSuite } from './suites/lifecycle.js'
 export { portableAnalysisSuite } from './suites/portable-analysis.js'
 
@@ -30,7 +30,7 @@ export interface SearchConformanceHooks {
   createProvider(): SearchProvider | Promise<SearchProvider>
   /**
    * Construct the adapter with an explicit portable analyzer. Supply this
-   * only when `capabilities.lexical.portableAnalysis` is true; doing so
+   * only when `capabilities.fullText.portableAnalysis` is true; doing so
    * registers the portable parser/fingerprint suites.
    */
   createPortableProvider?(
@@ -64,6 +64,6 @@ export function runSearchProviderConformanceSuite(hooks: SearchConformanceHooks)
 
   capabilitiesSuite(hooks)
   lifecycleSuite(hooks)
-  lexicalMatchingSuite(hooks)
+  fullTextMatchingSuite(hooks)
   portableAnalysisSuite(hooks)
 }

--- a/packages/search-conformance/src/suites/capabilities.ts
+++ b/packages/search-conformance/src/suites/capabilities.ts
@@ -20,11 +20,11 @@ export function capabilitiesSuite(hooks: SearchConformanceHooks): void {
       provider = await hooks.createProvider()
     })
 
-    it('declares one analysis strategy and the shared lexical matching floor', () => {
-      const lexical = provider.capabilities.lexical
+    it('declares one analysis strategy and the shared full-text matching floor', () => {
+      const fullText = provider.capabilities.fullText
 
-      expect(lexical.nativeAnalysis || lexical.portableAnalysis).toBe(true)
-      expect(lexical).toMatchObject({
+      expect(fullText.nativeAnalysis || fullText.portableAnalysis).toBe(true)
+      expect(fullText).toMatchObject({
         allTerms: true,
         anyTerms: true,
         minimumShouldMatch: true,
@@ -35,7 +35,7 @@ export function capabilitiesSuite(hooks: SearchConformanceHooks): void {
     it('declares portable analysis when a portable-provider factory is supplied', async () => {
       if (hooks.createPortableProvider == null) return
       const portableProvider = await hooks.createPortableProvider(createPortableSearchAnalyzer())
-      expect(portableProvider.capabilities.lexical.portableAnalysis).toBe(true)
+      expect(portableProvider.capabilities.fullText.portableAnalysis).toBe(true)
     })
   })
 }

--- a/packages/search-conformance/src/suites/full-text-matching.ts
+++ b/packages/search-conformance/src/suites/full-text-matching.ts
@@ -12,10 +12,10 @@ import { beforeEach, describe, expect, it } from 'vitest'
 import { searchDocument } from '../fixtures.js'
 import type { SearchConformanceHooks } from '../index.js'
 
-export function lexicalMatchingSuite(hooks: SearchConformanceHooks): void {
+export function fullTextMatchingSuite(hooks: SearchConformanceHooks): void {
   let provider: SearchProvider
 
-  describe.sequential('SearchProvider lexical matching', () => {
+  describe.sequential('SearchProvider full-text matching', () => {
     beforeEach(async () => {
       await hooks.reset()
       provider = await hooks.createProvider()

--- a/packages/search-mysql/src/mysql-search-provider.ts
+++ b/packages/search-mysql/src/mysql-search-provider.ts
@@ -29,7 +29,7 @@ const CAPABILITIES: SearchCapabilities = {
   bm25: false,
   weighting: true,
   highlights: false,
-  lexical: {
+  fullText: {
     nativeAnalysis: false,
     portableAnalysis: true,
     allTerms: true,

--- a/packages/search-postgres/README.md
+++ b/packages/search-postgres/README.md
@@ -109,7 +109,7 @@ option 2 so startup is deterministic and DDL permissions are explicit.
 provider.capabilities
 // { facets: false, typoTolerance: false, semantic: false,
 //   bm25: false, weighting: true, highlights: false,
-//   lexical: {
+//   fullText: {
 //     nativeAnalysis: false, portableAnalysis: true,
 //     allTerms: true, anyTerms: true,
 //     minimumShouldMatch: true, phrase: true
@@ -117,7 +117,7 @@ provider.capabilities
 ```
 
 The `tsvector` + `ts_rank` floor supports per-field **weighting** and all shared
-lexical matching policies. Facet *data* is indexed, but facet *aggregation*
+full-text matching policies. Facet *data* is indexed, but facet *aggregation*
 queries, structured `where` filtering, matched-source highlighting, fuzzy
 matching, BM25 ranking, and semantic/vector retrieval are follow-ups. The
 capability flags let consumers enable only supported behavior.

--- a/packages/search-postgres/src/postgres-search-provider.ts
+++ b/packages/search-postgres/src/postgres-search-provider.ts
@@ -31,7 +31,7 @@ const CAPABILITIES: SearchCapabilities = {
   bm25: false,
   weighting: true,
   highlights: false,
-  lexical: {
+  fullText: {
     nativeAnalysis: false,
     portableAnalysis: true,
     allTerms: true,


### PR DESCRIPTION
## Summary

- rename the public `SearchCapabilities.lexical` property to `SearchCapabilities.fullText`
- rename the shared conformance suite/export from lexical matching to full-text matching
- update the built-in PostgreSQL and MySQL providers, tests, developer documentation, package metadata, and pending release notes

This is a terminology-only refinement of the unreleased search contract. It avoids ambiguity with Byline's Lexical rich-text editor and does not change search behavior, database schemas, or index formats.

## Validation

- `pnpm byline:generate:check`
- `pnpm docs:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm knip`
- `pnpm test`
- `pnpm build`
- focused PostgreSQL provider integration/conformance suite (16 tests)
- focused MySQL provider integration/conformance suite (16 tests)
- focused search/client unit suites (170 tests)
- `git diff --check`

## Commit provenance

The commit includes the required DCO `Signed-off-by` trailer and has no cryptographic signature or co-author trailer.