### PR TITLE
feat(search): add portable highlighting

### DIFF
--- a/.changeset/search-analysis-contracts.md
+++ b/.changeset/search-analysis-contracts.md
@@ -9,7 +9,9 @@ Added provider-neutral full-text matching contracts and
 package. The analyzer preserves exact terms, validates locale declarations,
 uses ICU word boundaries, protects domain identifiers, emits optional
 language-specific variants and Han bigrams, and records a stable fingerprint
-for reindex decisions. Collection and zone search now pass explicit all/any,
-minimum-should-match, and phrase intent to search providers. Search providers
-must declare their full-text capabilities and implement index clearing so every
-derived projection remains explicitly rebuildable.
+for reindex decisions. It also builds bounded, original-text highlighted
+snippets from the same portable token offsets. Collection and zone search now
+pass explicit all/any, minimum-should-match, and phrase intent to search
+providers. Search providers must declare their full-text capabilities and
+implement index clearing so every derived projection remains explicitly
+rebuildable.

--- a/.changeset/search-mysql-adapter.md
+++ b/.changeset/search-mysql-adapter.md
@@ -7,7 +7,8 @@
 Added the built-in MySQL full-text `SearchProvider`, backed by portable
 multilingual analysis, weighted MySQL `FULLTEXT` indexes, driver-owned
 migrations, analyzer-fingerprint enforcement, and the shared provider
-conformance suite.
+conformance suite. Ranked hits include portable highlighted snippets from the
+stored original body text.
 
 Documented and wired `@byline/db-mysql` installations to use the real search
 provider instead of a no-op workaround.

--- a/.changeset/search-postgres-portable-analysis.md
+++ b/.changeset/search-postgres-portable-analysis.md
@@ -6,7 +6,9 @@ Replaced PostgreSQL-native term analysis with the shared portable
 multilingual analyzer and query plan. The adapter now supports all/any,
 minimum-should-match, phrases, protected identifiers, exact-preserving
 expansions, ordered Han-bigram fallback, and analyzer-fingerprint rebuild
-guards through one weighted `tsvector`.
+guards through one weighted `tsvector`. Ranked hits again include highlighted
+snippets, now produced from shared portable offsets rather than PostgreSQL's
+native analyzer.
 
 This is a direct cutover for the disposable search projection: reset the
 provider-owned search tables, apply the rewritten `0001_init.sql`, and rebuild

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,10 +27,10 @@ Byline CMS — an open-source, AI-first headless CMS. Currently at a stable v4.x
 | `packages/ui` | `@byline/ui` | Framework-agnostic React primitives — Button, Input, Modal, Drawer, Table, Alert, icons, datepicker, generic `DraggableSortable`. No CMS concepts; importable independent of admin. Single barrel at `@byline/ui/react`. |
 | `packages/i18n` | `@byline/i18n` | Admin-interface translation system — `TranslationBundle` types, `mergeTranslations`, ICU formatter, locale resolution. React surface (`I18nProvider`, `useTranslation`, `LanguageMenu`) at `@byline/i18n/react`. Built-in `byline-admin` bundle (EN/FR) + `adminTranslations({ locales })` factory at `@byline/i18n/admin`. |
 | `packages/richtext-lexical` | `@byline/richtext-lexical` | Lexical-based richtext editor adapter |
-| `packages/search-analysis` | `@byline/search-analysis` | Portable multilingual term analysis and backend-neutral query planning — NFKC normalization, locale resolution, protected identifiers, ICU word segmentation, language expansion hooks, Han bigrams, analyzer fingerprints, and SQL-safe physical tokens |
-| `packages/search-conformance` | `@byline/search-conformance` | Private backend-neutral behavioral suite for `SearchProvider` adapters — capabilities, lifecycle/scoping, full-text matching, portable parser survival, weighting, and analyzer-fingerprint rebuild enforcement |
-| `packages/search-mysql` | `@byline/search-mysql` | Built-in MySQL full-text `SearchProvider` driver — portable parser-safe tokens in weighted `FULLTEXT` indexes; owns its own schema; reuses the host mysql2 pool. See "Search & Retrieval" below |
-| `packages/search-postgres` | `@byline/search-postgres` | Built-in Postgres full-text `SearchProvider` driver — weighted `tsvector` index; owns its own schema (numbered SQL migrations); reuses the host pg pool. See "Search & Retrieval" below |
+| `packages/search-analysis` | `@byline/search-analysis` | Portable multilingual term analysis, backend-neutral query planning, and offset-aware highlighting — NFKC normalization, locale resolution, protected identifiers, ICU word segmentation, language expansion hooks, Han bigrams, analyzer fingerprints, and SQL-safe physical tokens |
+| `packages/search-conformance` | `@byline/search-conformance` | Private backend-neutral behavioral suite for `SearchProvider` adapters — capabilities, lifecycle/scoping, full-text matching, highlighting, portable parser survival, weighting, and analyzer-fingerprint rebuild enforcement |
+| `packages/search-mysql` | `@byline/search-mysql` | Built-in MySQL full-text `SearchProvider` driver — portable parser-safe tokens in weighted `FULLTEXT` indexes plus portable highlighted snippets; owns its own schema; reuses the host mysql2 pool. See "Search & Retrieval" below |
+| `packages/search-postgres` | `@byline/search-postgres` | Built-in Postgres full-text `SearchProvider` driver — weighted `tsvector` index plus portable highlighted snippets; owns its own schema (numbered SQL migrations); reuses the host pg pool. See "Search & Retrieval" below |
 | `packages/ai` | `@byline/ai` | AI subsystem — provider-agnostic execution (OpenAI / Google / Anthropic) for `executeInstruction`, `generateStructured`, and Lexical-node `patch` (streaming + non-streaming). Browser-safe root entry; SDK-backed execution behind `@byline/ai/server`; editor plugins at `@byline/ai/plugins/{text,lexical}`. See `packages/ai/README.md` |
 | `packages/cli` | `@byline/cli` | Guided installer that adds Byline to an existing TanStack Start app (`byline init`, `doctor`, …) |
 
@@ -227,8 +227,9 @@ the forward-looking landscape for the unbuilt phases is
   `FULLTEXT` indexes. Both factories take the host adapter's pool, implement the
   complete portable full-text matching and weighting contract, own independent disposable
   numbered-migration streams, and require a clear/rebuild after analyzer
-  fingerprint changes. Highlights, facets, structured `where`, fuzzy matching,
-  BM25, and semantic retrieval remain `false`.
+  fingerprint changes. Both return portable highlighted snippets. Facets,
+  structured `where`, fuzzy matching, BM25, and semantic retrieval remain
+  `false`.
 - **Indexing**: lifecycle hooks call `client.collection(x).indexDocument(id)` / `removeFromIndex(id)`
   (orchestration lives in `@byline/client`, not the provider). `indexDocument` re-syncs by reading
   the published view per locale (`status: 'published'`, `onMissingLocale: 'omit'`) and

--- a/apps/webapp/src/routes/$lng/_frontend/docs/search.tsx
+++ b/apps/webapp/src/routes/$lng/_frontend/docs/search.tsx
@@ -111,9 +111,9 @@ function RouteComponent() {
 }
 
 /**
- * Render a `ts_headline` snippet safely: split on the `<mark>…</mark>` markers
- * the provider emits and render React `<mark>` elements, so the surrounding
- * snippet text is escaped by React (never injected as raw HTML).
+ * Render a provider snippet safely: split on the portable `<mark>…</mark>`
+ * markers and render React `<mark>` elements, so the surrounding snippet text
+ * is escaped by React (never injected as raw HTML).
  */
 function Highlighted({ snippet }: { snippet: string }): React.JSX.Element {
   const parts = snippet.split(/(<mark>.*?<\/mark>)/g)

--- a/docs/05-reading-and-delivery/07-search.md
+++ b/docs/05-reading-and-delivery/07-search.md
@@ -131,9 +131,9 @@ interface SearchCapabilities {
   SearchProvider`; `initBylineCore()` fails fast when a collection opts into
   search but no provider is registered (`validateSearchConfig`).
 - **`capabilities`** is the honesty layer: both built-in SQL drivers declare
-  `weighting` and portable full-text matching; `highlights` / `facets` /
-  `typoTolerance` / `semantic` / `bm25` are `false` until a richer driver (or
-  capability) lands. Consumers
+  `weighting`, highlighted snippets, and portable full-text matching.
+  `facets` / `typoTolerance` / `semantic` / `bm25` remain `false` until a
+  richer driver (or capability) lands. Consumers
   light up features against it rather than assuming — which also makes driver
   degradation *deliberate*: a UI can hide facet chips when the registered
   driver can't aggregate, instead of silently returning less.
@@ -279,10 +279,10 @@ interface SearchFacetValue { id: number | string; term: string }  // counter id 
   and script detection guide ICU segmentation and optional language expanders.
   `defaultLocale` supplies the analyzer fallback for content or queries without
   a usable locale.
-- **Capabilities** — weighting plus `all`, `any`, minimum-should-match, and
-  phrase policies are supported. Facet *data* is indexed, but highlighting,
-  facet *aggregation*, structured `where` filtering, fuzzy matching, BM25
-  ranking, and semantic retrieval are flagged `false`.
+- **Capabilities** — weighting, portable highlighted snippets, and `all`,
+  `any`, minimum-should-match, and phrase policies are supported. Facet *data*
+  is indexed, but facet *aggregation*, structured `where` filtering, fuzzy
+  matching, BM25 ranking, and semantic retrieval are flagged `false`.
 - **Analyzer consistency** — every row and collection metadata record carries
   the portable analyzer fingerprint. A mismatch rejects reads and writes until
   the collection's search projection is cleared and rebuilt.
@@ -314,8 +314,9 @@ over MySQL 8 `FULLTEXT` indexes:
   before paging. Facets and typed filters remain JSON projections for future
   aggregation and structured filtering.
 - **Capabilities** — the provider reports the same portable full-text and
-  weighting capabilities as PostgreSQL. It does not claim BM25: MySQL's native
-  score is useful for ranking, but it is not a stable BM25 contract.
+  weighting capabilities as PostgreSQL, including portable highlighted
+  snippets. It does not claim BM25: MySQL's native score is useful for ranking,
+  but it is not a stable BM25 contract.
 - **Analyzer consistency** — collection metadata and rows carry the analyzer
   fingerprint. A mismatch requires clearing and rebuilding that collection.
 - **Schema ownership** — numbered SQL files under the package's `migrations/`
@@ -488,8 +489,12 @@ It accepts `status: 'any'`, but the framework lifecycle indexes published views
 only, so this does not make drafts appear in the built-in index; it only relaxes
 the provider filter for rows a custom indexing path may have supplied. It
 returns the **lightweight hit tier** — `title`, `path`, and `score`, plus
-provider-dependent `highlights` when advertised — enough to render a results
-list without hydration. Lightweight hits themselves are not document materializations, so
+`highlights.body` snippets from both built-in SQL providers — enough to render
+a results list without hydration. Each snippet preserves original indexed text
+and uses `<mark>…</mark>` delimiters around matching exact, normalized,
+expanded, identifier, or Han-gram ranges. Renderers must parse those delimiters
+and render all surrounding content as text rather than injecting the complete
+snippet as trusted HTML. Lightweight hits themselves are not document materializations, so
 `afterRead` does not transform them; when row authorization requires an internal
 projected re-read, that fresh internal document still runs its normal hook.
 Use `hydrate: true` when the returned result must carry an actor-redacted

--- a/docs/05-reading-and-delivery/09-multilingual-search-analysis.md
+++ b/docs/05-reading-and-delivery/09-multilingual-search-analysis.md
@@ -1,7 +1,7 @@
 ---
 title: "Portable Multilingual Search Analysis"
 path: "multilingual-search-analysis"
-summary: "The backend-neutral full-text matching, token analysis, query-plan, physical encoding, and analyzer-fingerprint contracts shared by Byline search providers."
+summary: "The backend-neutral full-text matching, token analysis, query-plan, highlighting, physical encoding, and analyzer-fingerprint contracts shared by Byline search providers."
 ---
 
 # Portable Multilingual Search Analysis
@@ -35,8 +35,8 @@ The ownership boundaries are:
 |---|---|
 | `@byline/core` | Public matching intent and provider capability declarations |
 | `@byline/client` | Pass matching intent from collection and zone calls without interpretation |
-| `@byline/search-analysis` | Normalization, locale resolution, token classes, grouped query plans, fingerprints, and SQL-safe token encoding |
-| Search adapter | Physical schema, persistence, query translation, ranking, highlights, and analyzer-consistency checks |
+| `@byline/search-analysis` | Normalization, locale resolution, token classes, grouped query plans, portable highlighting, fingerprints, and SQL-safe token encoding |
+| Search adapter | Physical schema, persistence, query translation, ranking, invoking highlights for ranked rows, and analyzer-consistency checks |
 
 This split keeps the portable behavior independently testable. It also avoids
 forcing Solr, OpenSearch, or another engine with a strong native analyzer to
@@ -63,7 +63,7 @@ quoted phrase constraints.
 
 These options describe product behavior rather than backend syntax. An adapter
 must translate them faithfully or advertise the missing feature through
-`SearchCapabilities.lexical`.
+`SearchCapabilities.fullText`.
 
 ## Analysis pipeline
 
@@ -123,6 +123,22 @@ The codec is an adapter building block, not the public search vocabulary.
 Adapters store original text for display and highlights and use encoded terms
 only in their portable index projection.
 
+## Portable highlighting
+
+`highlightPortableText()` re-analyzes the stored original text with the same
+analyzer and compares its logical terms with a `PortableQueryPlan`. Matching is
+based on the same kind-aware physical token identity used by the SQL adapters,
+so a snippet can mark the original source range for an exact, normalized,
+stemmed, lemmatized, identifier, or Han-gram match without asking a database to
+analyze the source text differently.
+
+The highlighter merges overlapping source ranges and selects at most two
+24-term fragments by default. It runs only for the ranked rows on the requested
+page, not while scanning the corpus. Both built-in SQL providers return the
+result as `highlights.body[0]`, with `<mark>…</mark>` delimiters. Consumers must
+parse the delimiters and render the remaining source as text; the complete
+snippet is not trusted HTML.
+
 ## Fingerprints and reindexing
 
 Every analyzer exposes an `analyzerFingerprint`. It includes the portable
@@ -152,7 +168,9 @@ The implementation sequence keeps each phase reviewable:
    adapter.**
 4. Complete `@byline/search-mysql` against the same query plans and conformance
    suite, with MySQL-specific schema and full-text translation. **Shipped.**
-5. Adapt the existing Solr implementation, normally using Solr's native
+5. Restore PostgreSQL highlighting through portable source offsets and apply
+   the same implementation to MySQL. **Shipped.**
+6. Adapt the existing Solr implementation, normally using Solr's native
    analyzers while mapping the public matching contract and capability report.
 
 PostgreSQL and MySQL migrations remain independent streams owned by their

--- a/packages/search-analysis/README.md
+++ b/packages/search-analysis/README.md
@@ -12,14 +12,19 @@ The package owns logical search behavior:
 - exact-preserving language expansion hooks;
 - overlapping Han bigrams;
 - grouped query concepts and phrase intent; and
-- a parser-safe SQL token codec.
+- a parser-safe SQL token codec; and
+- offset-aware, backend-neutral highlighted snippets.
 
 It does not own a search index or query a database. PostgreSQL, MySQL, Solr,
 and future providers translate the logical analysis into their own physical
 representations.
 
 ```ts
-import { createPortableSearchAnalyzer, encodeSqlToken } from '@byline/search-analysis'
+import {
+  createPortableSearchAnalyzer,
+  encodeSqlToken,
+  highlightPortableText,
+} from '@byline/search-analysis'
 
 const analyzer = createPortableSearchAnalyzer({
   defaultLocale: 'en',
@@ -38,8 +43,19 @@ const query = analyzer.analyzeQuery({
 })
 
 const physical = text.tokens.map((token) => encodeSqlToken(token))
+const snippet = highlightPortableText({
+  text: 'A forest restoration field report.',
+  plan: query,
+  analyzer,
+})
 ```
 
 Original content remains authoritative. Analyzer output is a disposable,
 versioned projection; `analyzer.fingerprint` changes when behavior that can
 affect indexed terms changes.
+
+`highlightPortableText()` preserves the original source text and inserts
+`<mark>…</mark>` delimiters around exact, normalized, expanded, identifier, and
+Han-gram matches. Renderers must parse those delimiters and render the
+surrounding content as text; they must not inject the complete snippet as
+trusted HTML.

--- a/packages/search-analysis/package.json
+++ b/packages/search-analysis/package.json
@@ -6,7 +6,7 @@
   "engines": {
     "node": ">=20.9.0"
   },
-  "description": "Portable multilingual term analysis and query planning for Byline CMS search providers",
+  "description": "Portable multilingual term analysis, query planning, and highlighting for Byline CMS search providers",
   "keywords": [
     "cms",
     "headless cms",

--- a/packages/search-analysis/src/highlight.test.node.ts
+++ b/packages/search-analysis/src/highlight.test.node.ts
@@ -1,0 +1,124 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import { createPortableSearchAnalyzer } from './analyzer.js'
+import { highlightPortableText } from './highlight.js'
+import type { SearchTokenExpander } from './types.js'
+
+describe('portable highlighting', () => {
+  it('preserves original text while marking normalized terms and protected identifiers', () => {
+    const analyzer = createPortableSearchAnalyzer()
+    const plan = analyzer.analyzeQuery({
+      query: 'alpha ffi Node.js',
+      locale: 'en',
+    })
+
+    expect(
+      highlightPortableText({
+        text: 'Prelude words before Alpha compatibility ﬃ and Node.js finish.',
+        plan,
+        analyzer,
+      })
+    ).toBe(
+      'Prelude words before <mark>Alpha</mark> compatibility <mark>ﬃ</mark> and <mark>Node.js</mark> finish.'
+    )
+  })
+
+  it('marks source terms that matched through a language expansion', () => {
+    const expander: SearchTokenExpander = {
+      fingerprint: 'english-highlight-test1',
+      supports: (locale) => locale.startsWith('en'),
+      expand: (token) =>
+        token.value === 'running' || token.value === 'runs' ? [{ kind: 'stem', value: 'run' }] : [],
+    }
+    const analyzer = createPortableSearchAnalyzer({ expanders: [expander] })
+    const plan = analyzer.analyzeQuery({ query: 'runs', locale: 'en' })
+
+    expect(
+      highlightPortableText({
+        text: 'Running through the forest.',
+        plan,
+        analyzer,
+      })
+    ).toBe('<mark>Running</mark> through the forest.')
+  })
+
+  it('marks only concepts present in a partial any-term match', () => {
+    const analyzer = createPortableSearchAnalyzer()
+    const plan = analyzer.analyzeQuery({
+      query: 'forest missing',
+      matching: { operator: 'any' },
+    })
+
+    expect(
+      highlightPortableText({
+        text: 'Forest restoration field notes.',
+        plan,
+        analyzer,
+      })
+    ).toBe('<mark>Forest</mark> restoration field notes.')
+  })
+
+  it('merges overlapping Han token and gram ranges', () => {
+    const analyzer = createPortableSearchAnalyzer()
+    const plan = analyzer.analyzeQuery({ query: '数据库' })
+
+    expect(highlightPortableText({ text: '研究数据库系统', plan, analyzer })).toContain(
+      '<mark>数据库</mark>'
+    )
+  })
+
+  it('selects bounded fragments around distant matches', () => {
+    const analyzer = createPortableSearchAnalyzer()
+    const words = Array.from({ length: 60 }, (_, index) => `word${index}`)
+    words[2] = 'alpha'
+    words[55] = 'beta'
+    const plan = analyzer.analyzeQuery({
+      query: 'alpha beta',
+      matching: { operator: 'any' },
+    })
+
+    const highlighted = highlightPortableText({
+      text: words.join(' '),
+      plan,
+      analyzer,
+      maxFragments: 2,
+      maxWords: 8,
+    })
+
+    expect(highlighted).toContain('<mark>alpha</mark>')
+    expect(highlighted).toContain('<mark>beta</mark>')
+    expect(highlighted).toContain(' … ')
+    expect(highlighted?.split(/\s+/)).toHaveLength(17)
+  })
+
+  it('returns undefined when the stored text contains no query term', () => {
+    const analyzer = createPortableSearchAnalyzer()
+    const plan = analyzer.analyzeQuery({ query: 'forest' })
+
+    expect(highlightPortableText({ text: 'ocean', plan, analyzer })).toBeUndefined()
+  })
+
+  it('rejects incompatible analyzers and invalid limits', () => {
+    const analyzer = createPortableSearchAnalyzer({ defaultLocale: 'en' })
+    const plan = analyzer.analyzeQuery({ query: 'forest' })
+
+    expect(() =>
+      highlightPortableText({
+        text: 'forest',
+        plan,
+        analyzer: createPortableSearchAnalyzer({ defaultLocale: 'th' }),
+      })
+    ).toThrow(/fingerprints/)
+    expect(() =>
+      highlightPortableText({ text: 'forest', plan, analyzer, maxFragments: 0 })
+    ).toThrow(RangeError)
+  })
+})

--- a/packages/search-analysis/src/highlight.ts
+++ b/packages/search-analysis/src/highlight.ts
@@ -1,0 +1,219 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import { encodeSqlToken } from './sql-token-codec.js'
+import type {
+  LogicalToken,
+  PortableQueryPlan,
+  PortableSearchAnalyzer,
+  QueryConcept,
+} from './types.js'
+
+const DEFAULT_MAX_FRAGMENTS = 2
+const DEFAULT_MAX_WORDS = 24
+
+export interface PortableHighlightOptions {
+  /** Maximum independently selected fragments. Defaults to 2. */
+  maxFragments?: number
+  /** Maximum analyzed source terms in each snippet. Defaults to 24. */
+  maxWords?: number
+}
+
+export interface HighlightPortableTextInput extends PortableHighlightOptions {
+  /** Original stored text from which source-preserving fragments are selected. */
+  text: string
+  /** Query plan produced by the same analyzer used for the index. */
+  plan: PortableQueryPlan
+  /** Analyzer used to recover source offsets from the stored text. */
+  analyzer: PortableSearchAnalyzer
+}
+
+interface TextRange {
+  start: number
+  end: number
+}
+
+interface Fragment extends TextRange {
+  matches: number
+}
+
+/**
+ * Build a backend-neutral matched snippet from portable logical-token offsets.
+ *
+ * The returned string contains `<mark>…</mark>` delimiters. Consumers must
+ * parse those delimiters and render the surrounding source text as text; they
+ * must not inject the complete result as trusted HTML.
+ */
+export function highlightPortableText({
+  text,
+  plan,
+  analyzer,
+  maxFragments = DEFAULT_MAX_FRAGMENTS,
+  maxWords = DEFAULT_MAX_WORDS,
+}: HighlightPortableTextInput): string | undefined {
+  assertPositiveInteger(maxFragments, 'maxFragments')
+  assertPositiveInteger(maxWords, 'maxWords')
+  if (text.length === 0 || plan.concepts.length === 0) return undefined
+  if (plan.analyzerFingerprint !== analyzer.fingerprint) {
+    throw new TypeError('Portable highlight plan and analyzer fingerprints do not match')
+  }
+
+  const queryTerms = new Set(queryTokens(plan).map((token) => encodeSqlToken(token)))
+  const analyzed = analyzer.analyzeText({ text, locale: plan.locale })
+  const matches = mergeRanges(
+    analyzed.tokens
+      .filter((token) => queryTerms.has(encodeSqlToken(token)))
+      .map(({ start, end }) => ({ start, end }))
+  )
+  if (matches.length === 0) return undefined
+
+  const sourceTerms = uniqueRanges(
+    [...analyzed.exactTokens, ...analyzed.identifierTokens]
+      .toSorted(compareTokenRanges)
+      .map(({ start, end }) => ({ start, end }))
+  )
+  const fragments = selectFragments(text, matches, sourceTerms, maxFragments, maxWords)
+  if (fragments.length === 0) return undefined
+
+  const rendered = fragments.map((fragment) => renderFragment(text, fragment, matches))
+  let snippet = rendered.join(' … ')
+  if (text.slice(0, fragments[0]?.start ?? 0).trim().length > 0) snippet = `… ${snippet}`
+  if (text.slice(fragments.at(-1)?.end ?? text.length).trim().length > 0) snippet += ' …'
+  return snippet
+}
+
+function queryTokens(plan: PortableQueryPlan): LogicalToken[] {
+  return [...plan.concepts.flatMap(conceptTokens), ...plan.gramSequences.flat()]
+}
+
+function conceptTokens(concept: QueryConcept): LogicalToken[] {
+  return [
+    ...concept.exactTokens,
+    ...concept.stemTokens,
+    ...concept.lemmaTokens,
+    ...concept.normalizedTokens,
+    ...concept.identifierTokens,
+    ...concept.gramTokens,
+  ]
+}
+
+function selectFragments(
+  text: string,
+  matches: readonly TextRange[],
+  sourceTerms: readonly TextRange[],
+  maxFragments: number,
+  maxWords: number
+): Fragment[] {
+  const candidates = uniqueRanges(
+    matches.map((match) => fragmentAroundMatch(text, match, sourceTerms, maxWords))
+  )
+    .map((range) => ({
+      ...range,
+      matches: matches.filter((match) => overlaps(range, match)).length,
+    }))
+    .toSorted((left, right) => right.matches - left.matches || left.start - right.start)
+
+  const selected: Fragment[] = []
+  for (const candidate of candidates) {
+    if (selected.some((fragment) => overlaps(fragment, candidate))) continue
+    selected.push(candidate)
+    if (selected.length === maxFragments) break
+  }
+  return selected.toSorted((left, right) => left.start - right.start)
+}
+
+function fragmentAroundMatch(
+  text: string,
+  match: TextRange,
+  sourceTerms: readonly TextRange[],
+  maxWords: number
+): TextRange {
+  const firstMatch = sourceTerms.findIndex((term) => overlaps(term, match))
+  if (firstMatch === -1) return match
+
+  let lastMatch = firstMatch
+  while (lastMatch + 1 < sourceTerms.length && overlaps(sourceTerms[lastMatch + 1]!, match)) {
+    lastMatch += 1
+  }
+
+  const matchedWords = lastMatch - firstMatch + 1
+  const contextWords = Math.max(0, maxWords - matchedWords)
+  let first = Math.max(0, firstMatch - Math.floor(contextWords / 2))
+  let last = Math.min(sourceTerms.length - 1, lastMatch + Math.ceil(contextWords / 2))
+
+  const currentWords = last - first + 1
+  if (currentWords < maxWords) {
+    const missing = maxWords - currentWords
+    const extendLeft = Math.min(first, missing)
+    first -= extendLeft
+    last = Math.min(sourceTerms.length - 1, last + missing - extendLeft)
+  }
+
+  return {
+    start: first === 0 ? 0 : (sourceTerms[first]?.start ?? match.start),
+    end: last === sourceTerms.length - 1 ? text.length : (sourceTerms[last]?.end ?? match.end),
+  }
+}
+
+function renderFragment(text: string, fragment: TextRange, matches: readonly TextRange[]): string {
+  const included = matches
+    .filter((match) => overlaps(fragment, match))
+    .map((match) => ({
+      start: Math.max(fragment.start, match.start),
+      end: Math.min(fragment.end, match.end),
+    }))
+
+  let cursor = fragment.start
+  let rendered = ''
+  for (const match of included) {
+    rendered += text.slice(cursor, match.start)
+    rendered += `<mark>${text.slice(match.start, match.end)}</mark>`
+    cursor = match.end
+  }
+  rendered += text.slice(cursor, fragment.end)
+  return rendered.trim()
+}
+
+function mergeRanges(ranges: readonly TextRange[]): TextRange[] {
+  const merged: TextRange[] = []
+  for (const range of uniqueRanges(ranges)) {
+    const previous = merged.at(-1)
+    if (previous == null || range.start > previous.end) {
+      merged.push({ ...range })
+      continue
+    }
+    previous.end = Math.max(previous.end, range.end)
+  }
+  return merged
+}
+
+function uniqueRanges(ranges: readonly TextRange[]): TextRange[] {
+  const unique = new Map<string, TextRange>()
+  for (const range of ranges.toSorted(compareRanges)) {
+    unique.set(`${range.start}:${range.end}`, range)
+  }
+  return [...unique.values()]
+}
+
+function overlaps(left: TextRange, right: TextRange): boolean {
+  return left.start < right.end && right.start < left.end
+}
+
+function compareTokenRanges(left: LogicalToken, right: LogicalToken): number {
+  return left.start - right.start || left.end - right.end
+}
+
+function compareRanges(left: TextRange, right: TextRange): number {
+  return left.start - right.start || left.end - right.end
+}
+
+function assertPositiveInteger(value: number, name: string): void {
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new RangeError(`Portable highlight ${name} must be a positive safe integer`)
+  }
+}

--- a/packages/search-analysis/src/index.ts
+++ b/packages/search-analysis/src/index.ts
@@ -8,6 +8,11 @@
 
 export { createPortableSearchAnalyzer, resolveMatching } from './analyzer.js'
 export {
+  type HighlightPortableTextInput,
+  highlightPortableText,
+  type PortableHighlightOptions,
+} from './highlight.js'
+export {
   canonicalSegmenterLocale,
   detectSearchLocale,
   resolveSearchLocale,

--- a/packages/search-conformance/README.md
+++ b/packages/search-conformance/README.md
@@ -8,6 +8,7 @@ connections itself. Each adapter supplies hooks for its real test backend:
 runSearchProviderConformanceSuite({
   createProvider,
   createPortableProvider,
+  expectedCapabilities: { highlights: true },
   migrate,
   reset,
   teardown,
@@ -19,7 +20,7 @@ The aggregate runner covers:
 - capability declarations;
 - idempotent upsert, removal, collection/global rebuilds, and query scoping;
 - pagination and published-status filtering;
-- all/any, minimum-should-match, and phrase behavior; and
+- all/any, minimum-should-match, phrase behavior, and highlighted snippets; and
 - portable normalization, SQL stopwords, identifiers, language expansions,
   Han-bigram fallback, relative weighting, and analyzer fingerprints.
 

--- a/packages/search-conformance/src/index.ts
+++ b/packages/search-conformance/src/index.ts
@@ -6,17 +6,19 @@
  * Copyright (c) Infonomic Company Limited
  */
 
-import type { SearchProvider } from '@byline/core'
+import type { SearchCapabilities, SearchProvider } from '@byline/core'
 import type { PortableSearchAnalyzer } from '@byline/search-analysis'
 import { afterAll, beforeAll } from 'vitest'
 
 import { capabilitiesSuite } from './suites/capabilities.js'
 import { fullTextMatchingSuite } from './suites/full-text-matching.js'
+import { highlightingSuite } from './suites/highlighting.js'
 import { lifecycleSuite } from './suites/lifecycle.js'
 import { portableAnalysisSuite } from './suites/portable-analysis.js'
 
 export { capabilitiesSuite } from './suites/capabilities.js'
 export { fullTextMatchingSuite } from './suites/full-text-matching.js'
+export { highlightingSuite } from './suites/highlighting.js'
 export { lifecycleSuite } from './suites/lifecycle.js'
 export { portableAnalysisSuite } from './suites/portable-analysis.js'
 
@@ -28,6 +30,8 @@ export { portableAnalysisSuite } from './suites/portable-analysis.js'
 export interface SearchConformanceHooks {
   /** Construct the adapter with its ordinary production defaults. */
   createProvider(): SearchProvider | Promise<SearchProvider>
+  /** Capabilities this adapter is expected to advertise. */
+  expectedCapabilities?: Partial<SearchCapabilities>
   /**
    * Construct the adapter with an explicit portable analyzer. Supply this
    * only when `capabilities.fullText.portableAnalysis` is true; doing so
@@ -65,5 +69,6 @@ export function runSearchProviderConformanceSuite(hooks: SearchConformanceHooks)
   capabilitiesSuite(hooks)
   lifecycleSuite(hooks)
   fullTextMatchingSuite(hooks)
+  highlightingSuite(hooks)
   portableAnalysisSuite(hooks)
 }

--- a/packages/search-conformance/src/suites/capabilities.ts
+++ b/packages/search-conformance/src/suites/capabilities.ts
@@ -32,6 +32,11 @@ export function capabilitiesSuite(hooks: SearchConformanceHooks): void {
       })
     })
 
+    it('declares the adapter capabilities expected by its conformance harness', () => {
+      if (hooks.expectedCapabilities == null) return
+      expect(provider.capabilities).toMatchObject(hooks.expectedCapabilities)
+    })
+
     it('declares portable analysis when a portable-provider factory is supplied', async () => {
       if (hooks.createPortableProvider == null) return
       const portableProvider = await hooks.createPortableProvider(createPortableSearchAnalyzer())

--- a/packages/search-conformance/src/suites/highlighting.ts
+++ b/packages/search-conformance/src/suites/highlighting.ts
@@ -1,0 +1,46 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import type { SearchProvider } from '@byline/core'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { searchDocument } from '../fixtures.js'
+import type { SearchConformanceHooks } from '../index.js'
+
+export function highlightingSuite(hooks: SearchConformanceHooks): void {
+  let provider: SearchProvider
+
+  describe.sequential('SearchProvider highlighting', () => {
+    beforeEach(async () => {
+      await hooks.reset()
+      provider = await hooks.createProvider()
+    })
+
+    it('returns marked original-text snippets when highlighting is advertised', async () => {
+      await provider.upsert(
+        searchDocument('Before Forest restoration <script>alert(1)</script> after.', {
+          documentId: 'highlighted',
+        })
+      )
+
+      const result = await provider.search({
+        query: 'forest',
+        collectionPath: 'search-conformance',
+      })
+      const highlight = result.hits[0]?.highlights?.body?.[0]
+
+      if (!provider.capabilities.highlights) {
+        expect(highlight).toBeUndefined()
+        return
+      }
+      expect(highlight).toBe(
+        'Before <mark>Forest</mark> restoration <script>alert(1)</script> after.'
+      )
+    })
+  })
+}

--- a/packages/search-mysql/README.md
+++ b/packages/search-mysql/README.md
@@ -84,14 +84,15 @@ DROP TABLE IF EXISTS byline_search_migrations;
 ## Capabilities
 
 The adapter supports portable analysis, `all` and `any` matching,
-minimum-should-match, phrase constraints, and field weighting. Facet data and
-typed filters are retained in JSON for future query features.
+minimum-should-match, phrase constraints, field weighting, and highlighted
+snippets built from stored original body text with the shared portable token
+offsets. Facet data and typed filters are retained in JSON for future query
+features.
 
-Highlighting, facet aggregation, structured filtering, typo tolerance,
-semantic retrieval, and BM25 are currently reported as unsupported. MySQL's
-native relevance score contributes term frequency and inverse document
-frequency, but the provider does not claim BM25 because MySQL does not expose a
-stable BM25 contract.
+Facet aggregation, structured filtering, typo tolerance, semantic retrieval,
+and BM25 are currently reported as unsupported. MySQL's native relevance score
+contributes term frequency and inverse document frequency, but the provider
+does not claim BM25 because MySQL does not expose a stable BM25 contract.
 
 ## Language and locale
 

--- a/packages/search-mysql/src/mysql-search-provider.ts
+++ b/packages/search-mysql/src/mysql-search-provider.ts
@@ -14,7 +14,7 @@ import type {
   SearchQuery,
   SearchResults,
 } from '@byline/core'
-import type { PortableSearchAnalyzer } from '@byline/search-analysis'
+import { highlightPortableText, type PortableSearchAnalyzer } from '@byline/search-analysis'
 import type { Pool, PoolConnection, ResultSetHeader, RowDataPacket } from 'mysql2/promise'
 
 import { buildIndexRow, type IndexRow } from './build-index-row.js'
@@ -28,7 +28,7 @@ const CAPABILITIES: SearchCapabilities = {
   semantic: false,
   bm25: false,
   weighting: true,
-  highlights: false,
+  highlights: true,
   fullText: {
     nativeAnalysis: false,
     portableAnalysis: true,
@@ -167,7 +167,7 @@ export class MySqlSearchProvider implements SearchProvider {
     const limit = query.limit ?? 20
     const offset = query.offset ?? 0
     const [hitRows] = await this.pool.query<HitRow[]>(
-      `SELECT d.collection_path, d.document_id, d.locale, d.title, d.path,
+      `SELECT d.collection_path, d.document_id, d.locale, d.title, d.path, d.body,
               (${scoreSql}) AS score
        FROM byline_search_documents d
        WHERE ${whereSql}
@@ -185,14 +185,22 @@ export class MySqlSearchProvider implements SearchProvider {
       ]
     )
 
-    const hits: SearchHit[] = hitRows.map((row) => ({
-      collectionPath: row.collection_path,
-      documentId: row.document_id,
-      locale: row.locale,
-      title: row.title,
-      path: row.path,
-      score: Number(row.score),
-    }))
+    const hits: SearchHit[] = hitRows.map((row) => {
+      const highlight = highlightPortableText({
+        text: row.body,
+        plan,
+        analyzer: this.analyzer,
+      })
+      return {
+        collectionPath: row.collection_path,
+        documentId: row.document_id,
+        locale: row.locale,
+        title: row.title,
+        path: row.path,
+        score: Number(row.score),
+        ...(highlight == null ? {} : { highlights: { body: [highlight] } }),
+      }
+    })
     return { hits, total }
   }
 
@@ -237,6 +245,7 @@ interface HitRow extends RowDataPacket {
   locale: string
   title: string
   path: string | null
+  body: string
   score: number | string
 }
 

--- a/packages/search-mysql/tests/conformance.integration.test.ts
+++ b/packages/search-mysql/tests/conformance.integration.test.ts
@@ -24,6 +24,7 @@ const pool = mysql.createPool({
 runSearchProviderConformanceSuite({
   createProvider: () => mysqlSearch({ pool, defaultLocale: 'en' }),
   createPortableProvider: (analyzer: PortableSearchAnalyzer) => mysqlSearch({ pool, analyzer }),
+  expectedCapabilities: { highlights: true },
 
   async migrate(): Promise<void> {
     await migrate(pool)

--- a/packages/search-postgres/README.md
+++ b/packages/search-postgres/README.md
@@ -108,7 +108,7 @@ option 2 so startup is deterministic and DDL permissions are explicit.
 ```ts
 provider.capabilities
 // { facets: false, typoTolerance: false, semantic: false,
-//   bm25: false, weighting: true, highlights: false,
+//   bm25: false, weighting: true, highlights: true,
 //   fullText: {
 //     nativeAnalysis: false, portableAnalysis: true,
 //     allTerms: true, anyTerms: true,
@@ -117,8 +117,10 @@ provider.capabilities
 ```
 
 The `tsvector` + `ts_rank` floor supports per-field **weighting** and all shared
-full-text matching policies. Facet *data* is indexed, but facet *aggregation*
-queries, structured `where` filtering, matched-source highlighting, fuzzy
+full-text matching policies. Ranked rows are highlighted from stored original
+body text through the shared portable token offsets, so snippets preserve the
+source spelling while matching normalized and expanded terms. Facet *data* is
+indexed, but facet *aggregation* queries, structured `where` filtering, fuzzy
 matching, BM25 ranking, and semantic/vector retrieval are follow-ups. The
 capability flags let consumers enable only supported behavior.
 

--- a/packages/search-postgres/src/postgres-search-provider.ts
+++ b/packages/search-postgres/src/postgres-search-provider.ts
@@ -14,7 +14,7 @@ import type {
   SearchQuery,
   SearchResults,
 } from '@byline/core'
-import type { PortableSearchAnalyzer } from '@byline/search-analysis'
+import { highlightPortableText, type PortableSearchAnalyzer } from '@byline/search-analysis'
 import type { Pool, PoolClient } from 'pg'
 
 import { buildIndexRow, type IndexRow } from './build-index-row.js'
@@ -30,7 +30,7 @@ const CAPABILITIES: SearchCapabilities = {
   semantic: false,
   bm25: false,
   weighting: true,
-  highlights: false,
+  highlights: true,
   fullText: {
     nativeAnalysis: false,
     portableAnalysis: true,
@@ -181,7 +181,7 @@ export class PostgresSearchProvider implements SearchProvider {
     const offsetParam = params.length + 2
     const hitResult = await this.pool.query<HitRow>(
       `${cte}
-       SELECT d.collection_path, d.document_id, d.locale, d.title, d.path,
+       SELECT d.collection_path, d.document_id, d.locale, d.title, d.path, d.body,
               ts_rank(d.search_vector, q.query) AS score
        FROM byline_search_documents d, q
        WHERE ${whereSql}
@@ -190,14 +190,22 @@ export class PostgresSearchProvider implements SearchProvider {
       [...params, limit, offset]
     )
 
-    const hits: SearchHit[] = hitResult.rows.map((row) => ({
-      collectionPath: row.collection_path,
-      documentId: row.document_id,
-      locale: row.locale,
-      title: row.title,
-      path: row.path,
-      score: Number(row.score),
-    }))
+    const hits: SearchHit[] = hitResult.rows.map((row) => {
+      const highlight = highlightPortableText({
+        text: row.body,
+        plan,
+        analyzer: this.analyzer,
+      })
+      return {
+        collectionPath: row.collection_path,
+        documentId: row.document_id,
+        locale: row.locale,
+        title: row.title,
+        path: row.path,
+        score: Number(row.score),
+        ...(highlight == null ? {} : { highlights: { body: [highlight] } }),
+      }
+    })
     return { hits, total }
   }
 
@@ -233,6 +241,7 @@ interface HitRow {
   locale: string
   title: string
   path: string | null
+  body: string
   score: number
 }
 

--- a/packages/search-postgres/tests/conformance.integration.test.ts
+++ b/packages/search-postgres/tests/conformance.integration.test.ts
@@ -18,6 +18,7 @@ const pool = new pg.Pool({ connectionString, max: 4 })
 runSearchProviderConformanceSuite({
   createProvider: () => postgresSearch({ pool, defaultLocale: 'en' }),
   createPortableProvider: (analyzer: PortableSearchAnalyzer) => postgresSearch({ pool, analyzer }),
+  expectedCapabilities: { highlights: true },
 
   async migrate(): Promise<void> {
     await migrate(pool)


### PR DESCRIPTION
## Summary

- add an offset-aware `highlightPortableText()` utility to `@byline/search-analysis`
- match stored original-text ranges through the same kind-aware portable tokens used for exact, normalized, expanded, identifier, and Han-gram search
- return bounded `<mark>…</mark>` fragments from both PostgreSQL and MySQL as `highlights.body[0]`
- advertise `capabilities.highlights: true` in both built-in SQL providers
- add shared highlighting conformance coverage and adapter-specific expected-capability assertions
- update the existing docs search UI comment, developer documentation, package READMEs, and pending release notes

## Implementation notes

The existing provider schemas already retain original `body` text, so this change requires no database migration, compatibility path, or reindex. Highlighting runs in Node.js only for the ranked rows on the requested page; it does not participate in corpus scanning or index writes.

The public `SearchHit.highlights` shape is unchanged. The current docs UI continues to parse the marker delimiters into React `<mark>` elements while rendering surrounding source content as escaped text.

## Validation

- `pnpm byline:generate:check`
- `pnpm docs:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm knip`
- `pnpm test`
- `pnpm build`
- PostgreSQL provider integration/conformance suite: 18 tests passed
- MySQL provider integration/conformance suite: 18 tests passed
- focused analysis/PostgreSQL/MySQL unit suites: 53 tests passed
- `git diff --check`

## Commit provenance

The commit includes the required DCO `Signed-off-by` trailer and has no cryptographic signature or co-author trailer.