### PR TITLE
fix(search): harden portable analysis

### DIFF
--- a/.changeset/search-analysis-contracts.md
+++ b/.changeset/search-analysis-contracts.md
@@ -14,4 +14,7 @@ snippets from the same portable token offsets. Collection and zone search now
 pass explicit all/any, minimum-should-match, and phrase intent to search
 providers. Search providers must declare their full-text capabilities and
 implement index clearing so every derived projection remains explicitly
-rebuildable.
+rebuildable. Query analysis rejects inputs above the shared 1,024-code-unit
+limit, identifier extraction remains linear on long unbroken text, and
+SKU/version constituents augment their complete identifier at one logical
+position instead of being removed from recall.

--- a/.changeset/search-mysql-adapter.md
+++ b/.changeset/search-mysql-adapter.md
@@ -11,4 +11,7 @@ conformance suite. Ranked hits include portable highlighted snippets from the
 stored original body text.
 
 Documented and wired `@byline/db-mysql` installations to use the real search
-provider instead of a no-op workaround.
+provider instead of a no-op workaround. Fingerprint checks use collection
+metadata rather than scanning indexed documents, and phrase translation now
+emits only the source and expansion-kind variants represented by physical
+matching streams.

--- a/.changeset/search-postgres-portable-analysis.md
+++ b/.changeset/search-postgres-portable-analysis.md
@@ -13,4 +13,6 @@ native analyzer.
 This is a direct cutover for the disposable search projection: reset the
 provider-owned search tables, apply the rewritten `0001_init.sql`, and rebuild
 published indexes. There is no native compatibility mode or in-place search
-migration.
+migration. Fingerprint checks read the per-collection metadata projection
+instead of scanning indexed documents, including zone-scoped checks, and
+ranked pagination uses stable document tie-breaks.

--- a/docs/05-reading-and-delivery/09-multilingual-search-analysis.md
+++ b/docs/05-reading-and-delivery/09-multilingual-search-analysis.md
@@ -59,7 +59,9 @@ The defaults are conservative: every analyzed concept must match, and quoted
 spans retain phrase intent. `minimumShouldMatch` is a positive integer and is
 only valid with `operator: 'any'`. `phrase: 'required'` makes the complete
 non-empty query an ordered phrase; `phrase: 'off'` disables even explicitly
-quoted phrase constraints.
+quoted phrase constraints. `SearchQuery.query` accepts at most 1,024 UTF-16
+code units. Portable analyzers reject a longer value before normalization or
+identifier extraction.
 
 These options describe product behavior rather than backend syntax. An adapter
 must translate them faithfully or advertise the missing feature through
@@ -77,7 +79,11 @@ must translate them faithfully or advertise the missing feature through
    then uses the configured fallback.
 3. Extract identifiers before general word segmentation. URLs, email
    addresses, mentions, hashtags, SKUs, versions, and selected technical terms
-   such as `C++`, `C#`, and `Node.js` remain single logical terms.
+   such as `C++`, `C#`, and `Node.js` remain single logical terms. URL and
+   email components stay protected from noisy word-level recall. SKU and
+   version constituents remain exact alternatives at the identifier's one
+   logical position, so `COVID-19` can match `covid`, `19`, or the complete
+   identifier without changing phrase adjacency.
 4. Segment remaining words with the Node.js runtime's ICU-backed
    `Intl.Segmenter`.
 5. Run optional locale-aware expansion plug-ins. Stems, lemmas, and normalized
@@ -114,7 +120,7 @@ character. SQL full-text parsers may discard or split those values differently.
 
 - lowercase ASCII alphanumeric output;
 - distinct prefixes for exact, stem, lemma, normalized, identifier, and gram
-  terms;
+terms;
 - enough encoded characters for a one-character source term to clear common
   minimum-token limits; and
 - deterministic SHA-256 fallback for terms above the configured length.
@@ -137,7 +143,8 @@ The highlighter merges overlapping source ranges and selects at most two
 page, not while scanning the corpus. Both built-in SQL providers return the
 result as `highlights.body[0]`, with `<mark>…</mark>` delimiters. Consumers must
 parse the delimiters and render the remaining source as text; the complete
-snippet is not trusted HTML.
+snippet is not trusted HTML. Overlapping identifier and constituent ranges
+count as one logical source term when applying the fragment word budget.
 
 ## Fingerprints and reindexing
 
@@ -151,7 +158,9 @@ A mismatch means stored terms and query terms may no longer be comparable.
 The provider should report the mismatch before searching or indexing the
 affected collection, and an explicit reindex should replace the projection and
 stored fingerprint. Adapters must not silently mix fingerprints within one
-active index.
+active index. The built-in SQL providers keep collection zones beside this
+metadata so collection- and zone-scoped checks do not scan the document
+projection on every query.
 
 ## Adapter rollout
 

--- a/packages/client/src/collection-handle.ts
+++ b/packages/client/src/collection-handle.ts
@@ -51,7 +51,7 @@ import {
   resolveReadSecurityFilters,
 } from './read-context.js'
 import { shapeDocument, shapePopulatedInPlace } from './response.js'
-import { finalizeSearchHits } from './search.js'
+import { assertSearchQueryLength, finalizeSearchHits } from './search.js'
 import type { BylineClient } from './client.js'
 import type {
   AuditLogOptions,
@@ -232,6 +232,7 @@ export class CollectionHandle<TFields extends Record<string, any> = Record<strin
    * Throws `ERR_VALIDATION` when no provider is registered.
    */
   async search(options: CollectionSearchOptions): Promise<ClientSearchResults> {
+    assertSearchQueryLength(options.query)
     const readMode = resolveReadMode(options.status)
     const readCtx = createReadContext()
     const requestContext = await this.resolveAndAssertRead(readMode, readCtx)

--- a/packages/client/src/search.test.node.ts
+++ b/packages/client/src/search.test.node.ts
@@ -1,0 +1,27 @@
+/**
+ * This Source Code is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) Infonomic Company Limited
+ */
+
+import { MAX_SEARCH_QUERY_LENGTH } from '@byline/core'
+import { describe, expect, it } from 'vitest'
+
+import { assertSearchQueryLength } from './search.js'
+
+describe('search query validation', () => {
+  it('accepts the portable query limit and rejects longer input', () => {
+    expect(() => assertSearchQueryLength('a'.repeat(MAX_SEARCH_QUERY_LENGTH))).not.toThrow()
+    expect(() => assertSearchQueryLength('a'.repeat(MAX_SEARCH_QUERY_LENGTH + 1))).toThrowError(
+      expect.objectContaining({
+        code: 'ERR_VALIDATION',
+        details: {
+          maximumLength: MAX_SEARCH_QUERY_LENGTH,
+          actualLength: MAX_SEARCH_QUERY_LENGTH + 1,
+        },
+      })
+    )
+  })
+})

--- a/packages/client/src/search.ts
+++ b/packages/client/src/search.ts
@@ -25,6 +25,7 @@ import {
   createReadContext,
   ERR_VALIDATION,
   getCollectionAdminConfig,
+  MAX_SEARCH_QUERY_LENGTH,
   resolveItemViewColumns,
   resolveSearchZones,
 } from '@byline/core'
@@ -203,6 +204,7 @@ export async function zoneSearch(
   client: BylineClient<any>,
   options: ZoneSearchOptions
 ): Promise<ClientSearchResults> {
+  assertSearchQueryLength(options.query)
   const provider = client.searchProvider
   if (provider == null) {
     throw ERR_VALIDATION({
@@ -290,4 +292,15 @@ export async function zoneSearch(
   return aggregateRestricted
     ? { hits, total: hits.length }
     : { hits, total: results.total, facets: results.facets }
+}
+
+export function assertSearchQueryLength(query: string): void {
+  if (query.length <= MAX_SEARCH_QUERY_LENGTH) return
+  throw ERR_VALIDATION({
+    message: `Search query exceeds the maximum length of ${MAX_SEARCH_QUERY_LENGTH} UTF-16 code units.`,
+    details: {
+      maximumLength: MAX_SEARCH_QUERY_LENGTH,
+      actualLength: query.length,
+    },
+  })
 }

--- a/packages/core/src/@types/search-types.ts
+++ b/packages/core/src/@types/search-types.ts
@@ -190,13 +190,16 @@ export interface SearchMatching {
   phrase?: SearchPhraseMode
 }
 
+/** Maximum UTF-16 length accepted for one full-text query. */
+export const MAX_SEARCH_QUERY_LENGTH = 1_024
+
 /**
  * A search request. Either collection-scoped (`collectionPath`) for
  * homogeneous results, or zone-scoped (`zone`) for heterogeneous
  * cross-collection results — see the two `client.search()` entry points.
  */
 export interface SearchQuery {
-  /** The free-text query string. */
+  /** The free-text query string, limited to {@link MAX_SEARCH_QUERY_LENGTH}. */
   query: string
   /**
    * Explicit full-text matching semantics. Defaults to all concepts required

--- a/packages/search-analysis/src/analyzer.test.node.ts
+++ b/packages/search-analysis/src/analyzer.test.node.ts
@@ -12,6 +12,7 @@ import { MAX_SEARCH_QUERY_LENGTH } from '@byline/core'
 import { describe, expect, it } from 'vitest'
 
 import { createPortableSearchAnalyzer, resolveMatching } from './analyzer.js'
+import { extractIdentifierSpans } from './identifiers.js'
 import { detectSearchLocale, resolveSearchLocale } from './locale.js'
 import { normalizeForSearch } from './normalize.js'
 import type { SearchTokenExpander } from './types.js'
@@ -110,12 +111,29 @@ describe('portable search analysis', () => {
     expect(quoted.phrases).toEqual([{ conceptIndexes: [0, 1], explicit: true }])
   })
 
-  it('keeps adversarial unbroken text analysis bounded', () => {
+  it('keeps adversarial identifier extraction below the quadratic baseline', () => {
+    extractIdentifierSpans('数'.repeat(1_000))
+
+    for (const character of ['数', 'a']) {
+      const shortStarted = performance.now()
+      extractIdentifierSpans(character.repeat(5_000))
+      const shortDuration = performance.now() - shortStarted
+
+      const longStarted = performance.now()
+      extractIdentifierSpans(character.repeat(40_000))
+      const longDuration = performance.now() - longStarted
+
+      // CI runs package suites concurrently, so this is a regression guard,
+      // not a production latency target. The old unbounded email rule took
+      // more than 10 seconds and grew roughly 50–60x for this 8x input.
+      expect(longDuration).toBeLessThan(Math.max(2_500, shortDuration * 32))
+    }
+  })
+
+  it('analyzes adversarial unbroken text within the unit-test timeout', () => {
     const analyzer = createPortableSearchAnalyzer()
     for (const text of ['数'.repeat(40_000), 'a'.repeat(40_000)]) {
-      const started = performance.now()
-      analyzer.analyzeText({ text })
-      expect(performance.now() - started).toBeLessThan(1_000)
+      expect(analyzer.analyzeText({ text }).normalized).toHaveLength(40_000)
     }
   })
 

--- a/packages/search-analysis/src/analyzer.test.node.ts
+++ b/packages/search-analysis/src/analyzer.test.node.ts
@@ -6,6 +6,9 @@
  * Copyright (c) Infonomic Company Limited
  */
 
+import { performance } from 'node:perf_hooks'
+
+import { MAX_SEARCH_QUERY_LENGTH } from '@byline/core'
 import { describe, expect, it } from 'vitest'
 
 import { createPortableSearchAnalyzer, resolveMatching } from './analyzer.js'
@@ -60,6 +63,70 @@ describe('portable search analysis', () => {
     ])
     expect(analyzed.exactTokens.map((token) => token.value)).toContain('see')
     expect(analyzed.exactTokens.map((token) => token.value)).toContain('mail')
+    expect(analyzed.exactTokens.map((token) => token.value)).not.toContain('example')
+    expect(analyzed.exactTokens.map((token) => token.value)).not.toContain('tést')
+  })
+
+  it('retains SKU and version constituents at one logical source position', () => {
+    const analyzer = createPortableSearchAnalyzer()
+    const analyzed = analyzer.analyzeText({
+      text: 'COVID-19 cases utf-8 encoding Section 1.2',
+    })
+    const positions = [...analyzed.exactTokens, ...analyzed.identifierTokens].map(
+      ({ kind, value, position }) => ({ kind, value, position })
+    )
+
+    expect(positions).toEqual(
+      expect.arrayContaining([
+        { kind: 'exact', value: 'covid', position: 0 },
+        { kind: 'exact', value: '19', position: 0 },
+        { kind: 'identifier', value: 'covid-19', position: 0 },
+        { kind: 'exact', value: 'cases', position: 1 },
+        { kind: 'exact', value: 'utf', position: 2 },
+        { kind: 'exact', value: '8', position: 2 },
+        { kind: 'identifier', value: 'utf-8', position: 2 },
+        { kind: 'exact', value: 'encoding', position: 3 },
+        { kind: 'exact', value: 'section', position: 4 },
+        { kind: 'exact', value: '1.2', position: 5 },
+        { kind: 'identifier', value: '1.2', position: 5 },
+      ])
+    )
+  })
+
+  it('uses a complete identifier as one query concept', () => {
+    const analyzer = createPortableSearchAnalyzer()
+    const cases = [
+      ['covid-19', 1],
+      ['covid-19 vaccine', 2],
+      ['utf-8 encoding', 2],
+      ['Section 1.2', 2],
+    ] as const
+
+    for (const [query, conceptCount] of cases) {
+      expect(analyzer.analyzeQuery({ query }).concepts, query).toHaveLength(conceptCount)
+    }
+    const quoted = analyzer.analyzeQuery({ query: '"covid-19 cases"' })
+    expect(quoted.concepts[0]?.identifierTokens.map((token) => token.value)).toEqual(['covid-19'])
+    expect(quoted.phrases).toEqual([{ conceptIndexes: [0, 1], explicit: true }])
+  })
+
+  it('keeps adversarial unbroken text analysis bounded', () => {
+    const analyzer = createPortableSearchAnalyzer()
+    for (const text of ['数'.repeat(40_000), 'a'.repeat(40_000)]) {
+      const started = performance.now()
+      analyzer.analyzeText({ text })
+      expect(performance.now() - started).toBeLessThan(1_000)
+    }
+  })
+
+  it('rejects an over-long query before analysis', () => {
+    const analyzer = createPortableSearchAnalyzer()
+    expect(() =>
+      analyzer.analyzeQuery({ query: 'a'.repeat(MAX_SEARCH_QUERY_LENGTH) })
+    ).not.toThrow()
+    expect(() => analyzer.analyzeQuery({ query: 'a'.repeat(MAX_SEARCH_QUERY_LENGTH + 1) })).toThrow(
+      RangeError
+    )
   })
 
   it('emits ordered overlapping Han bigrams without replacing exact terms', () => {

--- a/packages/search-analysis/src/analyzer.ts
+++ b/packages/search-analysis/src/analyzer.ts
@@ -6,7 +6,7 @@
  * Copyright (c) Infonomic Company Limited
  */
 
-import type { SearchMatching } from '@byline/core'
+import { MAX_SEARCH_QUERY_LENGTH, type SearchMatching } from '@byline/core'
 
 import { extractIdentifierSpans, maskIdentifierSpans } from './identifiers.js'
 import { canonicalSegmenterLocale, resolveSearchLocale } from './locale.js'
@@ -28,7 +28,7 @@ import type {
 const PIPELINE_VERSION = 'portable1'
 const NORMALIZATION_VERSION = 'nfkc-lower1'
 const LOCALE_VERSION = 'locale1'
-const IDENTIFIER_VERSION = 'identifiers1'
+const IDENTIFIER_VERSION = 'identifiers2'
 const GRAM_VERSION = 'han-bigram1'
 
 const wordSegmenters = new Map<string, Intl.Segmenter>()
@@ -120,9 +120,7 @@ class PortableSearchAnalyzerImpl implements PortableSearchAnalyzer {
     sourceTokens.sort(
       (a, b) => a.normalizedStart - b.normalizedStart || a.normalizedEnd - b.normalizedEnd
     )
-    sourceTokens.forEach((token, position) => {
-      token.position = position
-    })
+    assignLogicalPositions(sourceTokens)
 
     const derivedTokens: LogicalToken[] = []
     for (const token of sourceTokens) {
@@ -156,6 +154,11 @@ class PortableSearchAnalyzerImpl implements PortableSearchAnalyzer {
   }
 
   analyzeQuery(input: AnalyzeQueryInput): PortableQueryPlan {
+    if (input.query.length > MAX_SEARCH_QUERY_LENGTH) {
+      throw new RangeError(
+        `Search query exceeds the maximum length of ${MAX_SEARCH_QUERY_LENGTH} UTF-16 code units`
+      )
+    }
     const matching = resolveMatching(input.matching)
     const full = this.analyzeText({ text: input.query, locale: input.locale })
     const parts = splitQueryParts(input.query)
@@ -167,29 +170,45 @@ class PortableSearchAnalyzerImpl implements PortableSearchAnalyzer {
       const analyzed = this.analyzeText({ text: part.text, locale: full.locale })
       const normalizedBase = normalizeForSearch(input.query.slice(0, part.start)).value.length
       const partConceptIndexes: number[] = []
-      const sourceTokens = [...analyzed.exactTokens, ...analyzed.identifierTokens].sort(
-        (a, b) => a.position - b.position
-      )
+      const sourceGroups = groupTokensByPosition([
+        ...analyzed.exactTokens,
+        ...analyzed.identifierTokens,
+      ])
 
-      for (const source of sourceTokens) {
+      for (const sourceGroup of sourceGroups) {
         const conceptIndex = concepts.length
         const queryToken = (token: LogicalToken): LogicalToken =>
           rebaseQueryToken(token, part.start, normalizedBase, conceptIndex)
+        const identifiers = sourceGroup.filter((token) => token.kind === 'identifier')
+        const exact = identifiers.length === 0 ? sourceGroup : []
+        const source = identifiers[0] ?? exact[0]
+        if (source == null) continue
         partConceptIndexes.push(conceptIndex)
         concepts.push({
           index: conceptIndex,
           position: conceptIndex,
-          exactTokens: source.kind === 'exact' ? [queryToken(source)] : [],
-          stemTokens: analyzed.derivedTokens
-            .filter((token) => token.kind === 'stem' && token.position === source.position)
-            .map(queryToken),
-          lemmaTokens: analyzed.derivedTokens
-            .filter((token) => token.kind === 'lemma' && token.position === source.position)
-            .map(queryToken),
-          normalizedTokens: analyzed.derivedTokens
-            .filter((token) => token.kind === 'normalized' && token.position === source.position)
-            .map(queryToken),
-          identifierTokens: source.kind === 'identifier' ? [queryToken(source)] : [],
+          exactTokens: exact.map(queryToken),
+          stemTokens:
+            identifiers.length === 0
+              ? analyzed.derivedTokens
+                  .filter((token) => token.kind === 'stem' && token.position === source.position)
+                  .map(queryToken)
+              : [],
+          lemmaTokens:
+            identifiers.length === 0
+              ? analyzed.derivedTokens
+                  .filter((token) => token.kind === 'lemma' && token.position === source.position)
+                  .map(queryToken)
+              : [],
+          normalizedTokens:
+            identifiers.length === 0
+              ? analyzed.derivedTokens
+                  .filter(
+                    (token) => token.kind === 'normalized' && token.position === source.position
+                  )
+                  .map(queryToken)
+              : [],
+          identifierTokens: identifiers.map(queryToken),
           gramTokens: analyzed.gramTokens
             .filter(
               (token) =>
@@ -233,6 +252,36 @@ class PortableSearchAnalyzerImpl implements PortableSearchAnalyzer {
   }
 }
 
+function assignLogicalPositions(tokens: LogicalToken[]): void {
+  let position = -1
+  let groupEnd = -1
+
+  for (const token of tokens) {
+    if (position === -1 || token.normalizedStart >= groupEnd) {
+      position += 1
+      groupEnd = token.normalizedEnd
+    } else {
+      groupEnd = Math.max(groupEnd, token.normalizedEnd)
+    }
+    token.position = position
+  }
+}
+
+function groupTokensByPosition(tokens: readonly LogicalToken[]): LogicalToken[][] {
+  const groups = new Map<number, LogicalToken[]>()
+  for (const token of tokens.toSorted(
+    (left, right) =>
+      left.position - right.position ||
+      left.normalizedStart - right.normalizedStart ||
+      left.normalizedEnd - right.normalizedEnd
+  )) {
+    const group = groups.get(token.position)
+    if (group == null) groups.set(token.position, [token])
+    else group.push(token)
+  }
+  return [...groups.values()]
+}
+
 function logicalToken(
   kind: LogicalToken['kind'],
   value: string,
@@ -262,6 +311,9 @@ function buildHanBigrams(
   sourceTokens: readonly LogicalToken[]
 ): LogicalToken[] {
   const grams: LogicalToken[] = []
+  let sourceIndex = 0
+  let previousPosition = 0
+
   for (const match of text.matchAll(/\p{Script=Han}+/gu)) {
     const run = match[0]
     const runStart = match.index
@@ -277,13 +329,19 @@ function buildHanBigrams(
       const first = characters[index]
       const second = characters[index + 1]
       if (first == null || second == null) continue
-      const containingToken = sourceTokens.find(
-        (token) => token.normalizedStart <= first.start && token.normalizedEnd >= first.end
-      )
-      const previousPosition = sourceTokens.findLastIndex(
-        (token) => token.normalizedStart <= first.start
-      )
-      const position = containingToken?.position ?? Math.max(0, previousPosition)
+      while (sourceIndex < sourceTokens.length) {
+        const source = sourceTokens[sourceIndex]
+        if (source == null || source.normalizedEnd > first.start) break
+        previousPosition = source.position
+        sourceIndex += 1
+      }
+      const candidate = sourceTokens[sourceIndex]
+      const position =
+        candidate != null &&
+        candidate.normalizedStart <= first.start &&
+        candidate.normalizedEnd >= first.end
+          ? candidate.position
+          : previousPosition
       grams.push(
         logicalToken(
           'gram',

--- a/packages/search-analysis/src/highlight.test.node.ts
+++ b/packages/search-analysis/src/highlight.test.node.ts
@@ -99,6 +99,21 @@ describe('portable highlighting', () => {
     expect(highlighted?.split(/\s+/)).toHaveLength(17)
   })
 
+  it('counts overlapping identifier constituents as one snippet term', () => {
+    const analyzer = createPortableSearchAnalyzer()
+    const plan = analyzer.analyzeQuery({ query: 'covid' })
+
+    expect(
+      highlightPortableText({
+        text: 'COVID-19 one two three',
+        plan,
+        analyzer,
+        maxFragments: 1,
+        maxWords: 2,
+      })
+    ).toContain('one')
+  })
+
   it('returns undefined when the stored text contains no query term', () => {
     const analyzer = createPortableSearchAnalyzer()
     const plan = analyzer.analyzeQuery({ query: 'forest' })

--- a/packages/search-analysis/src/highlight.ts
+++ b/packages/search-analysis/src/highlight.ts
@@ -72,11 +72,7 @@ export function highlightPortableText({
   )
   if (matches.length === 0) return undefined
 
-  const sourceTerms = uniqueRanges(
-    [...analyzed.exactTokens, ...analyzed.identifierTokens]
-      .toSorted(compareTokenRanges)
-      .map(({ start, end }) => ({ start, end }))
-  )
+  const sourceTerms = logicalSourceRanges([...analyzed.exactTokens, ...analyzed.identifierTokens])
   const fragments = selectFragments(text, matches, sourceTerms, maxFragments, maxWords)
   if (fragments.length === 0) return undefined
 
@@ -85,6 +81,20 @@ export function highlightPortableText({
   if (text.slice(0, fragments[0]?.start ?? 0).trim().length > 0) snippet = `… ${snippet}`
   if (text.slice(fragments.at(-1)?.end ?? text.length).trim().length > 0) snippet += ' …'
   return snippet
+}
+
+function logicalSourceRanges(tokens: readonly LogicalToken[]): TextRange[] {
+  const byPosition = new Map<number, TextRange>()
+  for (const token of tokens.toSorted(compareTokenRanges)) {
+    const current = byPosition.get(token.position)
+    if (current == null) {
+      byPosition.set(token.position, { start: token.start, end: token.end })
+      continue
+    }
+    current.start = Math.min(current.start, token.start)
+    current.end = Math.max(current.end, token.end)
+  }
+  return [...byPosition.values()].toSorted(compareRanges)
 }
 
 function queryTokens(plan: PortableQueryPlan): LogicalToken[] {

--- a/packages/search-analysis/src/identifiers.ts
+++ b/packages/search-analysis/src/identifiers.ts
@@ -13,12 +13,15 @@ export interface IdentifierSpan {
   value: string
   start: number
   end: number
+  /** Whether word segmentation should retain exact constituent terms. */
+  preserveConstituents: boolean
 }
 
 interface IdentifierRule {
   kind: SearchIdentifierKind
   pattern: RegExp
   value?: (match: string) => string
+  preserveConstituents?: boolean
 }
 
 const RULES: readonly IdentifierRule[] = [
@@ -29,7 +32,7 @@ const RULES: readonly IdentifierRule[] = [
   },
   {
     kind: 'email',
-    pattern: /[\p{L}\p{N}._%+-]+@[\p{L}\p{N}.-]+\.[\p{L}]{2,}/giu,
+    pattern: /[\p{L}\p{N}._%+-]{1,64}@[\p{L}\p{N}.-]{1,255}\.[\p{L}]{2,63}/giu,
   },
   {
     kind: 'technical',
@@ -38,10 +41,12 @@ const RULES: readonly IdentifierRule[] = [
   {
     kind: 'sku',
     pattern: /\b[\p{L}]{2,}[-_]\d+\b/giu,
+    preserveConstituents: true,
   },
   {
     kind: 'version',
     pattern: /\bv?\d+(?:\.\d+){1,3}(?:-[\p{L}\p{N}.-]+)?\b/giu,
+    preserveConstituents: true,
   },
   {
     kind: 'mention',
@@ -88,7 +93,13 @@ export function extractIdentifierSpans(text: string): IdentifierSpan[] {
       const start = matchStart
       const end = start + value.length
       if (spans.some((span) => start < span.end && end > span.start)) continue
-      spans.push({ kind: rule.kind, value, start, end })
+      spans.push({
+        kind: rule.kind,
+        value,
+        start,
+        end,
+        preserveConstituents: rule.preserveConstituents ?? false,
+      })
     }
   }
 
@@ -100,6 +111,7 @@ export function maskIdentifierSpans(text: string, spans: readonly IdentifierSpan
   if (spans.length === 0) return text
   const characters = text.split('')
   for (const span of spans) {
+    if (span.preserveConstituents) continue
     for (let index = span.start; index < span.end; index++) {
       if (characters[index] !== '\n') characters[index] = ' '
     }

--- a/packages/search-conformance/src/suites/lifecycle.ts
+++ b/packages/search-conformance/src/suites/lifecycle.ts
@@ -81,8 +81,9 @@ export function lifecycleSuite(hooks: SearchConformanceHooks): void {
     })
 
     it('returns stable pagination with a corpus-wide total', async () => {
+      const updatedAt = '2026-07-26T00:00:00.000Z'
       for (const documentId of ['page-a', 'page-b', 'page-c']) {
-        await provider.upsert(searchDocument('pagination marker', { documentId }))
+        await provider.upsert(searchDocument('pagination marker', { documentId, updatedAt }))
       }
 
       const first = await provider.search({
@@ -101,7 +102,8 @@ export function lifecycleSuite(hooks: SearchConformanceHooks): void {
       expect(second).toMatchObject({ total: 3 })
       expect(first.hits).toHaveLength(1)
       expect(second.hits).toHaveLength(1)
-      expect(second.hits[0]?.documentId).not.toBe(first.hits[0]?.documentId)
+      expect(first.hits[0]?.documentId).toBe('page-a')
+      expect(second.hits[0]?.documentId).toBe('page-b')
     })
 
     it('removes one locale or every locale for a document', async () => {

--- a/packages/search-conformance/src/suites/portable-analysis.ts
+++ b/packages/search-conformance/src/suites/portable-analysis.ts
@@ -42,6 +42,40 @@ export function portableAnalysisSuite(hooks: SearchConformanceHooks): void {
       }
     })
 
+    it('retains recall for SKU constituents without leaking URL or email components', async () => {
+      await provider.upsert(
+        searchDocument(
+          'COVID-19 cases use utf-8 encoding. Contact editor@example.com at https://example.org/docs.',
+          { documentId: 'portable-identifier-constituents' }
+        )
+      )
+
+      for (const query of ['covid', '19', 'covid-19', 'utf', '8', 'utf-8']) {
+        await expect(
+          provider.search({ query, collectionPath: 'search-conformance' }),
+          query
+        ).resolves.toMatchObject({
+          total: 1,
+          hits: [{ documentId: 'portable-identifier-constituents' }],
+        })
+      }
+      for (const query of ['example', 'docs']) {
+        await expect(
+          provider.search({ query, collectionPath: 'search-conformance' }),
+          query
+        ).resolves.toMatchObject({ total: 0 })
+      }
+      await expect(
+        provider.search({
+          query: '"covid-19 cases"',
+          collectionPath: 'search-conformance',
+        })
+      ).resolves.toMatchObject({
+        total: 1,
+        hits: [{ documentId: 'portable-identifier-constituents' }],
+      })
+    })
+
     it('matches ordered Han-bigram substrings with a positive score', async () => {
       await provider.upsert(
         searchDocument('数据库搜索', {
@@ -147,6 +181,12 @@ export function portableAnalysisSuite(hooks: SearchConformanceHooks): void {
 
       await original.upsert(document)
       await expect(changed.search({ query: 'fingerprint', collectionPath })).rejects.toMatchObject({
+        code: 'SEARCH_INDEX_REINDEX_REQUIRED',
+        collectionPath,
+      })
+      await expect(
+        changed.search({ query: 'fingerprint', zone: 'search-conformance' })
+      ).rejects.toMatchObject({
         code: 'SEARCH_INDEX_REINDEX_REQUIRED',
         collectionPath,
       })

--- a/packages/search-mysql/migrations/0001_init.sql
+++ b/packages/search-mysql/migrations/0001_init.sql
@@ -35,6 +35,7 @@ CREATE TABLE IF NOT EXISTS byline_search_documents (
 CREATE TABLE IF NOT EXISTS byline_search_index_metadata (
   collection_path      varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
   analyzer_fingerprint varchar(512) CHARACTER SET ascii COLLATE ascii_bin      NOT NULL,
+  zones                json                                                   NOT NULL,
   updated_at           datetime(6)                                            NOT NULL,
   PRIMARY KEY (collection_path)
 ) ENGINE=InnoDB;

--- a/packages/search-mysql/src/migrations-data.ts
+++ b/packages/search-mysql/src/migrations-data.ts
@@ -53,6 +53,7 @@ CREATE TABLE IF NOT EXISTS byline_search_documents (
 CREATE TABLE IF NOT EXISTS byline_search_index_metadata (
   collection_path      varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
   analyzer_fingerprint varchar(512) CHARACTER SET ascii COLLATE ascii_bin      NOT NULL,
+  zones                json                                                   NOT NULL,
   updated_at           datetime(6)                                            NOT NULL,
   PRIMARY KEY (collection_path)
 ) ENGINE=InnoDB;

--- a/packages/search-mysql/src/mysql-search-provider.ts
+++ b/packages/search-mysql/src/mysql-search-provider.ts
@@ -57,13 +57,13 @@ export class MySqlSearchProvider implements SearchProvider {
       await connection.beginTransaction()
       await connection.query(
         `INSERT INTO byline_search_index_metadata
-           (collection_path, analyzer_fingerprint, updated_at)
-         VALUES (?, ?, UTC_TIMESTAMP(6))
+           (collection_path, analyzer_fingerprint, zones, updated_at)
+         VALUES (?, ?, ?, UTC_TIMESTAMP(6))
          ON DUPLICATE KEY UPDATE collection_path = collection_path`,
-        [row.collectionPath, indexDocument.analyzerFingerprint]
+        [row.collectionPath, indexDocument.analyzerFingerprint, JSON.stringify(row.zones)]
       )
       const [metadata] = await connection.query<FingerprintRow[]>(
-        `SELECT analyzer_fingerprint
+        `SELECT analyzer_fingerprint, zones
          FROM byline_search_index_metadata
          WHERE collection_path = ?
          FOR UPDATE`,
@@ -77,6 +77,15 @@ export class MySqlSearchProvider implements SearchProvider {
           actualFingerprint
         )
       }
+      const zones = [
+        ...new Set([...(parseJsonStringArray(metadata[0]?.zones) ?? []), ...row.zones]),
+      ]
+      await connection.query(
+        `UPDATE byline_search_index_metadata
+         SET zones = ?, updated_at = UTC_TIMESTAMP(6)
+         WHERE collection_path = ?`,
+        [JSON.stringify(zones), row.collectionPath]
+      )
 
       await connection.query<ResultSetHeader>(UPSERT_SQL, upsertParams(row, indexDocument))
       await connection.commit()
@@ -206,12 +215,12 @@ export class MySqlSearchProvider implements SearchProvider {
 
   private async assertAnalyzerFingerprint(query: SearchQuery): Promise<void> {
     const params: unknown[] = [this.analyzer.fingerprint]
-    const where = ['d.analyzer_fingerprint <> ?']
-    appendScopeFilters(query, params, where, false)
+    const where = ['m.analyzer_fingerprint <> ?']
+    appendMetadataScopeFilters(query, params, where)
 
     const [rows] = await this.pool.query<IncompatibleRow[]>(
-      `SELECT d.collection_path, d.analyzer_fingerprint
-       FROM byline_search_documents d
+      `SELECT m.collection_path, m.analyzer_fingerprint
+       FROM byline_search_index_metadata m
        WHERE ${where.join(' AND ')}
        LIMIT 1`,
       params
@@ -227,8 +236,20 @@ export class MySqlSearchProvider implements SearchProvider {
   }
 }
 
+function appendMetadataScopeFilters(query: SearchQuery, params: unknown[], where: string[]): void {
+  if (query.collectionPath != null) {
+    params.push(query.collectionPath)
+    where.push('m.collection_path = ?')
+  }
+  if (query.zone != null) {
+    params.push(query.zone)
+    where.push('JSON_CONTAINS(m.zones, JSON_ARRAY(?))')
+  }
+}
+
 interface FingerprintRow extends RowDataPacket {
   analyzer_fingerprint: string
+  zones: string | string[]
 }
 
 interface IncompatibleRow extends FingerprintRow {
@@ -253,6 +274,15 @@ interface PortableIndexValues {
   searchText: string
   weighted: Record<'A' | 'B' | 'C' | 'D', string>
   analyzerFingerprint: string
+}
+
+function parseJsonStringArray(value: string | string[] | undefined): string[] | undefined {
+  if (value == null) return undefined
+  if (Array.isArray(value)) return value
+  const parsed: unknown = JSON.parse(value)
+  return Array.isArray(parsed) && parsed.every((item) => typeof item === 'string')
+    ? parsed
+    : undefined
 }
 
 function upsertParams(row: IndexRow, indexDocument: PortableIndexValues): unknown[] {

--- a/packages/search-mysql/src/portable-index-document.test.node.ts
+++ b/packages/search-mysql/src/portable-index-document.test.node.ts
@@ -80,4 +80,22 @@ describe('buildPortableMySqlIndexDocument', () => {
 
     expect(document.searchText).toContain(`${stem} ${exactNeighbor}`)
   })
+
+  it('writes identifier and constituent phrase streams at one logical position', () => {
+    const document = buildPortableMySqlIndexDocument(
+      row({ weighted: { A: 'COVID-19 cases', B: '', C: '', D: '' } }),
+      createPortableSearchAnalyzer()
+    )
+    const cases = encodeSqlToken({ kind: 'exact', value: 'cases' })
+
+    expect(document.searchText).toContain(
+      `${encodeSqlToken({ kind: 'identifier', value: 'covid-19' })} ${cases}`
+    )
+    expect(document.searchText).toContain(
+      `${encodeSqlToken({ kind: 'exact', value: 'covid' })} ${cases}`
+    )
+    expect(document.searchText).toContain(
+      `${encodeSqlToken({ kind: 'exact', value: '19' })} ${cases}`
+    )
+  })
 })

--- a/packages/search-mysql/src/portable-index-document.ts
+++ b/packages/search-mysql/src/portable-index-document.ts
@@ -115,24 +115,70 @@ function serializeMatchingStreams(tokens: readonly LogicalToken[]): string[] {
   const source = tokens
     .filter((token) => token.kind === 'exact' || token.kind === 'identifier')
     .toSorted(compareTokens)
-  const streams = source.length > 0 ? [serializeTokenStream(source)] : []
+  const sourceGroups = groupTokensByPosition(source)
+  const sourceStreams = buildSourceStreams(sourceGroups)
+  const streams = [...sourceStreams]
+  const primarySource = sourceGroups.map(preferredSourceToken)
 
   for (const kind of ['stem', 'lemma', 'normalized'] as const) {
     const derived = tokens.filter((token) => token.kind === kind)
     if (derived.length === 0) continue
 
-    const firstByPosition = new Map<number, LogicalToken>()
+    const byPosition = new Map<number, LogicalToken[]>()
     for (const token of derived.toSorted(compareTokens)) {
-      if (!firstByPosition.has(token.position)) firstByPosition.set(token.position, token)
+      const positioned = byPosition.get(token.position)
+      if (positioned == null) byPosition.set(token.position, [token])
+      else positioned.push(token)
     }
     streams.push(
-      serializeTokenStream(source.map((token) => firstByPosition.get(token.position) ?? token))
+      serializeTokenStream(
+        primarySource.map((fallback) => byPosition.get(fallback.position)?.[0] ?? fallback)
+      )
     )
   }
 
   const grams = tokens.filter((token) => token.kind === 'gram').toSorted(compareTokens)
   if (grams.length > 0) streams.push(serializeTokenStream(grams))
-  return streams.filter((stream) => stream.length > 0)
+  return [...new Set(streams.filter((stream) => stream.length > 0))]
+}
+
+function buildSourceStreams(groups: readonly LogicalToken[][]): string[] {
+  if (groups.length === 0) return []
+  const streams = [serializeTokenStream(groups.map(preferredSourceToken))]
+  const exactVariantCount = Math.max(
+    0,
+    ...groups.map((group) => group.filter((token) => token.kind === 'exact').length)
+  )
+
+  for (let variant = 0; variant < exactVariantCount; variant++) {
+    streams.push(
+      serializeTokenStream(
+        groups.map((group) => {
+          const exact = group.filter((token) => token.kind === 'exact')
+          return exact[variant] ?? exact[0] ?? preferredSourceToken(group)
+        })
+      )
+    )
+  }
+  return [...new Set(streams)]
+}
+
+function preferredSourceToken(group: readonly LogicalToken[]): LogicalToken {
+  const token =
+    group.find((candidate) => candidate.kind === 'identifier') ??
+    group.find((candidate) => candidate.kind === 'exact')
+  if (token == null) throw new TypeError('Portable source position has no searchable token')
+  return token
+}
+
+function groupTokensByPosition(tokens: readonly LogicalToken[]): LogicalToken[][] {
+  const groups = new Map<number, LogicalToken[]>()
+  for (const token of tokens) {
+    const group = groups.get(token.position)
+    if (group == null) groups.set(token.position, [token])
+    else group.push(token)
+  }
+  return [...groups.values()]
 }
 
 function serializeTokenStream(tokens: readonly LogicalToken[]): string {

--- a/packages/search-mysql/src/portable-query.test.node.ts
+++ b/packages/search-mysql/src/portable-query.test.node.ts
@@ -49,6 +49,36 @@ describe('buildPortableMySqlQuery', () => {
     expect(translated.minimumShouldMatch).toBe(2)
   })
 
+  it('emits only phrase variants that mirror physical index streams', () => {
+    const phraseExpander: SearchTokenExpander = {
+      fingerprint: 'phrase-test1',
+      supports: (locale) => locale.startsWith('en'),
+      expand: (token) =>
+        token.value === 'running'
+          ? [{ kind: 'stem', value: 'run' }]
+          : token.value === 'restoration'
+            ? [{ kind: 'stem', value: 'restore' }]
+            : [],
+    }
+    const translated = buildPortableMySqlQuery(
+      createPortableSearchAnalyzer({ expanders: [phraseExpander] }).analyzeQuery({
+        query: '"running restoration"',
+        locale: 'en',
+      })
+    )
+
+    expect(translated.phraseQueries[0]).toEqual([
+      `"${encodeSqlToken({ kind: 'exact', value: 'running' })} ${encodeSqlToken({
+        kind: 'exact',
+        value: 'restoration',
+      })}"`,
+      `"${encodeSqlToken({ kind: 'stem', value: 'run' })} ${encodeSqlToken({
+        kind: 'stem',
+        value: 'restore',
+      })}"`,
+    ])
+  })
+
   it('returns an empty ranking query for punctuation-only input', () => {
     const translated = buildPortableMySqlQuery(
       createPortableSearchAnalyzer().analyzeQuery({ query: '— -- !!!' })

--- a/packages/search-mysql/src/portable-query.ts
+++ b/packages/search-mysql/src/portable-query.ts
@@ -13,8 +13,6 @@ import {
   type QueryConcept,
 } from '@byline/search-analysis'
 
-const MAX_PHRASE_VARIANTS = 256
-
 export interface PortableMySqlQuery {
   /** Boolean-mode query per source concept; terms inside one query are ORs. */
   conceptQueries: string[]
@@ -36,11 +34,11 @@ export function buildPortableMySqlQuery(plan: PortableQueryPlan): PortableMySqlQ
   }
 
   const phraseQueries = plan.phrases.map((phrase) => {
-    const alternatives = phrase.conceptIndexes.map((index) => conceptTerms[index])
-    if (alternatives.some((terms) => terms == null || terms.length === 0)) {
+    const concepts = phrase.conceptIndexes.map((index) => plan.concepts[index])
+    if (concepts.some((concept) => concept == null)) {
       throw new RangeError('Portable query phrase references an unknown concept')
     }
-    return phraseVariants(alternatives as string[][])
+    return phraseStreamVariants(concepts as QueryConcept[])
   })
 
   const gramQueries = plan.gramSequences
@@ -79,24 +77,33 @@ function conceptAlternatives(concept: QueryConcept): string[] {
   return [...new Set(terms)]
 }
 
-function phraseVariants(alternatives: string[][]): string[] {
-  let variants: string[][] = [[]]
-  for (const terms of alternatives) {
-    const next: string[][] = []
-    for (const prefix of variants) {
-      for (const term of terms) {
-        // A concept-local gram fallback is itself quoted and cannot be nested
-        // into a larger MySQL phrase. Cross-concept grams are represented by
-        // `gramQueries` instead.
-        if (term.startsWith('"')) continue
-        next.push([...prefix, term])
-        if (next.length >= MAX_PHRASE_VARIANTS) break
-      }
-      if (next.length >= MAX_PHRASE_VARIANTS) break
-    }
-    variants = next
+/**
+ * Mirror the index's phrase-capable source and expansion-kind streams. Mixed
+ * expansion kinds never coexist in one indexed stream, so their Cartesian
+ * product would only produce impossible phrases.
+ */
+function phraseStreamVariants(concepts: readonly QueryConcept[]): string[] {
+  const source = concepts.map(sourceToken)
+  const variants: LogicalToken[][] = [source]
+
+  for (const kind of ['stemTokens', 'lemmaTokens', 'normalizedTokens'] as const) {
+    if (!concepts.some((concept) => concept[kind].length > 0)) continue
+    variants.push(concepts.map((concept, index) => concept[kind][0] ?? source[index]!))
   }
-  return variants.map(quotedPhrase).filter((query) => query.length > 0)
+
+  return [
+    ...new Set(
+      variants
+        .map((tokens) => quotedPhrase(tokens.map((token) => encodeSqlToken(token))))
+        .filter((query) => query.length > 0)
+    ),
+  ]
+}
+
+function sourceToken(concept: QueryConcept): LogicalToken {
+  const token = concept.identifierTokens[0] ?? concept.exactTokens[0]
+  if (token == null) throw new TypeError('Portable query concept has no source token')
+  return token
 }
 
 function orderedTerms(tokens: readonly LogicalToken[]): string[] {

--- a/packages/search-postgres/migrations/0001_init.sql
+++ b/packages/search-postgres/migrations/0001_init.sql
@@ -43,9 +43,11 @@ CREATE INDEX IF NOT EXISTS byline_search_documents_collection_idx
   ON byline_search_documents (collection_path, status);
 
 -- One locked row per collection prevents concurrent processes with different
--- analyzer fingerprints from mixing incompatible projections.
+-- analyzer fingerprints from mixing incompatible projections. Collection
+-- zones let fingerprint guards retain zone scope without scanning documents.
 CREATE TABLE IF NOT EXISTS byline_search_index_metadata (
   collection_path      text        PRIMARY KEY,
   analyzer_fingerprint text        NOT NULL,
+  zones                text[]      NOT NULL DEFAULT '{}',
   updated_at           timestamptz NOT NULL DEFAULT now()
 );

--- a/packages/search-postgres/src/migrations-data.ts
+++ b/packages/search-postgres/src/migrations-data.ts
@@ -76,10 +76,12 @@ CREATE INDEX IF NOT EXISTS byline_search_documents_collection_idx
   ON byline_search_documents (collection_path, status);
 
 -- One locked row per collection prevents concurrent processes with different
--- analyzer fingerprints from mixing incompatible projections.
+-- analyzer fingerprints from mixing incompatible projections. Collection
+-- zones let fingerprint guards retain zone scope without scanning documents.
 CREATE TABLE IF NOT EXISTS byline_search_index_metadata (
   collection_path      text        PRIMARY KEY,
   analyzer_fingerprint text        NOT NULL,
+  zones                text[]      NOT NULL DEFAULT '{}',
   updated_at           timestamptz NOT NULL DEFAULT now()
 );
 `,

--- a/packages/search-postgres/src/postgres-search-provider.ts
+++ b/packages/search-postgres/src/postgres-search-provider.ts
@@ -62,10 +62,13 @@ export class PostgresSearchProvider implements SearchProvider {
       await client.query('BEGIN')
       await client.query(
         `INSERT INTO byline_search_index_metadata
-           (collection_path, analyzer_fingerprint, updated_at)
-         VALUES ($1, $2, now())
-         ON CONFLICT (collection_path) DO NOTHING`,
-        [row.collectionPath, vector.analyzerFingerprint]
+           (collection_path, analyzer_fingerprint, zones, updated_at)
+         VALUES ($1, $2, $3, now())
+         ON CONFLICT (collection_path) DO UPDATE
+           SET zones = ARRAY(
+             SELECT DISTINCT unnest(byline_search_index_metadata.zones || EXCLUDED.zones)
+           )`,
+        [row.collectionPath, vector.analyzerFingerprint, row.zones]
       )
       const metadata = await client.query<{ analyzer_fingerprint: string }>(
         `SELECT analyzer_fingerprint
@@ -185,7 +188,8 @@ export class PostgresSearchProvider implements SearchProvider {
               ts_rank(d.search_vector, q.query) AS score
        FROM byline_search_documents d, q
        WHERE ${whereSql}
-       ORDER BY score DESC, d.updated_at DESC
+       ORDER BY score DESC, d.updated_at DESC,
+                d.collection_path, d.document_id, d.locale
        LIMIT $${limitParam} OFFSET $${offsetParam}`,
       [...params, limit, offset]
     )
@@ -211,15 +215,15 @@ export class PostgresSearchProvider implements SearchProvider {
 
   private async assertAnalyzerFingerprint(query: SearchQuery): Promise<void> {
     const params: unknown[] = [this.analyzer.fingerprint]
-    const where = ['d.analyzer_fingerprint IS DISTINCT FROM $1']
-    appendScopeFilters(query, params, where, false)
+    const where = ['m.analyzer_fingerprint IS DISTINCT FROM $1']
+    appendMetadataScopeFilters(query, params, where)
 
     const incompatible = await this.pool.query<{
       collection_path: string
       analyzer_fingerprint: string | null
     }>(
-      `SELECT d.collection_path, d.analyzer_fingerprint
-       FROM byline_search_documents d
+      `SELECT m.collection_path, m.analyzer_fingerprint
+       FROM byline_search_index_metadata m
        WHERE ${where.join(' AND ')}
        LIMIT 1`,
       params
@@ -232,6 +236,17 @@ export class PostgresSearchProvider implements SearchProvider {
         row.analyzer_fingerprint
       )
     }
+  }
+}
+
+function appendMetadataScopeFilters(query: SearchQuery, params: unknown[], where: string[]): void {
+  if (query.collectionPath != null) {
+    params.push(query.collectionPath)
+    where.push(`m.collection_path = $${params.length}`)
+  }
+  if (query.zone != null) {
+    params.push([query.zone])
+    where.push(`m.zones @> $${params.length}`)
   }
 }
 

--- a/specs/2026-07-26-search-analysis-p1-p3-handoff.md
+++ b/specs/2026-07-26-search-analysis-p1-p3-handoff.md
@@ -1,0 +1,233 @@
+# Search analysis P1–P3 handoff
+
+Review findings from PRs #60–#65 (portable search analysis), all merged to
+`develop` and **unreleased** — three pending changesets, so a fingerprint change
+costs nothing beyond a rebuild of the two owned installations.
+
+Implementation is assigned to another agent. Verification is a separate pass
+against the acceptance criteria below.
+
+## P1 — ReDoS in the email identifier rule (unauthenticated reach)
+
+`packages/search-analysis/src/identifiers.ts:32`
+
+```ts
+pattern: /[\p{L}\p{N}._%+-]+@[\p{L}\p{N}.-]+\.[\p{L}]{2,}/giu
+```
+
+The unbounded leading quantifier backtracks quadratically over any long run of
+letters containing no `@`. CJK text is exactly that shape (no spaces), and so is
+a hostile query string.
+
+`analyzeQuery` runs the same extraction on the query, and no layer caps its
+length: `/$lng/docs/search?q=` → route `validateSearch` → `searchDocsFn`
+validator → `searchDocs` (trim only) → `CollectionHandle.search` →
+`analyzeQuery`.
+
+Measured blocking CPU (single-threaded event loop, `email` rule accounts for
+466ms of 490ms at 8000 chars):
+
+| query length | blocking CPU |
+|---|---|
+| 1 000 | 32 ms |
+| 5 000 | 656 ms |
+| 20 000 | 8 669 ms |
+| 50 000 | 51 004 ms |
+
+Same defect makes CJK indexing and highlighting quadratic: highlighting
+re-analyzes each hit's full body, so one results page over 12k-char Chinese
+bodies costs 12.7 s (identical English page: 26 ms).
+
+**Direction** — bound the quantifiers to RFC limits. Verified linear and still
+matching real addresses (`editor@example.com`,
+`a.b+tag@sub.example.co.uk`, NFKC-folded full-width local parts):
+
+```ts
+pattern: /[\p{L}\p{N}._%+-]{1,64}@[\p{L}\p{N}.-]{1,255}\.[\p{L}]{2,63}/giu
+```
+
+16 000 chars: 2003 ms → 17 ms. 40 000 chars: 12 450 ms → 40 ms.
+
+Audit the other six rules for the same shape while in there. Add a
+query-length cap at the `SearchQuery` boundary as defence in depth, and a
+linear-time guard test in `analyzer.test.node.ts`.
+
+**Acceptance**
+
+1. `extractIdentifierSpans` and `analyzeQuery` scale linearly on unbroken
+   Han and Latin runs up to 40 000 chars.
+2. Real email addresses, `Node.js`, `SKU-1234` still extract as identifiers
+   (existing conformance test must keep passing).
+3. A CJK results page (10 hits × 12k-char bodies) completes in well under a
+   second.
+4. An over-long query is rejected or truncated rather than analyzed.
+
+## P2 — the SKU rule destroys recall on ordinary prose
+
+`packages/search-analysis/src/identifiers.ts:39` — `\b[\p{L}]{2,}[-_]\d+\b`
+combined with `maskIdentifierSpans` removes the constituent words from the index
+entirely:
+
+```
+COVID-19 cases rose  => identifier:covid-19 | exact:cases | exact:rose
+utf-8 encoding       => identifier:utf-8    | exact:encoding
+
+  query "covid"    matches doc? false
+  query "covid-19" matches doc? true
+```
+
+Also `top-10`, `byline-4`. The `version` rule does the same to plain decimals:
+`Section 1.2`, `priced at 19.99`, `2026.07.26` all become exact-only identifier
+tokens.
+
+This contradicts the principle the package states for expansions — "stems,
+lemmas, and normalized variants augment their exact source token and never
+replace it" (docs/05-reading-and-delivery/09-multilingual-search-analysis.md).
+Masking makes identifiers the one replacing stage.
+
+**Direction** (agreed with the implementing agent — supersedes the original
+"just stop masking" sketch, which would have distorted matching semantics):
+
+1. Preserve constituent `exact` tokens for SKU/version-like identifiers.
+2. Group the identifier and its overlapping constituents at **one logical
+   position**. This is the mechanism expansions already use — a stem shares its
+   source token's `position` — so identifiers should follow suit rather than
+   consume extra positions.
+3. When the query contains the complete form, the complete identifier is the
+   query concept.
+4. Retain masking for URLs and emails, where indexing every component creates
+   noisy recall.
+5. Increment `IDENTIFIER_VERSION`, requiring the expected index rebuild.
+
+Why the naive unmask is wrong, measured on the current build: sorted
+`sourceTokens` get sequential positions, so unmasked constituents would push
+`cases` in `COVID-19 cases rose` from position 1 to position 2, and a bare
+`covid-19` query would yield 3 concepts instead of 1 — distorting `operator:
+'all'`, `minimumShouldMatch`, and `<->`/phrase adjacency in both drivers.
+
+**Acceptance**
+
+1. A document containing `COVID-19` is found by `covid`, by `19`, and by
+   `covid-19`.
+2. `utf-8 encoding` is found by `utf`, `8`, and `utf-8`.
+3. URL and email spans still do **not** leak their internal words as separate
+   exact terms.
+4. Plan shape is unchanged: `covid-19` → 1 concept; `covid-19 vaccine` → 2;
+   `"covid-19 cases"` → 2 concepts with phrase `[[0,1]]`; `utf-8 encoding` → 2;
+   `Section 1.2` → 2.
+5. An identifier occupies exactly one logical position — every token
+   overlapping the identifier span shares its `position`, and the next word
+   keeps position 1.
+6. The analyzer fingerprint changes, and the conformance rebuild-enforcement
+   test still passes.
+
+**Downstream detail to watch** — `highlightPortableText` builds `sourceTerms`
+from exact + identifier tokens and dedupes by exact `start:end` range, so
+overlapping constituent ranges will each consume a slot of the `maxWords`
+fragment budget, mildly shrinking snippets around identifiers. Cosmetic, but
+cheap to handle while the code is open.
+
+## P3 — fingerprint guard scans documents on every query
+
+`packages/search-postgres/src/postgres-search-provider.ts:212`
+`packages/search-mysql/src/mysql-search-provider.ts:207`
+
+Both run `SELECT … FROM byline_search_documents WHERE analyzer_fingerprint IS
+DISTINCT FROM $1 … LIMIT 1`, and neither migration indexes that column. In the
+healthy case no row matches, so `LIMIT 1` never short-circuits and the query
+scans the whole collection slice per search.
+
+`byline_search_index_metadata` already holds exactly one authoritative
+fingerprint row per collection (written under `FOR UPDATE` by `upsert`), so
+reading that makes the guard O(1).
+
+**Direction** — resolve the guard against the metadata table. Keep the
+behavioural contract identical: mismatch must still raise
+`SEARCH_INDEX_REINDEX_REQUIRED` with `collectionPath`, for both `search` and
+`upsert`, in both drivers. Note the zone- and locale-scoped cases: metadata is
+keyed by collection only, so a zone query spanning collections needs either a
+per-collection lookup or an explicit decision to guard at first-touch.
+
+**Acceptance**
+
+1. The fingerprint guard issues no query against `byline_search_documents`.
+2. The conformance `rejects mixed analyzer fingerprints until the collection
+   is rebuilt` test passes on both drivers.
+3. Zone-scoped queries are still guarded (or the narrowing is documented).
+
+## Pre-fix baseline (for the verification pass)
+
+Analyzer fingerprint before any change:
+
+```
+portable1+nfkc-lower1+icu78.3+locale1+default-en+han-zh+identifiers1+han-bigram1
+```
+
+Measured on `develop` at 60fe393a, Node 24.18, ICU 78.3:
+
+| probe | before |
+|---|---|
+| `extractIdentifierSpans`, 40k unbroken Han | 11 438 ms (58.9x for 8x input) |
+| `extractIdentifierSpans`, 40k unbroken Latin | 698 ms (53.3x for 8x input) |
+| `analyzeQuery`, 5 000-char query | 554 ms |
+| `analyzeQuery`, 50 000-char query | 50 835 ms |
+| CJK results page, 10 hits × 12k chars | 13 583 ms |
+| `COVID-19 cases rose` found by `covid` / `19` | no |
+| `utf-8 encoding` found by `utf` | no |
+
+Note the Latin run is quadratic too — this is not a CJK-only defect.
+
+Guardrails that already pass and must keep passing: `editor@example.com`,
+`a.b+tag@sub.example.co.uk`, `Node.js`, `SKU-1234` and bare URLs still extract as
+identifiers; `example` must **not** match a document whose only occurrence is
+inside `editor@example.com`; `docs` must **not** match inside a bare URL.
+
+## P4 — deterministic PostgreSQL pagination
+
+`postgres-search-provider.ts:188` orders by `score DESC, updated_at DESC`;
+MySQL adds `collection_path, document_id, locale`. Postgres pagination is
+non-deterministic on ties. Match MySQL's tiebreak. In scope for this branch.
+
+## P5 — MySQL phrase-variant expansion (before any Snowball expander)
+
+`packages/search-mysql/src/portable-query.ts:82` builds the cartesian product of
+per-concept alternatives, which generates **impossible mixed-kind phrases** —
+a variant like `[exact:running, stem:restored]` matches no indexed stream,
+because `serializeMatchingStreams` writes one stream per kind (each falling back
+to the exact token where that kind produced nothing). Those dead variants then
+consume the `MAX_PHRASE_VARIANTS = 256` budget, after which real variants are
+silently truncated mid-build with no log.
+
+**Direction** — generate one phrase variant per *stream kind* (exact, stem,
+lemma, normalized) to mirror the index's actual structure. That is ≤4 variants
+regardless of query length, removes the need for `MAX_PHRASE_VARIANTS`
+entirely, and eliminates both the dead clauses and the silent truncation.
+
+Latent today (no expander configured → 1 variant per concept), so this is
+either part of this branch or an immediate follow-up — but it must precede
+enabling a Snowball expander.
+
+## Deferred — not in this branch
+
+- Body text containing a literal `<mark>` mis-splits in the docs UI
+  `Highlighted` component. Cosmetic — React still escapes, no injection.
+- Index sizing is undocumented in both driver READMEs. MySQL stores each token
+  twice (`search_text` plus its weight column), base32-encoded, across five
+  FULLTEXT indexes. **Do not publish a multiplier until it is benchmarked** —
+  the earlier "roughly 8x for CJK" figure was arithmetic from the token
+  encoding, not a measurement. Benchmark real
+  `pg_total_relation_size` / `information_schema.TABLES` + `INNODB_INDEXES`
+  figures against a representative corpus first.
+
+## Branch
+
+`fix/search-analysis-hardening` — P1, P2, P3, P4, the fingerprint bump,
+adversarial performance tests, and cross-provider conformance coverage. P5
+here or as an immediate follow-up.
+
+No migration or compatibility layer: the search index is disposable derived
+state and both owned installations rebuild it. One operational note for the
+release — the fingerprint guard raises `SEARCH_INDEX_REINDEX_REQUIRED` on
+every search between deploying this and completing the reindex, so for any
+installation with search live the reindex must be sequenced with the deploy
+rather than run afterwards.


### PR DESCRIPTION
## Summary

- bound email identifier matching, enforce the shared 1,024-code-unit query limit at client and analyzer boundaries, and remove the quadratic Han-bigram position scan
- preserve SKU/version constituents at the complete identifier's logical position while keeping URL/email components protected; keep complete identifiers as one query concept and one snippet-budget term
- make MySQL source and expansion phrase streams match query translation, removing impossible Cartesian phrase variants and the 256-variant cap
- move PostgreSQL and MySQL fingerprint guards to zone-aware per-collection metadata and add deterministic PostgreSQL pagination tie-breaks
- bump the identifier fingerprint and extend analyzer and cross-provider conformance coverage

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm byline:generate:check`
- `pnpm knip`
- `pnpm test`
- `pnpm build`
- `pnpm docs:check`
- PostgreSQL live search-provider conformance: 19/19
- MySQL live search-provider conformance: 19/19
- compiled CJK highlighting probe: ten 12,000-character bodies in 177 ms locally

## Operational note

This remains a direct cutover for disposable search projections. The identifier fingerprint and metadata schema changed, so installations should drop/recreate the provider-owned search tables from the rewritten `0001_init.sql` and rebuild published indexes as part of deployment. No compatibility migration is included.